### PR TITLE
feat: 빵집 목록 검색·정렬·필터·페이징 API 구현

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 
 	// Google Cloud SQL Socket Factory for PostgreSQL
 	implementation 'com.google.cloud.sql:postgres-socket-factory:1.15.2'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa::jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt::jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -6,6 +6,8 @@ import com.breadbread.bakery.entity.BakerySortType;
 import com.breadbread.bakery.service.BakeryService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +23,18 @@ public class BakeryController {
 
     private final BakeryService bakeryService;
 
-    @Operation(summary = "빵집 목록 조회 (검색/정렬/필터/페이징)")
+    @Operation(
+            summary = "빵집 목록 조회",
+            description = "키워드 검색, 지역 필터, 정렬, 영업 중 필터, 페이징 지원"
+    )
+    @Parameters({
+            @Parameter(name = "keyword", description = "빵집 이름 검색어", example = "성심당"),
+            @Parameter(name = "sort", description = "정렬 기준 (RATING: 별점순 / REVIEW_COUNT: 리뷰순 / LIKE_COUNT: 하트순)"),
+            @Parameter(name = "open", description = "영업 중인 빵집만 조회 (기본값: false)"),
+            @Parameter(name = "region", description = "지역구 필터", example = "대전 중구"),
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작, 기본값: 0)"),
+            @Parameter(name = "size", description = "페이지 크기 (기본값: 10)")
+    })
     @GetMapping
     public ApiResponse<BakeryListResponse> search(
             @RequestParam(required = false) String keyword,

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -2,11 +2,13 @@ package com.breadbread.bakery.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.bakery.dto.*;
+import com.breadbread.bakery.entity.BakerySortType;
 import com.breadbread.bakery.service.BakeryService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,11 +21,23 @@ public class BakeryController {
 
     private final BakeryService bakeryService;
 
-    @Operation(summary = "빵집 전체 조회")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
+    @Operation(summary = "빵집 목록 조회 (검색/정렬/필터/페이징)")
     @GetMapping
-    public ApiResponse<BakeryListResponse> findAll() {
-        return ApiResponse.ok(bakeryService.findAll());
+    public ApiResponse<BakeryListResponse> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) BakerySortType sort,
+            @RequestParam(defaultValue = "false") boolean open,
+            @RequestParam(required = false) String region,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        BakerySearch search = BakerySearch.builder()
+                .keyword(keyword)
+                .sort(sort)
+                .open(open)
+                .region(region)
+                .build();
+        return ApiResponse.ok(bakeryService.search(search, PageRequest.of(page, size)));
     }
 
     @Operation(summary = "빵집 상세 조회")

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryListResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryListResponse.java
@@ -10,4 +10,7 @@ import java.util.List;
 public class BakeryListResponse {
     private List<BakerySummaryResponse> bakeries;
     private int total;
+    private int page;
+    private int size;
+    private boolean hasNext;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class BakerySearch {
-    String keyword;
-    BakerySortType sort;
+    private String keyword;
+    private BakerySortType sort;
     private boolean open;
     private String region;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
@@ -1,0 +1,14 @@
+package com.breadbread.bakery.dto;
+
+import com.breadbread.bakery.entity.BakerySortType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BakerySearch {
+    String keyword;
+    BakerySortType sort;
+    private boolean open;
+    private String region;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/CreateBakeryRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/CreateBakeryRequest.java
@@ -49,7 +49,7 @@ public class CreateBakeryRequest {
     private Set<DayOfWeek> crowdedDays;
     private boolean dineInAvailable;
     private boolean parkingAvailable;
-    private boolean drinkingAvailable;
+    private boolean drinkAvailable;
 
     @Schema(description = "빵 나오는 시각")
     private LocalTime appearanceTime;

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BakerySortType.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BakerySortType.java
@@ -1,0 +1,7 @@
+package com.breadbread.bakery.entity;
+
+public enum BakerySortType {
+    RATING,
+    REVIEW_COUNT,
+    LIKE_COUNT
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
@@ -3,5 +3,5 @@ package com.breadbread.bakery.repository;
 import com.breadbread.bakery.entity.Bakery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BakeryRepository extends JpaRepository<Bakery, Long> {
+public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRepositoryCustom {
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryCustom.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.dto.BakerySearch;
+import com.breadbread.bakery.entity.Bakery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BakeryRepositoryCustom {
+    Page<Bakery> search(BakerySearch bakerySearch, Pageable pageable);
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
@@ -1,0 +1,111 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.dto.BakerySearch;
+import com.breadbread.bakery.entity.*;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.StringUtils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+@RequiredArgsConstructor
+public class BakeryRepositoryImpl implements BakeryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Bakery> search(BakerySearch search, Pageable pageable) {
+        QBakery bakery = QBakery.bakery;
+        QReview review = QReview.review;
+        QBakeryLike like = QBakeryLike.bakeryLike;
+
+        BooleanExpression keyword = containKeyword(bakery, search.getKeyword());
+        BooleanExpression open = isOpenNow(bakery, search.isOpen());
+        BooleanExpression region = eqRegion(bakery, search.getRegion());
+
+        List<Bakery> content = fetchContent(search.getSort(), bakery, review, like, keyword, open, region, pageable);
+
+        Long total = queryFactory
+                .select(bakery.count())
+                .from(bakery)
+                .where(keyword, open, region)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // 정렬별 쿼리 분기 + 페이징 한 곳에서 처리
+    private List<Bakery> fetchContent(BakerySortType sort, QBakery bakery,
+                                      QReview review, QBakeryLike like,
+                                      BooleanExpression keyword, BooleanExpression open,
+                                      BooleanExpression region, Pageable pageable) {
+
+        if (sort == BakerySortType.REVIEW_COUNT) {
+            return applyPaging(queryFactory.selectFrom(bakery)
+                    .leftJoin(review).on(review.bakery.eq(bakery))
+                    .where(keyword, open, region)
+                    .groupBy(bakery.id)
+                    .orderBy(review.count().desc(), bakery.id.desc()), pageable);
+        }
+        if (sort == BakerySortType.LIKE_COUNT) {
+            return applyPaging(queryFactory.selectFrom(bakery)
+                    .leftJoin(like).on(like.bakery.eq(bakery))
+                    .where(keyword, open, region)
+                    .groupBy(bakery.id)
+                    .orderBy(like.count().desc(), bakery.id.desc()), pageable);
+        }
+        return applyPaging(queryFactory.selectFrom(bakery)
+                .where(keyword, open, region)
+                .orderBy(defaultOrder(sort, bakery)), pageable);
+    }
+
+    private List<Bakery> applyPaging(JPAQuery<Bakery> query, Pageable pageable) {
+        return query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private OrderSpecifier<?>[] defaultOrder(BakerySortType sort, QBakery bakery) {
+        if (sort == BakerySortType.RATING) {
+            return new OrderSpecifier<?>[]{
+                    new OrderSpecifier<>(Order.DESC, bakery.rating, OrderSpecifier.NullHandling.NullsLast),
+                    bakery.id.desc()
+            };
+        }
+        return new OrderSpecifier<?>[]{bakery.id.desc()};
+    }
+
+    private BooleanExpression containKeyword(QBakery bakery, String keyword) {
+        return StringUtils.hasText(keyword) ? bakery.name.contains(keyword) : null;
+    }
+
+    private BooleanExpression isOpenNow(QBakery bakery, boolean open) {
+        if (!open) return null;
+
+        DayOfWeek today = LocalDate.now().getDayOfWeek();
+        LocalTime now = LocalTime.now();
+        boolean isWeekend = (today == DayOfWeek.SATURDAY || today == DayOfWeek.SUNDAY);
+
+        BooleanExpression timeCondition = isWeekend
+                ? bakery.businessHours.weekendOpen.loe(now)
+                .and(bakery.businessHours.weekendClose.goe(now))
+                : bakery.businessHours.weekdayOpen.loe(now)
+                .and(bakery.businessHours.weekdayClose.goe(now));
+
+        return bakery.closedDays.contains(today).not().and(timeCondition);
+    }
+
+    private BooleanExpression eqRegion(QBakery bakery, String region) {
+        return StringUtils.hasText(region) ? bakery.region.eq(region) : null;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -11,24 +11,27 @@ import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BakeryService {
-
     private final BakeryRepository bakeryRepository;
     private final BreadRepository breadRepository;
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public BakeryListResponse findAll() {
+    public BakeryListResponse search(BakerySearch search, Pageable pageable) {
+        Page<Bakery> result = bakeryRepository.search(search, pageable);
         return BakeryListResponse.builder()
-                .bakeries(bakeryRepository.findAll().stream()
-                        .map(BakerySummaryResponse::from)
-                        .toList())
-                .total((int) bakeryRepository.count())
+                .bakeries(result.getContent().stream().map(BakerySummaryResponse::from).toList())
+                .total((int) result.getTotalElements())
+                .page(pageable.getPageNumber())
+                .size(pageable.getPageSize())
+                .hasNext(result.hasNext())
                 .build();
     }
 
@@ -60,7 +63,7 @@ public class BakeryService {
                 .crowdedDays(request.getCrowdedDays())
                 .dineInAvailable(request.isDineInAvailable())
                 .parkingAvailable(request.isParkingAvailable())
-                .drinkAvailable(request.isDrinkingAvailable())
+                .drinkAvailable(request.isDrinkAvailable())
                 .appearanceTime(request.getAppearanceTime())
                 .frequency(request.getFrequency())
                 .weekdayOpen(request.getWeekdayOpen())

--- a/apps/be/src/main/java/com/breadbread/global/config/QueryDslConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.breadbread.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## Task
## Task
- 빵집 목록 조회 API에 검색·정렬·필터·페이징 기능 구현

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [x] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [ ] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Detail
- QueryDSL 의존성 추가
- `BakerySearch`, `BakerySortType` 추가
- `BakeryRepositoryImpl` — 키워드/지역 필터, 별점·리뷰수·하트수 정렬, 영업 중 필터(DB 레벨), 페이징
- `BakeryListResponse` — 페이징 필드 추가 (page, size, hasNext)
- `GET /api/bakeries` 파라미터 확장 (keyword, sort, open, region, page, size)

## Issue
- close #75 
