### PR TITLE
feat: Figma 디자인 토큰 추출 및 Tailwind CSS 연동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: apps/fe/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -45,7 +45,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: apps/be/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -68,7 +68,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: apps/be/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
+      - run: pnpm test -- --passWithNoTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   lint-and-typecheck-fe:
     name: "FE: Lint & Type-check"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/fe
@@ -31,6 +33,8 @@ jobs:
   lint-and-typecheck-be:
     name: "BE: Lint & Type-check"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/be
@@ -54,6 +58,8 @@ jobs:
   test-be:
     name: "BE: Unit Tests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test -- --passWithNoTests
+      - run: pnpm exec jest --passWithNoTests

--- a/.github/workflows/sync-postman.yml
+++ b/.github/workflows/sync-postman.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/apps/fe/.gitignore
+++ b/apps/fe/.gitignore
@@ -7,6 +7,10 @@ lerna-debug.log*
 
 node_modules
 dist
+
+# Generated files
+src/tokens.css
+src/routeTree.gen.ts
 dist-ssr
 *.local
 

--- a/apps/fe/build-tokens.mjs
+++ b/apps/fe/build-tokens.mjs
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const tokens = JSON.parse(readFileSync(join(__dirname, 'src/tokens/tokens.json'), 'utf-8'))
+
+const lines = ['@theme {']
+
+// Colors: Wireframe(Temp)/Mode 1 > gray
+const gray = tokens['Wireframe(Temp)/Mode 1']?.gray ?? {}
+for (const [key, val] of Object.entries(gray)) {
+  if (val.$type === 'color') {
+    const name = key.replace('gray_', '')
+    lines.push(`  --color-gray-${name}: ${val.$value};`)
+  }
+}
+
+// Border radius: radius/Mode 1
+const radius = tokens['radius/Mode 1'] ?? {}
+for (const [key, val] of Object.entries(radius)) {
+  if (val.$type === 'number') {
+    const name = key.replace(/_/g, '-')
+    lines.push(`  --radius-${name}: ${val.$value}px;`)
+  }
+}
+
+// Spacing: scaling/Mode 1
+const spacing = tokens['scaling/Mode 1'] ?? {}
+for (const [key, val] of Object.entries(spacing)) {
+  if (val.$type === 'number') {
+    const name = key.replace(/_/g, '-')
+    lines.push(`  --spacing-${name}: ${val.$value}px;`)
+  }
+}
+
+// Font family
+lines.push(`  --font-sans: Pretendard, sans-serif;`)
+
+// Font sizes: global.fontSize
+const fontSizes = tokens.global?.fontSize ?? {}
+for (const [key, val] of Object.entries(fontSizes)) {
+  if (val.$type === 'fontSizes') {
+    lines.push(`  --font-size-${key}: ${val.$value}px;`)
+  }
+}
+
+// Font weights
+const fontWeightMap = { regular: '400', medium: '500', bold: '700' }
+for (const [key, weight] of Object.entries(fontWeightMap)) {
+  lines.push(`  --font-weight-${key}: ${weight};`)
+}
+
+// Line heights: global.lineHeight
+const lineHeights = tokens.global?.lineHeight ?? {}
+for (const [key, val] of Object.entries(lineHeights)) {
+  if (val.$type === 'lineHeights') {
+    const name = key.replace('height_', '')
+    lines.push(`  --leading-${name}: ${val.$value}px;`)
+  }
+}
+
+// Box shadows: global.shadow_*
+for (const [key, val] of Object.entries(tokens.global ?? {})) {
+  if (val.$type === 'boxShadow') {
+    const { x, y, blur, spread, color } = val.$value
+    lines.push(`  --shadow-${key.replace('shadow_', '')}: ${x}px ${y}px ${blur}px ${spread}px ${color};`)
+  }
+}
+
+lines.push('}')
+
+const output = lines.join('\n') + '\n'
+writeFileSync(join(__dirname, 'src/tokens.css'), output)
+console.log(`Generated src/tokens.css (${lines.length - 2} tokens)`)

--- a/apps/fe/build-tokens.mjs
+++ b/apps/fe/build-tokens.mjs
@@ -5,14 +5,13 @@ import { dirname, join } from 'path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const tokens = JSON.parse(readFileSync(join(__dirname, 'src/tokens/tokens.json'), 'utf-8'))
 
