### PR TITLE
feat: BE TypeORM 엔티티 및 DB 네이밍 전략 추가

### DIFF
--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -28,7 +28,8 @@
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",
@@ -42,11 +43,11 @@
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "jest": "^29.7.0",
+    "prettier": "^3.8.1",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.0",
-    "prettier": "^3.8.1",
     "typescript-eslint": "^8.57.2"
   },
   "jest": {

--- a/apps/be/src/database/database.module.ts
+++ b/apps/be/src/database/database.module.ts
@@ -1,34 +1,36 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigService } from '@nestjs/config';
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ConfigService } from "@nestjs/config";
+import { SnakeNamingStrategy } from "typeorm-naming-strategies";
 
 @Module({
   imports: [
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {
-        const connectionName = config.get<string>('CLOUD_SQL_CONNECTION_NAME');
+        const connectionName = config.get<string>("CLOUD_SQL_CONNECTION_NAME");
 
         // Cloud Run: Unix socket via Cloud SQL Auth Proxy
         // Local: TCP connection via docker-compose
         const isCloudRun = !!connectionName;
 
         return {
-          type: 'postgres',
+          type: "postgres",
           ...(isCloudRun
             ? {
                 host: `/cloudsql/${connectionName}`,
               }
             : {
-                host: config.get<string>('DB_HOST', 'localhost'),
-                port: config.get<number>('DB_PORT', 5432),
+                host: config.get<string>("DB_HOST", "localhost"),
+                port: config.get<number>("DB_PORT", 5432),
               }),
-          database: config.get<string>('DB_NAME', 'breaddb'),
-          username: config.get<string>('DB_USERNAME', 'bread'),
-          password: config.get<string>('DB_PASSWORD', 'bread1234'),
-          entities: [__dirname + '/../**/*.entity{.ts,.js}'],
-          synchronize: config.get<string>('NODE_ENV') !== 'production',
-          logging: config.get<string>('NODE_ENV') !== 'production',
+          database: config.get<string>("DB_NAME", "breaddb"),
+          username: config.get<string>("DB_USERNAME", "bread"),
+          password: config.get<string>("DB_PASSWORD", "bread1234"),
+          entities: [__dirname + "/../**/*.entity{.ts,.js}"],
+          namingStrategy: new SnakeNamingStrategy(),
+          synchronize: config.get<string>("NODE_ENV") !== "production",
+          logging: config.get<string>("NODE_ENV") !== "production",
         };
       },
     }),

--- a/apps/be/src/modules/ai/entities/ai-course.entity.ts
+++ b/apps/be/src/modules/ai/entities/ai-course.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { AiCoursesBakery } from "./ai-courses-bakery.entity";
+
+@Entity("ai_course")
+export class AiCourse {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 200 })
+  title: string;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  totalDistance: number;
+
+  @Column({ nullable: true })
+  estimatedCost: number;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  estimatedTime: number;
+
+  @Column({ default: false })
+  isPublic: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ nullable: true })
+  userId: number;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn()
+  user: User;
+
+  @OneToMany(() => AiCoursesBakery, (acb) => acb.aiCourse)
+  aiCoursesBakeries: AiCoursesBakery[];
+}

