### PR TITLE
feat: 공통 응답 포맷 및 전역 예외 처리 구현

### DIFF
--- a/apps/be/src/main/java/com/breadbread/auth/controller/AuthController.java
+++ b/apps/be/src/main/java/com/breadbread/auth/controller/AuthController.java
@@ -6,12 +6,12 @@ import com.breadbread.auth.service.AuthService;
 import com.breadbread.auth.dto.SignupRequest;
 import com.breadbread.auth.dto.CheckIdResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import com.breadbread.global.dto.ApiResponse;
 
 @Tag(name = "인증")
 @RestController
@@ -22,82 +22,76 @@ public class AuthController {
     private final AuthService authService;
 
     @Operation(summary = "회원가입")
-    @ApiResponse(responseCode = "201")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/signup")
-    public String signup(@Valid @RequestBody SignupRequest request) {
-        return authService.signup(request);
+    public ApiResponse<Void> signup(@Valid @RequestBody SignupRequest request) {
+        authService.signup(request);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "로그인")
-    @ApiResponse(responseCode = "200", description = "accessToken, refreshToken 반환")
     @PostMapping("/login")
-    public TokenResponse login(@Valid @RequestBody LoginRequest request){
-        return authService.login(request);
+    public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request){
+        return ApiResponse.ok(authService.login(request));
     }
 
     @Operation(summary = "로그아웃")
-    @ApiResponse(responseCode = "200")
     @PostMapping("/logout")
-    public void logout(@RequestHeader("Authorization") String bearerToken) {
+    public ApiResponse<Void> logout(@RequestHeader("Authorization") String bearerToken) {
         String accessToken = bearerToken.substring(7);
         authService.logout(accessToken);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "토큰 갱신")
-    @ApiResponse(responseCode = "200", description = "accessToken, refreshToken 반환")
     @PostMapping("/refresh")
-    public TokenResponse refresh(@Valid @RequestBody TokenRequest request) {
-        return authService.refresh(request.getRefreshToken());
+    public ApiResponse<TokenResponse> refresh(@Valid @RequestBody TokenRequest request) {
+        return ApiResponse.ok(authService.refresh(request.getRefreshToken()));
     }
 
     @Operation(summary = "아이디 중복 확인")
-    @ApiResponse(responseCode = "200", description = "중복 여부 반환")
     @GetMapping("/check-id")
-    public CheckIdResponse checkId(@RequestParam String loginId) {
-        return authService.checkId(loginId);
+    public ApiResponse<CheckIdResponse> checkId(@RequestParam String loginId) {
+        return ApiResponse.ok(authService.checkId(loginId));
     }
 
     @Operation(summary = "아이디 찾기")
-    @ApiResponse(responseCode = "200", description = "아이디 반환")
     @PostMapping("/find-id")
-    public FindIdResponse findId(@Valid @RequestBody FindIdRequest request) {
-        return authService.findId(request);
+    public ApiResponse<FindIdResponse> findId(@Valid @RequestBody FindIdRequest request) {
+        return ApiResponse.ok(authService.findId(request));
     }
 
     @Operation(summary = "비밀번호 찾기")
-    @ApiResponse(responseCode = "200")
     @PostMapping("/find-pw")
-    public void findPw(@Valid @RequestBody FindPwRequest request) {
+    public ApiResponse<Void> findPw(@Valid @RequestBody FindPwRequest request) {
         authService.findPassword(request);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "비밀번호 재설정")
-    @ApiResponse(responseCode = "200")
     @PatchMapping("/reset-pw")
-    public void resetPw(@Valid @RequestBody ResetPwRequest request) {
+    public ApiResponse<Void> resetPw(@Valid @RequestBody ResetPwRequest request) {
         authService.resetPassword(request);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "휴대전화 인증 요청")
-    @ApiResponse(responseCode = "200")
     @PostMapping("/phone/send")
-    public void sendPhone(@Valid @RequestBody SendPhoneRequest request) {
+    public ApiResponse<Void> sendPhone(@Valid @RequestBody SendPhoneRequest request) {
         authService.sendVerificationCode(request);
+        return ApiResponse.ok();
     }
 
     @Operation(summary = "휴대전화 인증 확인")
-    @ApiResponse(responseCode = "200", description = "verificationToken 반환")
     @PostMapping("/phone/verify")
-    public VerifyPhoneResponse verifyPhone(@Valid @RequestBody VerifyPhoneRequest request) {
-        return authService.verifyCode(request);
+    public ApiResponse<VerifyPhoneResponse> verifyPhone(@Valid @RequestBody VerifyPhoneRequest request) {
+        return ApiResponse.ok(authService.verifyCode(request));
     }
 
     @Operation(summary = "소셜 로그인")
-    @ApiResponse(responseCode = "200", description = "accessToken, refreshToken 반환")
     @PostMapping("/social/{provider}")
-    public TokenResponse socialLogin(@PathVariable SsoProvider provider,
-                                     @RequestBody SocialLoginRequest request) {
-        return authService.socialLogin(provider, request);
+    public ApiResponse<TokenResponse> socialLogin(@PathVariable SsoProvider provider,
+                                                  @RequestBody SocialLoginRequest request) {
+        return ApiResponse.ok(authService.socialLogin(provider, request));
     }
 }

--- a/apps/be/src/main/java/com/breadbread/auth/service/AuthService.java
+++ b/apps/be/src/main/java/com/breadbread/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.breadbread.auth.service;
 import com.breadbread.auth.dto.*;
 import com.breadbread.auth.entity.*;
 import com.breadbread.auth.repository.PhoneVerificationRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.util.SmsUtil;
 import com.breadbread.auth.dto.CheckIdResponse;
 import com.breadbread.user.entity.User;
@@ -39,17 +41,17 @@ public class AuthService {
     private static final Random RANDOM = new Random();
 
     @Transactional
-    public String signup(SignupRequest signupRequest) {
+    public void signup(SignupRequest signupRequest) {
         if(userRepository.findByLoginId(signupRequest.getLoginId()).isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+            throw new CustomException(ErrorCode.DUPLICATE_LOGIN_ID);
         }
         if(!signupRequest.getPassword().equals(signupRequest.getPasswordConfirm())) {
-            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
         PhoneVerification verification = validateVerificationToken(
                 signupRequest.getVerificationToken(), VerificationPurpose.SIGNUP);
         if(!verification.getPhone().equals(signupRequest.getPhone())) {
-            throw new IllegalArgumentException("인증된 휴대전화 번호와 입력한 번호가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.PHONE_VERIFICATION_MISMATCH);
         }
         String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
         User user = User.builder()
@@ -65,15 +67,13 @@ public class AuthService {
                 .build();
         userRepository.save(user);
         phoneVerificationRepository.delete(verification);
-        return "회원가입이 완료되었습니다.";
     }
 
     @Transactional
     public TokenResponse login(LoginRequest loginRequest) {
         User user = userRepository.findByLoginId(loginRequest.getLoginId()).orElseThrow(
-                () -> new RuntimeException("해당 아이디가 존재하지 않습니다.")
+                () -> new CustomException(ErrorCode.INVALID_LOGIN_ID)
         );
-
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         user.getId().toString(),
@@ -104,9 +104,9 @@ public class AuthService {
         PhoneVerification verification = validateVerificationToken(
                 findIdRequest.getVerificationToken(), VerificationPurpose.FIND_ID);
         User user = userRepository.findByPhone(findIdRequest.getPhone())
-                .orElseThrow(() -> new RuntimeException("해당 휴대전화 번호로 가입된 아이디가 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if(!user.getName().equals(findIdRequest.getName()) || !user.getPhone().equals(verification.getPhone())) {
-            throw new RuntimeException("사용자 정보가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.USER_INFO_MISMATCH);
         }
         phoneVerificationRepository.delete(verification);
         return FindIdResponse.builder().loginId(user.getLoginId()).build();
@@ -116,9 +116,9 @@ public class AuthService {
     public void findPassword(FindPwRequest findPwRequest) {
         PhoneVerification verification = validateVerificationToken(findPwRequest.getVerificationToken(), VerificationPurpose.FIND_PW);
         User user = userRepository.findByLoginId(findPwRequest.getLoginId())
-                .orElseThrow(() -> new RuntimeException("해당 아이디가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if(!user.getName().equals(findPwRequest.getName()) || !user.getPhone().equals(verification.getPhone())) {
-            throw new RuntimeException("사용자 정보가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.USER_INFO_MISMATCH);
         }
     }
 
@@ -127,9 +127,9 @@ public class AuthService {
         PhoneVerification verification = validateVerificationToken(
                 resetPwRequest.getVerificationToken(), VerificationPurpose.FIND_PW);
         User user = userRepository.findByPhone(verification.getPhone())
-                .orElseThrow(() -> new RuntimeException("해당 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if(!resetPwRequest.getNewPassword().equals(resetPwRequest.getNewPasswordConfirm())) {
-            throw new RuntimeException("새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
         user.updatePassword(passwordEncoder.encode(resetPwRequest.getNewPassword()));
         userRepository.save(user);
@@ -157,15 +157,15 @@ public class AuthService {
     @Transactional
     public VerifyPhoneResponse verifyCode(VerifyPhoneRequest verifyPhoneRequest) {
         PhoneVerification verification = phoneVerificationRepository.findByPhoneAndPurpose(verifyPhoneRequest.getPhone(), verifyPhoneRequest.getPurpose())
-                .orElseThrow(() -> new RuntimeException("인증번호를 먼저 요청해주세요."));
+                .orElseThrow(() -> new CustomException(ErrorCode.VERIFICATION_NOT_FOUND));
         if (verification.isVerified()) {
-            throw new RuntimeException("이미 인증된 번호입니다.");
+            throw new CustomException(ErrorCode.ALREADY_VERIFIED);
         }
         if (verification.getExpiredAt().isBefore(LocalDateTime.now())) {
-            throw new RuntimeException("인증 코드가 만료되었습니다.");
+            throw new CustomException(ErrorCode.VERIFICATION_EXPIRED);
         }
         if (!verification.getCode().equals(verifyPhoneRequest.getCode())) {
-            throw new RuntimeException("인증 코드가 일치하지 않습니다.");
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE);
         }
         String verificationToken = verification.verify();
         phoneVerificationRepository.save(verification);
@@ -178,12 +178,12 @@ public class AuthService {
 
     private PhoneVerification validateVerificationToken(String token, VerificationPurpose purpose) {
         PhoneVerification verification = phoneVerificationRepository.findByVerificationToken(token)
-                .orElseThrow(() -> new RuntimeException("유효하지 않은 인증 토큰입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.VERIFICATION_NOT_FOUND));
         if (verification.getExpiredAt().isBefore(LocalDateTime.now())) {
-            throw new RuntimeException("인증이 만료되었습니다. 다시 인증해주세요.");
+            throw new CustomException(ErrorCode.VERIFICATION_EXPIRED);
         }
         if (verification.getPurpose() != purpose) {
-            throw new RuntimeException("올바르지 않은 인증 토큰입니다.");
+            throw new CustomException(ErrorCode.VERIFICATION_PURPOSE_MISMATCH);
         }
         return verification;
     }

--- a/apps/be/src/main/java/com/breadbread/auth/service/CustomUserDetailsService.java
+++ b/apps/be/src/main/java/com/breadbread/auth/service/CustomUserDetailsService.java
@@ -16,12 +16,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Long userId;
-        try {
-            userId = Long.parseLong(username);
-        } catch (NumberFormatException e) {
-            throw new UsernameNotFoundException("User Not Found", e);
-        }
+        Long userId = Long.parseLong(username);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
         return new CustomUserDetails(user);

--- a/apps/be/src/main/java/com/breadbread/auth/service/TokenService.java
+++ b/apps/be/src/main/java/com/breadbread/auth/service/TokenService.java
@@ -3,6 +3,8 @@ package com.breadbread.auth.service;
 import com.breadbread.auth.dto.TokenResponse;
 import com.breadbread.auth.entity.RefreshToken;
 import com.breadbread.auth.repository.RefreshTokenRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.jwt.JwtProvider;
 import com.breadbread.user.entity.User;
 import jakarta.transaction.Transactional;
@@ -12,7 +14,6 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.LocalDateTime;
 import java.util.Base64;
 
 @Service
@@ -30,13 +31,10 @@ public class TokenService {
     @Transactional
     public TokenResponse refresh(String refreshToken) {
         if (!jwtProvider.validateRefreshToken(refreshToken)) {
-            throw new RuntimeException("RefreshToken 유효하지 않음");
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
         RefreshToken token = refreshTokenRepository.findByToken(hashToken(refreshToken))
-                .orElseThrow(() -> new RuntimeException("RefreshToken 없음"));
-        if(token.getExpiredAt().isBefore(LocalDateTime.now())){
-            throw new RuntimeException("RefreshToken 만료");
-        }
+                .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         refreshTokenRepository.delete(token);
 
@@ -63,12 +61,7 @@ public class TokenService {
     @Transactional
     public void logout(String accessToken) {
         String extractedUserId = jwtProvider.getUserIdFromAccessToken(accessToken);
-        Long userId;
-        try {
-            userId = Long.parseLong(extractedUserId);
-        } catch (NumberFormatException e) {
-            throw new RuntimeException("AccessToken userId 형식이 올바르지 않음", e);
-        }
+        Long userId = Long.parseLong(extractedUserId);
         refreshTokenRepository.deleteByUser_Id(userId);
     }
 
@@ -78,7 +71,7 @@ public class TokenService {
             byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(hash);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("토큰 해싱 실패", e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.breadbread.global.config;
 import com.breadbread.auth.service.CustomUserDetailsService;
 import com.breadbread.global.filter.JwtAuthenticationFilter;
 import com.breadbread.global.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,7 +44,8 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
                 "https://breadbread.app",
-                "https://breadbread.vercel.app"
+                "https://breadbread.vercel.app",
+                "http://localhost:3000"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
@@ -60,6 +62,20 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        // 인증 실패 (토큰 없음/만료/유효하지 않음) → 401
+                        .authenticationEntryPoint((request, response, e) -> {
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().write("{\"success\":false,\"error\":{\"code\":\"E0002\",\"message\":\"접근 권한이 없습니다.\"}}");
+                        })
+                        // 권한 부족 (인증은 되었으나 권한 없음) → 403
+                        .accessDeniedHandler((request, response, e) -> {
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.getWriter().write("{\"success\":false,\"error\":{\"code\":\"E0003\",\"message\":\"권한이 없습니다.\"}}");
+                        })
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",

--- a/apps/be/src/main/java/com/breadbread/global/dto/ApiResponse.java
+++ b/apps/be/src/main/java/com/breadbread/global/dto/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.breadbread.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private boolean success;
+    private T data;
+    private ErrorInfo error;
+
+    public static ApiResponse<Void> ok() {
+        ApiResponse<Void> response = new ApiResponse<>();
+        response.success = true;
+        return response;
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.success = true;
+        response.data = data;
+        return response;
+    }
+
+    public static <T> ApiResponse<T> fail(String code, String message) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.success = false;
+        response.error = new ErrorInfo(code, message);
+        return response;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/dto/ErrorInfo.java
+++ b/apps/be/src/main/java/com/breadbread/global/dto/ErrorInfo.java
@@ -1,0 +1,11 @@
+package com.breadbread.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorInfo {
+    private String code;
+    private String message;
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/CustomException.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.breadbread.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -1,0 +1,64 @@
+package com.breadbread.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 공통 E00xx
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "E0001", "잘못된 입력값입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E0002", "접근 권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "E0003", "권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "E0004", "존재하지 않는 리소스입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0005", "서버 오류가 발생했습니다."),
+
+    // 회원/인증 E01xx
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E0101", "존재하지 않는 사용자입니다."),
+    DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "E0102", "이미 사용 중인 아이디입니다."),
+    INVALID_LOGIN_ID(HttpStatus.UNAUTHORIZED, "E0103","아이디가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "E0104", "비밀번호가 일치하지 않습니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "E0105", "인증번호가 일치하지 않습니다."),
+    VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "E0106", "인증 토큰이 만료되었습니다."),
+    VERIFICATION_PURPOSE_MISMATCH(HttpStatus.BAD_REQUEST, "E0107", "인증 목적이 일치하지 않습니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "E0108", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    PHONE_VERIFICATION_MISMATCH(HttpStatus.BAD_REQUEST, "E0109", "전화번호와 인증 토큰이 일치하지 않습니다."),
+    USER_INFO_MISMATCH(HttpStatus.BAD_REQUEST, "E0110", "사용자 정보가 일치하지 않습니다."),
+    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E0111", "인증 정보가 존재하지 않습니다."),
+    ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "E0112", "이미 인증된 전화번호입니다."),
+    
+    // 토큰 E02xx
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E0201", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "E0202", "만료된 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "E0203", "리프레시 토큰이 존재하지 않습니다."),
+
+    // 빵집 E03xx
+    BAKERY_NOT_FOUND(HttpStatus.NOT_FOUND, "E0301", "존재하지 않는 빵집입니다."),
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "E0302", "존재하지 않는 메뉴입니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "E0303", "존재하지 않는 리뷰입니다."),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "E0304", "이미 찜한 빵집입니다."),
+    NOT_LIKED(HttpStatus.BAD_REQUEST, "E0305", "찜하지 않은 빵집입니다."),
+
+    // 코스/AI추천 E04xx
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E0401", "존재하지 않는 코스입니다."),
+    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E0402", "AI 추천 서버 오류가 발생했습니다."),
+    PREFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E0403", "선호도 조사 결과가 없습니다."),
+
+    // 예약 E05xx
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E0501", "존재하지 않는 예약입니다."),
+    ALREADY_RESERVED(HttpStatus.CONFLICT, "E0502", "이미 예약된 시간입니다."),
+    INVALID_RESERVATION_TIME(HttpStatus.BAD_REQUEST, "E0503", "유효하지 않은 예약 시간입니다."),
+    RESERVATION_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "E0504", "예약 취소가 불가능합니다."),
+
+    // 결제 E06xx
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E0601", "존재하지 않는 결제 내역입니다."),
+    PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "E0602", "결제에 실패했습니다."),
+    PAYMENT_ALREADY_DONE(HttpStatus.CONFLICT, "E0603", "이미 완료된 결제입니다."),
+    PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "E0604", "결제 취소에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.breadbread.global.exception;
+
+import com.breadbread.global.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    // 커스텀 예외
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<Void> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ApiResponse.fail(errorCode.getCode(), errorCode.getMessage());
+    }
+
+    // @Valid 어노테이션 유효성 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Void> handleValidException(MethodArgumentNotValidException e) {
+        log.warn("Validation failed: {}", e.getMessage());
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), message);
+    }
+
+    // enum 매핑 실패 (@PathVariable 등)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ApiResponse<?> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("TypeMismatch: {}", e.getValue());
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), "올바르지 않은 값입니다: " + e.getValue());
+    }
+
+    // 비밀번호 불일치 등 인증 실패
+    @ExceptionHandler(BadCredentialsException.class)
+    public ApiResponse<Void> handleBadCredentials(BadCredentialsException e) {
+        log.warn("BadCredentials: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.INVALID_PASSWORD.getCode(), ErrorCode.INVALID_PASSWORD.getMessage());
+    }
+
+    // 잘못된 JSON 형식
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<Void> handleNotReadable(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadable: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), "올바르지 않은 요청 형식입니다.");
+    }
+
+    // 지원하지 않는 HTTP 메서드 (GET으로 POST API 호출 등)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ApiResponse<Void> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), "지원하지 않는 HTTP 메서드입니다.");
+    }
+
+    // 그 외
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<Void> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR.getCode(), ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    }
+}


### PR DESCRIPTION
## Task
- BE 공통 API 응답 포맷(`ApiResponse`) 도입
- 전역 예외 처리(`GlobalExceptionHandler`, `CustomException`, `ErrorCode`) 추가
- 인증/인가 실패 시 JSON 응답 형식 통일
- CORS 설정에 로컬 개발용 Origin 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [ ] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #55 