-const lines = ['@theme {']
+const lines = ['/* Do not edit directly, this file was auto-generated. */', '@theme {']
 
 // Colors: Wireframe(Temp)/Mode 1 > gray
 const gray = tokens['Wireframe(Temp)/Mode 1']?.gray ?? {}
 for (const [key, val] of Object.entries(gray)) {
   if (val.$type === 'color') {
-    const name = key.replace('gray_', '')
-    lines.push(`  --color-gray-${name}: ${val.$value};`)
+    lines.push(`  --color-gray-${key.replace('gray_', '')}: ${val.$value};`)
   }
 }
 
@@ -20,8 +19,7 @@ for (const [key, val] of Object.entries(gray)) {
 const radius = tokens['radius/Mode 1'] ?? {}
 for (const [key, val] of Object.entries(radius)) {
   if (val.$type === 'number') {
-    const name = key.replace(/_/g, '-')
-    lines.push(`  --radius-${name}: ${val.$value}px;`)
+    lines.push(`  --radius-${key.replace(/_/g, '-')}: ${val.$value}px;`)
   }
 }
 
@@ -29,8 +27,7 @@ for (const [key, val] of Object.entries(radius)) {
 const spacing = tokens['scaling/Mode 1'] ?? {}
 for (const [key, val] of Object.entries(spacing)) {
   if (val.$type === 'number') {
-    const name = key.replace(/_/g, '-')
-    lines.push(`  --spacing-${name}: ${val.$value}px;`)
+    lines.push(`  --spacing-${key.replace(/_/g, '-')}: ${val.$value}px;`)
   }
 }
 
@@ -55,8 +52,7 @@ for (const [key, weight] of Object.entries(fontWeightMap)) {
 const lineHeights = tokens.global?.lineHeight ?? {}
 for (const [key, val] of Object.entries(lineHeights)) {
   if (val.$type === 'lineHeights') {
-    const name = key.replace('height_', '')
-    lines.push(`  --leading-${name}: ${val.$value}px;`)
+    lines.push(`  --leading-${key.replace('height_', '')}: ${val.$value}px;`)
   }
 }
 
@@ -72,4 +68,4 @@ lines.push('}')
 
 const output = lines.join('\n') + '\n'
 writeFileSync(join(__dirname, 'src/tokens.css'), output)
-console.log(`Generated src/tokens.css (${lines.length - 2} tokens)`)
+console.log(`Generated src/tokens.css (${lines.length - 3} tokens)`)

--- a/apps/fe/package.json
+++ b/apps/fe/package.json
@@ -5,8 +5,9 @@
   "packageManager": "pnpm@10.8.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build:tokens": "node build-tokens.mjs",
+    "dev": "node build-tokens.mjs && vite",
+    "build": "node build-tokens.mjs && tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "preview": "vite preview"

--- a/apps/fe/src/index.css
+++ b/apps/fe/src/index.css
@@ -1,5 +1,2 @@
 @import "tailwindcss";
-
-/* Design tokens — PD 디자인 시스템 확정 후 채워넣을 것 */
-@theme {
-}
+@import "./tokens.css";

--- a/apps/fe/src/tokens/tokens.json
+++ b/apps/fe/src/tokens/tokens.json
@@ -1,0 +1,1239 @@
+{
+  "global": {
+    "shadow_1": {
+      "$type": "boxShadow",
+      "$value": {
+        "color": "#00000014",
+        "type": "dropShadow",
+        "x": 0,
+        "y": 1,
+        "blur": 4,
+        "spread": 0
+      }
+    },
+    "shadow_2": {
+      "$type": "boxShadow",
+      "$value": {
+        "color": "#0000001a",
+        "type": "dropShadow",
+        "x": 0,
+        "y": 2,
+        "blur": 10,
+        "spread": 0
+      }
+    },
+    "shadow_3": {
+      "$type": "boxShadow",
+      "$value": {
+        "color": "#0000001f",
+        "type": "dropShadow",
+        "x": 0,
+        "y": 4,
+        "blur": 16,
+        "spread": 0
+      }
+    },
+    "fontFamily": {
+      "pretendard": {
+        "$type": "fontFamilies",
+        "$value": "Pretendard"
+      }
+    },
+    "lineHeight": {
+      "height_t1": {
+        "$type": "lineHeights",
+        "$value": 15
+      },
+      "height_t2": {
+        "$type": "lineHeights",
+        "$value": 16
+      },
+      "height_t3": {
+        "$type": "lineHeights",
+        "$value": 18
+      },
+      "height_t4": {
+        "$type": "lineHeights",
+        "$value": 19
+      },
+      "height_t5": {
+        "$type": "lineHeights",
+        "$value": 22
+      },
+      "height_t6": {
+        "$type": "lineHeights",
+        "$value": 24
+      },
+      "height_t7": {
+        "$type": "lineHeights",
+        "$value": 27
+      },
+      "height_t8": {
+        "$type": "lineHeights",
+        "$value": 30
+      },
+      "height_t9": {
+        "$type": "lineHeights",
+        "$value": 32
+      },
+      "height_t10": {
+        "$type": "lineHeights",
+        "$value": 35
+      }
+    },
+    "fontWeight": {
+      "regular": {
+        "$type": "fontWeights",
+        "$value": "Regular"
+      },
+      "medium": {
+        "$type": "fontWeights",
+        "$value": "Medium"
+      },
+      "bold": {
+        "$type": "fontWeights",
+        "$value": "Bold"
+      }
+    },
+    "fontSize": {
+      "0": {
+        "$type": "fontSizes",
+        "$value": 11
+      },
+      "1": {
+        "$type": "fontSizes",
+        "$value": 12
+      },
+      "2": {
+        "$type": "fontSizes",
+        "$value": 13
+      },
+      "3": {
+        "$type": "fontSizes",
+        "$value": 14
+      },
+      "4": {
+        "$type": "fontSizes",
+        "$value": 16
+      },
+      "5": {
+        "$type": "fontSizes",
+        "$value": 18
+      },
+      "6": {
+        "$type": "fontSizes",
+        "$value": 20
+      },
+      "7": {
+        "$type": "fontSizes",
+        "$value": 22
+      },
+      "8": {
+        "$type": "fontSizes",
+        "$value": 24
+      },
+      "9": {
+        "$type": "fontSizes",
+        "$value": 26
+      }
+    },
+    "letterSpacing": {
+      "0": {
+        "$type": "letterSpacing",
+        "$value": 0
+      },
+      "1": {
+        "$type": "letterSpacing",
+        "$value": -0.1
+      },
+      "2": {
+        "$type": "letterSpacing",
+        "$value": -0.2
+      },
+      "3": {
+        "$type": "letterSpacing",
+        "$value": -0.3
+      }
+    },
+    "paragraphSpacing": {
+      "0": {
+        "$type": "paragraphSpacing",
+        "$value": 0
+      }
+    },
+    "t1regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t1}",
+        "fontSize": "{fontSize.0}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t1medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t1}",
+        "fontSize": "{fontSize.0}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t1bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t1}",
+        "fontSize": "{fontSize.0}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t2regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t2}",
+        "fontSize": "{fontSize.1}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t2medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t2}",
+        "fontSize": "{fontSize.1}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t2bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t2}",
+        "fontSize": "{fontSize.1}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t3regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t3}",
+        "fontSize": "{fontSize.2}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t3medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t3}",
+        "fontSize": "{fontSize.2}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t3bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t3}",
+        "fontSize": "{fontSize.2}",
+        "letterSpacing": "{letterSpacing.0}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t4regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t4}",
+        "fontSize": "{fontSize.3}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t4medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t4}",
+        "fontSize": "{fontSize.3}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t4bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t4}",
+        "fontSize": "{fontSize.3}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t5regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t5}",
+        "fontSize": "{fontSize.4}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t5medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t5}",
+        "fontSize": "{fontSize.4}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t5bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t5}",
+        "fontSize": "{fontSize.4}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t6regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t6}",
+        "fontSize": "{fontSize.5}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t6medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t6}",
+        "fontSize": "{fontSize.5}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t6bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t6}",
+        "fontSize": "{fontSize.5}",
+        "letterSpacing": "{letterSpacing.1}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t7regular": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.regular}",
+        "lineHeight": "{lineHeight.height_t7}",
+        "fontSize": "{fontSize.6}",
+        "letterSpacing": "{letterSpacing.2}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t7medium": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.medium}",
+        "lineHeight": "{lineHeight.height_t7}",
+        "fontSize": "{fontSize.6}",
+        "letterSpacing": "{letterSpacing.2}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t7bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t7}",
+        "fontSize": "{fontSize.6}",
+        "letterSpacing": "{letterSpacing.2}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t8bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t8}",
+        "fontSize": "{fontSize.7}",
+        "letterSpacing": "{letterSpacing.2}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t9bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t9}",
+        "fontSize": "{fontSize.8}",
+        "letterSpacing": "{letterSpacing.3}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "t10bold": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{fontFamily.pretendard}",
+        "fontWeight": "{fontWeight.bold}",
+        "lineHeight": "{lineHeight.height_t10}",
+        "fontSize": "{fontSize.9}",
+        "letterSpacing": "{letterSpacing.3}",
+        "paragraphSpacing": "{paragraphSpacing.0}",
+        "paragraphIndent": "{paragraphIndent.0}",
+        "textCase": "{textCase.none}",
+        "textDecoration": "{textDecoration.none}"
+      }
+    },
+    "textCase": {
+      "none": {
+        "$type": "textCase",
+        "$value": "none"
+      }
+    },
+    "textDecoration": {
+      "none": {
+        "$type": "textDecoration",
+        "$value": "none"
+      }
+    },
+    "paragraphIndent": {
+      "0": {
+        "$type": "dimension",
+        "$value": "0px"
+      }
+    }
+  },
+  "Wireframe(Temp)/Mode 1": {
+    "gray": {
+      "gray_00": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#ffffff"
+      },
+      "gray_100": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#f7f8f9"
+      },
+      "gray_200": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#f3f4f5"
+      },
+      "gray_300": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#eeeff1"
+      },
+      "gray_400": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#dcdee3"
+      },
+      "gray_500": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#d1d3d8"
+      },
+      "gray_600": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#b0b3ba"
+      },
+      "gray_700": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#868b94"
+      },
+      "gray_800": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#555d6d"
+      },
+      "gray_900": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#2a3038"
+      },
+      "gray_1000": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "color",
+        "$value": "#1a1c20"
+      }
+    }
+  },
+  "typography/Mode 1": {
+    "fontFamily": {
+      "pretendard": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "text",
+        "$value": "Pretendard"
+      }
+    },
+    "fontWeight": {
+      "regular": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "text",
+        "$value": "regular"
+      },
+      "medium": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "text",
+        "$value": "medium"
+      },
+      "bold": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "text",
+        "$value": "bold"
+      }
+    },
+    "fontSize": {
+      "size_t1": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 11
+      },
+      "size_t2": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 12
+      },
+      "size_t3": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 13
+      },
+      "size_t4": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 14
+      },
+      "size_t5": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 16
+      },
+      "size_t6": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 18
+      },
+      "size_t7": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 20
+      },
+      "size_t8": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 22
+      },
+      "size_t9": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 24
+      },
+      "size_t10": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 26
+      }
+    },
+    "lineHeight": {
+      "height_t1": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 15
+      },
+      "height_t2": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 16
+      },
+      "height_t3": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 18
+      },
+      "height_t4": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 19
+      },
+      "height_t5": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 22
+      },
+      "height_t6": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 24
+      },
+      "height_t7": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 27
+      },
+      "height_t8": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 30
+      },
+      "height_t9": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 32
+      },
+      "height_t10": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 35
+      }
+    },
+    "letterSpacing": {
+      "space_t1": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": 0
+      },
+      "space_t2": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": -0.1
+      },
+      "space_t3": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": -0.2
+      },
+      "space_t4": {
+        "$extensions": {
+          "com.figma.scopes": [
+            "ALL_SCOPES"
+          ],
+          "com.figma.hiddenFromPublishing": false
+        },
+        "$type": "number",
+        "$value": -0.3
+      }
+    }
+  },
+  "radius/Mode 1": {
+    "r0_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 2
+    },
+    "r1": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 4
+    },
+    "r1_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 6
+    },
+    "r2": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 8
+    },
+    "r2_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 10
+    },
+    "r3": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 12
+    },
+    "r3_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 14
+    },
+    "r4": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 16
+    },
+    "r5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 20
+    },
+    "r6": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 24
+    },
+    "full": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 9999
+    }
+  },
+  "scaling/Mode 1": {
+    "x0_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 2
+    },
+    "x1": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 4
+    },
+    "x1_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 6
+    },
+    "x2": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 8
+    },
+    "x2_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 10
+    },
+    "x3": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 12
+    },
+    "x3_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 14
+    },
+    "x4": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 16
+    },
+    "x4_5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 18
+    },
+    "x5": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 20
+    },
+    "x6": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 24
+    },
+    "x7": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 28
+    },
+    "x8": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 32
+    },
+    "x9": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 36
+    },
+    "x10": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 40
+    },
+    "x12": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 48
+    },
+    "x13": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 52
+    },
+    "x14": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 56
+    },
+    "x16": {
+      "$extensions": {
+        "com.figma.scopes": [
+          "ALL_SCOPES"
+        ],
+        "com.figma.hiddenFromPublishing": false
+      },
+      "$type": "number",
+      "$value": 64
+    }
+  },
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": [
+      "global",
+      "Wireframe(Temp)/Mode 1",
+      "typography/Mode 1",
+      "radius/Mode 1",
+      "scaling/Mode 1"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8988,7 +8988,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
## Task
- Figma 디자인 토큰 추출(색상, 타이포그래피, radius, spacing 등) 및 `build-tokens.mjs`로 Tailwind CSS @theme에 자동 연동

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [x] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #2 