--- a/apps/be/src/modules/ai/entities/ai-course.entity.ts
+++ b/apps/be/src/modules/ai/entities/ai-course.entity.ts
@@ -18,13 +18,13 @@ export class AiCourse {
   @Column({ length: 200 })
   title: string;
 
-  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  @Column({ type: "float", nullable: true })
   totalDistance: number;
 
   @Column({ nullable: true })
   estimatedCost: number;
 
-  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  @Column({ type: "float", nullable: true })
   estimatedTime: number;
 
   @Column({ default: false })

--- a/apps/be/src/modules/ai/entities/ai-courses-bakery.entity.ts
+++ b/apps/be/src/modules/ai/entities/ai-courses-bakery.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, Column, ManyToOne, JoinColumn, PrimaryColumn } from "typeorm";
+import { AiCourse } from "./ai-course.entity";
+import { Bakery } from "../../bakeries/entities/bakery.entity";
+
+@Entity("ai_course_bakery")
+export class AiCoursesBakery {
+  @PrimaryColumn()
+  aiCourseId: number;
+
+  @PrimaryColumn()
+  bakeryId: number;
+
+  @Column()
+  visitOrder: number;
+
+  @Column({ type: "text", nullable: true })
+  recommendReason: string;
+
+  @ManyToOne(() => AiCourse, (aiCourse) => aiCourse.aiCoursesBakeries)
+  @JoinColumn()
+  aiCourse: AiCourse;
+
+  @ManyToOne(() => Bakery)
+  @JoinColumn()
+  bakery: Bakery;
+}

--- a/apps/be/src/modules/auth/entities/phone-verification.entity.ts
+++ b/apps/be/src/modules/auth/entities/phone-verification.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { User } from "../../users/entities/user.entity";
+
+export enum AuthType {
+  SMS = "SMS",
+  PASS = "PASS",
+}
+
+@Entity("phone_verification")
+export class PhoneVerification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ nullable: true })
+  userId: number;
+
+  @Column({ length: 20 })
+  phone: string;
+
+  @Column({ default: false })
+  isVerified: boolean;
+
+  @Column({ length: 10 })
+  code: string;
+
+  @Column()
+  expiredAt: Date;
+
+  @Column({ type: "enum", enum: AuthType })
+  authType: AuthType;
+
+  @ManyToOne(() => User, (user) => user.phoneVerifications, { nullable: true })
+  @JoinColumn()
+  user: User;
+}

--- a/apps/be/src/modules/auth/entities/sso-account.entity.ts
+++ b/apps/be/src/modules/auth/entities/sso-account.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+
+@Entity("sso_account")
+export class SsoAccount {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ length: 20 })
+  provider: string;
+
+  @Column({ length: 100 })
+  providerUserId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => User, (user) => user.ssoAccounts)
+  @JoinColumn()
+  user: User;
+}

--- a/apps/be/src/modules/bakeries/entities/bakery.entity.ts
+++ b/apps/be/src/modules/bakeries/entities/bakery.entity.ts
@@ -1,0 +1,78 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Menu } from "./menu.entity";
+
+export enum BakeryType {
+  BAKERY = "BAKERY",
+  CAFE = "CAFE",
+  DESSERT = "DESSERT",
+}
+
+@Entity("bakery")
+export class Bakery {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ type: "enum", enum: BakeryType })
+  bakeryType: BakeryType;
+
+  @Column({ length: 255 })
+  address: string;
+
+  @Column({ type: "decimal", precision: 10, scale: 7 })
+  latitude: number;
+
+  @Column({ type: "decimal", precision: 10, scale: 7 })
+  longitude: number;
+
+  @Column({ length: 100, nullable: true })
+  closedDays: string;
+
+  @Column({ length: 100, nullable: true })
+  openingHours: string;
+
+  @Column({ length: 20, nullable: true })
+  phone: string;
+
+  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  rating: number;
+
+  @Column({ default: 0 })
+  reviewCount: number;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ default: false })
+  isDineInAvailable: boolean;
+
+  @Column({ default: false })
+  isParkingAvailable: boolean;
+
+  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  waitRisk: number;
+
+  @Column({ length: 500, nullable: true })
+  thumbnailUrl: string;
+
+  @Column({ type: "text", nullable: true })
+  description: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(() => Menu, (menu) => menu.bakery)
+  menus: Menu[];
+}

--- a/apps/be/src/modules/bakeries/entities/bakery.entity.ts
+++ b/apps/be/src/modules/bakeries/entities/bakery.entity.ts
@@ -28,10 +28,10 @@ export class Bakery {
   @Column({ length: 255 })
   address: string;
 
-  @Column({ type: "decimal", precision: 10, scale: 7 })
+  @Column({ type: "float" })
   latitude: number;
 
-  @Column({ type: "decimal", precision: 10, scale: 7 })
+  @Column({ type: "float" })
   longitude: number;
 
   @Column({ length: 100, nullable: true })
@@ -43,7 +43,7 @@ export class Bakery {
   @Column({ length: 20, nullable: true })
   phone: string;
 
-  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  @Column({ type: "float", nullable: true })
   rating: number;
 
   @Column({ default: 0 })
@@ -58,7 +58,7 @@ export class Bakery {
   @Column({ default: false })
   isParkingAvailable: boolean;
 
-  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  @Column({ type: "float", nullable: true })
   waitRisk: number;
 
   @Column({ length: 500, nullable: true })

--- a/apps/be/src/modules/bakeries/entities/category.entity.ts
+++ b/apps/be/src/modules/bakeries/entities/category.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
+import { Menu } from "./menu.entity";
+
+export enum CategoryType {
+  BREAD = "BREAD",
+  CAKE = "CAKE",
+  COOKIE = "COOKIE",
+  BEVERAGE = "BEVERAGE",
+  OTHER = "OTHER",
+}
+
+@Entity("category")
+export class Category {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: "enum", enum: CategoryType })
+  type: CategoryType;
+
+  @Column({ length: 50 })
+  name: string;
+
+  @OneToMany(() => Menu, (menu) => menu.category)
+  menus: Menu[];
+}

--- a/apps/be/src/modules/bakeries/entities/menu.entity.ts
+++ b/apps/be/src/modules/bakeries/entities/menu.entity.ts
@@ -1,0 +1,38 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Bakery } from "./bakery.entity";
+import { Category } from "./category.entity";
+
+@Entity("menu")
+export class Menu {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50 })
+  name: string;
+
+  @Column()
+  bakeryId: number;
+
+  @Column({ type: "text", nullable: true })
+  description: string;
+
+  @Column({ nullable: true })
+  categoryId: number;
+
+  @Column({ type: "int" })
+  price: number;
+
+  @Column({ length: 500, nullable: true })
+  imageUrl: string;
+
+  @Column({ default: true })
+  isAvailable: boolean;
+
+  @ManyToOne(() => Bakery, (bakery) => bakery.menus)
+  @JoinColumn()
+  bakery: Bakery;
+
+  @ManyToOne(() => Category, (category) => category.menus, { nullable: true })
+  @JoinColumn()
+  category: Category;
+}

--- a/apps/be/src/modules/community/entities/comment.entity.ts
+++ b/apps/be/src/modules/community/entities/comment.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Post } from "./post.entity";
+import { User } from "../../users/entities/user.entity";
+
+@Entity("comment")
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  postId: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ type: "text" })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(() => Post, (post) => post.comments)
+  @JoinColumn()
+  post: Post;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+}

--- a/apps/be/src/modules/community/entities/post-like.entity.ts
+++ b/apps/be/src/modules/community/entities/post-like.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, ManyToOne, JoinColumn, CreateDateColumn, PrimaryColumn } from "typeorm";
+import { Post } from "./post.entity";
+import { User } from "../../users/entities/user.entity";
+
+@Entity("post_like")
+export class PostLike {
+  @PrimaryColumn()
+  postId: number;
+
+  @PrimaryColumn()
+  userId: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Post, (post) => post.likes)
+  @JoinColumn()
+  post: Post;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+}

--- a/apps/be/src/modules/community/entities/post.entity.ts
+++ b/apps/be/src/modules/community/entities/post.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { Bakery } from "../../bakeries/entities/bakery.entity";
+import { PostLike } from "./post-like.entity";
+import { Comment } from "./comment.entity";
+
+@Entity("post")
+export class Post {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ nullable: true })
+  bakeryId: number;
+
+  @Column({ length: 50 })
+  title: string;
+
+  @Column({ type: "text", nullable: true })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Bakery, { nullable: true })
+  @JoinColumn()
+  bakery: Bakery;
+
+  @OneToMany(() => PostLike, (like) => like.post)
+  likes: PostLike[];
+
+  @OneToMany(() => Comment, (comment) => comment.post)
+  comments: Comment[];
+}

--- a/apps/be/src/modules/community/entities/review-image.entity.ts
+++ b/apps/be/src/modules/community/entities/review-image.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Review } from "./review.entity";
+
+@Entity("review_image")
+export class ReviewImage {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  reviewId: number;
+
+  @Column({ length: 500 })
+  imageUrl: string;
+
+  @ManyToOne(() => Review, (review) => review.images)
+  @JoinColumn()
+  review: Review;
+}

--- a/apps/be/src/modules/community/entities/review.entity.ts
+++ b/apps/be/src/modules/community/entities/review.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { Bakery } from "../../bakeries/entities/bakery.entity";
+import { ReviewImage } from "./review-image.entity";
+
+@Entity("review")
+export class Review {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  bakeryId: number;
+
+  @Column({ type: "int" })
+  rating: number;
+
+  @Column({ type: "text", nullable: true })
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Bakery)
+  @JoinColumn()
+  bakery: Bakery;
+
+  @OneToMany(() => ReviewImage, (img) => img.review)
+  images: ReviewImage[];
+}

--- a/apps/be/src/modules/courses/entities/course.entity.ts
+++ b/apps/be/src/modules/courses/entities/course.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { CoursesBakery } from "./courses-bakery.entity";
+import { Route } from "./route.entity";
+
+@Entity("course")
+export class Course {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50 })
+  title: string;
+
+  @Column({ default: false })
+  isEditorPick: boolean;
+
+  @Column({ length: 50, nullable: true })
+  name: string;
+
+  @Column({ length: 50, nullable: true })
+  region: string;
+
+  @Column({ length: 50, nullable: true })
+  theme: string;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  totalDistance: number;
+
+  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  estimatedTime: number;
+
+  @Column({ default: true })
+  isPublic: boolean;
+
+  @Column({ length: 500, nullable: true })
+  thumbnailUrl: string;
+
+  @Column({ type: "text", nullable: true })
+  description: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ nullable: true })
+  userId: number;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn()
+  user: User;
+
+  @OneToMany(() => CoursesBakery, (cb) => cb.course)
+  coursesBakeries: CoursesBakery[];
+
+  @OneToMany(() => Route, (route) => route.course)
+  routes: Route[];
+}

--- a/apps/be/src/modules/courses/entities/course.entity.ts
+++ b/apps/be/src/modules/courses/entities/course.entity.ts
@@ -31,10 +31,10 @@ export class Course {
   @Column({ length: 50, nullable: true })
   theme: string;
 
-  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  @Column({ type: "float", nullable: true })
   totalDistance: number;
 
-  @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
+  @Column({ type: "float", nullable: true })
   estimatedTime: number;
 
   @Column({ default: true })

--- a/apps/be/src/modules/courses/entities/courses-bakery.entity.ts
+++ b/apps/be/src/modules/courses/entities/courses-bakery.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, Column, ManyToOne, JoinColumn, PrimaryColumn } from "typeorm";
+import { Course } from "./course.entity";
+import { Bakery } from "../../bakeries/entities/bakery.entity";
+
+@Entity("course_bakery")
+export class CoursesBakery {
+  @PrimaryColumn()
+  courseId: number;
+
+  @PrimaryColumn()
+  bakeryId: number;
+
+  @Column()
+  visitOrder: number;
+
+  @Column({ type: "text", nullable: true })
+  recommendReason: string;
+
+  @ManyToOne(() => Course, (course) => course.coursesBakeries)
+  @JoinColumn()
+  course: Course;
+
+  @ManyToOne(() => Bakery)
+  @JoinColumn()
+  bakery: Bakery;
+}

--- a/apps/be/src/modules/courses/entities/route.entity.ts
+++ b/apps/be/src/modules/courses/entities/route.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Course } from "./course.entity";
+
+export enum RouteStatus {
+  ACTIVE = "ACTIVE",
+  COMPLETED = "COMPLETED",
+}
+
+@Entity("route")
+export class Route {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  courseId: number;
+
+  @Column({ type: "enum", enum: RouteStatus, default: RouteStatus.ACTIVE })
+  status: RouteStatus;
+
+  @Column({ nullable: true })
+  activatedAt: Date;
+
+  @Column({ nullable: true })
+  completedAt: Date;
+
+  @ManyToOne(() => Course, (course) => course.routes)
+  @JoinColumn()
+  course: Course;
+}

--- a/apps/be/src/modules/payments/entities/payment.entity.ts
+++ b/apps/be/src/modules/payments/entities/payment.entity.ts
@@ -39,7 +39,7 @@ export class Payment {
   cancelledAt: Date;
 
   @Column({ nullable: true })
-  refundAt: Date;
+  refundedAt: Date;
 
   @ManyToOne(() => User)
   @JoinColumn()

--- a/apps/be/src/modules/payments/entities/payment.entity.ts
+++ b/apps/be/src/modules/payments/entities/payment.entity.ts
@@ -1,0 +1,51 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { Reservation } from "../../reservations/entities/reservation.entity";
+
+export enum PaymentStatus {
+  PENDING = "PENDING",
+  PAID = "PAID",
+  CANCELLED = "CANCELLED",
+  REFUNDED = "REFUNDED",
+}
+
+@Entity("payment")
+export class Payment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  reservationId: number;
+
+  @Column({ length: 100, nullable: true })
+  pgTransactionId: string;
+
+  @Column({ type: "enum", enum: PaymentStatus, default: PaymentStatus.PENDING })
+  status: PaymentStatus;
+
+  @Column()
+  totalAmount: number;
+
+  @Column({ length: 20, nullable: true })
+  paymentMethod: string;
+
+  @Column({ nullable: true })
+  paidAt: Date;
+
+  @Column({ nullable: true })
+  cancelledAt: Date;
+
+  @Column({ nullable: true })
+  refundAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Reservation)
+  @JoinColumn()
+  reservation: Reservation;
+}

--- a/apps/be/src/modules/reservations/entities/reservation.entity.ts
+++ b/apps/be/src/modules/reservations/entities/reservation.entity.ts
@@ -43,10 +43,10 @@ export class Reservation {
   @Column({ length: 200, nullable: true })
   departure: string;
 
-  @Column({ type: "decimal", precision: 10, scale: 7, nullable: true })
+  @Column({ type: "float", nullable: true })
   departureLat: number;
 
-  @Column({ type: "decimal", precision: 10, scale: 7, nullable: true })
+  @Column({ type: "float", nullable: true })
   departureLng: number;
 
   @Column({ type: "enum", enum: ReservationStatus, default: ReservationStatus.PENDING })

--- a/apps/be/src/modules/reservations/entities/reservation.entity.ts
+++ b/apps/be/src/modules/reservations/entities/reservation.entity.ts
@@ -1,0 +1,72 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from "typeorm";
+import { User } from "../../users/entities/user.entity";
+import { Driver } from "../../users/entities/driver.entity";
+import { Course } from "../../courses/entities/course.entity";
+
+export enum ReservationStatus {
+  PENDING = "PENDING",
+  CONFIRMED = "CONFIRMED",
+  COMPLETED = "COMPLETED",
+  CANCELLED = "CANCELLED",
+}
+
+@Entity("reservation")
+export class Reservation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ nullable: true })
+  driverId: number;
+
+  @Column()
+  courseId: number;
+
+  @Column({ type: "date" })
+  date: Date;
+
+  @Column()
+  headCount: number;
+
+  @Column({ nullable: true })
+  deadline: Date;
+
+  @Column({ length: 200, nullable: true })
+  departure: string;
+
+  @Column({ type: "decimal", precision: 10, scale: 7, nullable: true })
+  departureLat: number;
+
+  @Column({ type: "decimal", precision: 10, scale: 7, nullable: true })
+  departureLng: number;
+
+  @Column({ type: "enum", enum: ReservationStatus, default: ReservationStatus.PENDING })
+  status: ReservationStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ nullable: true })
+  cancelledAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Driver, { nullable: true })
+  @JoinColumn()
+  driver: Driver;
+
+  @ManyToOne(() => Course)
+  @JoinColumn()
+  course: Course;
+}

--- a/apps/be/src/modules/users/entities/badge.entity.ts
+++ b/apps/be/src/modules/users/entities/badge.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
+import { UserBadge } from "./user-badge.entity";
+
+@Entity("badge")
+export class Badge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @OneToMany(() => UserBadge, (ub) => ub.badge)
+  userBadges: UserBadge[];
+}

--- a/apps/be/src/modules/users/entities/driver.entity.ts
+++ b/apps/be/src/modules/users/entities/driver.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from "typeorm";
+import { User } from "./user.entity";
+
+export enum DriverStatus {
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE",
+  SUSPENDED = "SUSPENDED",
+}
+
+@Entity("driver")
+export class Driver {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ type: "enum", enum: DriverStatus, default: DriverStatus.INACTIVE })
+  status: DriverStatus;
+
+  @Column({ length: 20 })
+  carNumber: string;
+
+  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  rating: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @OneToOne(() => User, (user) => user.driver)
+  @JoinColumn()
+  user: User;
+}

--- a/apps/be/src/modules/users/entities/driver.entity.ts
+++ b/apps/be/src/modules/users/entities/driver.entity.ts
@@ -28,7 +28,7 @@ export class Driver {
   @Column({ length: 20 })
   carNumber: string;
 
-  @Column({ type: "decimal", precision: 2, scale: 1, nullable: true })
+  @Column({ type: "float", nullable: true })
   rating: number;
 
   @CreateDateColumn()

--- a/apps/be/src/modules/users/entities/user-badge.entity.ts
+++ b/apps/be/src/modules/users/entities/user-badge.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, ManyToOne, JoinColumn, CreateDateColumn, PrimaryColumn } from "typeorm";
+import { User } from "./user.entity";
+import { Badge } from "./badge.entity";
+
+@Entity("user_badge")
+export class UserBadge {
+  @PrimaryColumn()
+  userId: number;
+
+  @PrimaryColumn()
+  badgeId: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => User, (user) => user.userBadges)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Badge, (badge) => badge.userBadges)
+  @JoinColumn()
+  badge: Badge;
+}

--- a/apps/be/src/modules/users/entities/user-preference.entity.ts
+++ b/apps/be/src/modules/users/entities/user-preference.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToOne, JoinColumn, ManyToOne } from "typeorm";
+import { User } from "./user.entity";
+import { Category } from "../../bakeries/entities/category.entity";
+
+export enum TravelType {
+  SLOW = "SLOW",
+  NORMAL = "NORMAL",
+  FAST = "FAST",
+}
+
+export enum BudgetRange {
+  LOW = "LOW",
+  MEDIUM = "MEDIUM",
+  HIGH = "HIGH",
+}
+
+@Entity("user_preference")
+export class UserPreference {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column({ type: "enum", enum: TravelType, nullable: true })
+  travelType: TravelType;
+
+  @Column({ type: "enum", enum: BudgetRange, nullable: true })
+  budgetRange: BudgetRange;
+
+  @Column({ default: false })
+  waitingPreference: boolean;
+
+  @Column({ default: false })
+  hasBeverage: boolean;
+
+  @Column({ nullable: true })
+  breadTypeId: number;
+
+  @OneToOne(() => User, (user) => user.preference)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Category, { nullable: true })
+  @JoinColumn()
+  breadType: Category;
+}

--- a/apps/be/src/modules/users/entities/user.entity.ts
+++ b/apps/be/src/modules/users/entities/user.entity.ts
@@ -18,7 +18,7 @@ export enum UserRole {
   DRIVER = "DRIVER",
 }
 
-@Entity("user")
+@Entity("users")
 export class User {
   @PrimaryGeneratedColumn()
   id: number;
@@ -26,7 +26,7 @@ export class User {
   @Column({ length: 50, unique: true })
   loginId: string;
 
-  @Column({ length: 255 })
+  @Column({ length: 255, select: false })
   password: string;
 
   @Column({ length: 50 })

--- a/apps/be/src/modules/users/entities/user.entity.ts
+++ b/apps/be/src/modules/users/entities/user.entity.ts
@@ -1,0 +1,73 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  OneToOne,
+  CreateDateColumn,
+} from "typeorm";
+import { SsoAccount } from "../../auth/entities/sso-account.entity";
+import { PhoneVerification } from "../../auth/entities/phone-verification.entity";
+import { UserPreference } from "./user-preference.entity";
+import { UserBadge } from "./user-badge.entity";
+import { Driver } from "./driver.entity";
+
+export enum UserRole {
+  USER = "USER",
+  BUSINESS = "BUSINESS",
+  DRIVER = "DRIVER",
+}
+
+@Entity("user")
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 50, unique: true })
+  loginId: string;
+
+  @Column({ length: 255 })
+  password: string;
+
+  @Column({ length: 50 })
+  name: string;
+
+  @Column({ length: 100, nullable: true, unique: true })
+  email: string;
+
+  @Column({ length: 20, nullable: true })
+  telecom: string;
+
+  @Column({ length: 20, nullable: true })
+  phone: string;
+
+  @Column({ type: "enum", enum: UserRole, default: UserRole.USER })
+  role: UserRole;
+
+  @Column({ default: false })
+  termsAgreed: boolean;
+
+  @Column({ default: false })
+  privacyAgreed: boolean;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @OneToMany(() => SsoAccount, (sso) => sso.user)
+  ssoAccounts: SsoAccount[];
+
+  @OneToMany(() => PhoneVerification, (pv) => pv.user)
+  phoneVerifications: PhoneVerification[];
+
+  @OneToOne(() => UserPreference, (pref) => pref.user)
+  preference: UserPreference;
+
+  @OneToMany(() => UserBadge, (ub) => ub.user)
+  userBadges: UserBadge[];
+
+  @OneToOne(() => Driver, (driver) => driver.user)
+  driver: Driver;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      typeorm-naming-strategies:
+        specifier: ^4.1.0
+        version: 4.1.0(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.0
@@ -4810,6 +4813,11 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typeorm-naming-strategies@4.1.0:
+    resolution: {integrity: sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==}
+    peerDependencies:
+      typeorm: ^0.2.0 || ^0.3.0
 
   typeorm@0.3.28:
     resolution: {integrity: sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==}
@@ -10466,6 +10474,10 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typedarray@0.0.6: {}
+
+  typeorm-naming-strategies@4.1.0(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))):
+    dependencies:
+      typeorm: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
 
   typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Task
- BreadBread ERD 기반 22개 엔티티 생성 (auth, users, bakeries, courses, ai, reservations, payments, community)
- SnakeNamingStrategy 적용으로 camelCase → snake_case 자동 변환
- `openapi.yaml` 기반 필드 보정 (loginId, email, createdAt, UserRole.BUSINESS 등)
- 테이블명 단수형 통일
- `typeorm-naming-strategies` 패키지 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [x] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [ ] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #16 
