### PR TITLE
feat: 이미지 업로드 및 빵집 전체 데이터 조회 API 추가

### DIFF
--- a/.github/workflows/cd-cloud-run.yml
+++ b/.github/workflows/cd-cloud-run.yml
@@ -54,6 +54,7 @@ jobs:
             GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
             GCP_REGION=${{ secrets.GCP_REGION }}
             CLOUD_SQL_INSTANCE=${{ secrets.CLOUD_SQL_INSTANCE }}
+            GCS_BUCKET=${{ secrets.GCS_BUCKET }}
             DB_NAME=${{ secrets.DB_NAME }}
             DB_USERNAME=${{ secrets.DB_USERNAME }}
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}

--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// Google Cloud SQL Socket Factory for PostgreSQL
 	implementation 'com.google.cloud.sql:postgres-socket-factory:1.15.2'
 
+	// Google Cloud Storage
+	implementation 'com.google.cloud:spring-cloud-gcp-starter-storage:5.10.0'
+
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa::jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt::jakarta'

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -23,6 +23,13 @@ public class BakeryController {
 
     private final BakeryService bakeryService;
 
+    @Operation(summary = "AI용 빵집 전체 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
+    @GetMapping("/ai")
+    public ApiResponse<java.util.List<BakeryAiResponse>> findAllForAi() {
+        return ApiResponse.ok(bakeryService.findAllForAi());
+    }
+
     @Operation(
             summary = "빵집 목록 조회",
             description = "키워드 검색, 지역 필터, 정렬, 영업 중 필터, 페이징 지원"

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
@@ -1,0 +1,135 @@
+package com.breadbread.bakery.dto;
+
+import com.breadbread.bakery.entity.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class BakeryAiResponse {
+
+    private Long id;
+    private String name;
+    private String address;
+    private String region;
+    private Double lat;
+    private Double lng;
+    private String phone;
+    private String mapLink;
+    private String note;
+    private Integer rating;
+    private boolean dineInAvailable;
+    private boolean parkingAvailable;
+    private boolean drinkAvailable;
+    private String bakeryType;
+    private LocalTime appearanceTime;
+    private String frequency;
+    private Set<String> closedDays;
+    private String closedDayNote;
+    private Set<String> crowdedDays;
+    private List<String> useTypes;
+    private List<String> personalities;
+    private LocalTime weekdayOpen;
+    private LocalTime weekdayClose;
+    private LocalTime weekendOpen;
+    private LocalTime weekendClose;
+    private String lastOrderTime;
+    private boolean holidayClosed;
+    private List<BreadInfo> breads;
+    private List<CrowdTimeInfo> crowdTimes;
+    private List<String> imageUrls;
+
+    public static BakeryAiResponse from(Bakery bakery, List<Bread> breads, List<CrowdTime> crowdTimes) {
+        BusinessHours bh = bakery.getBusinessHours();
+        return BakeryAiResponse.builder()
+                .id(bakery.getId())
+                .name(bakery.getName())
+                .address(bakery.getAddress())
+                .region(bakery.getRegion())
+                .lat(bakery.getLatitude())
+                .lng(bakery.getLongitude())
+                .phone(bakery.getPhone())
+                .mapLink(bakery.getMapLink())
+                .note(bakery.getNote())
+                .rating(bakery.getRating())
+                .dineInAvailable(bakery.isDineInAvailable())
+                .parkingAvailable(bakery.isParkingAvailable())
+                .drinkAvailable(bakery.isDrinkAvailable())
+                .bakeryType(bakery.getBakeryType() != null ? bakery.getBakeryType().name() : null)
+                .appearanceTime(bakery.getAppearanceTime())
+                .frequency(bakery.getFrequency() != null ? bakery.getFrequency().name() : null)
+                .closedDays(bakery.getClosedDays().stream()
+                        .map(DayOfWeek::name)
+                        .collect(Collectors.toSet()))
+                .closedDayNote(bh != null ? bh.getClosedDayNote() : null)
+                .crowdedDays(bakery.getCrowdedDays().stream()
+                        .map(DayOfWeek::name)
+                        .collect(Collectors.toSet()))
+                .useTypes(bakery.getBakeryUseTypes().stream()
+                        .map(BakeryUseType::name)
+                        .toList())
+                .personalities(bakery.getBakeryPersonalities().stream()
+                        .map(BakeryPersonality::name)
+                        .toList())
+                .weekdayOpen(bh != null ? bh.getWeekdayOpen() : null)
+                .weekdayClose(bh != null ? bh.getWeekdayClose() : null)
+                .weekendOpen(bh != null ? bh.getWeekendOpen() : null)
+                .weekendClose(bh != null ? bh.getWeekendClose() : null)
+                .lastOrderTime(bh != null ? bh.getLastOrderTime() : null)
+                .holidayClosed(bh != null && bh.isHolidayClosed())
+                .breads(breads.stream().map(BreadInfo::from).toList())
+                .crowdTimes(crowdTimes.stream().map(CrowdTimeInfo::from).toList())
+                .imageUrls(bakery.getImages().stream()
+                        .map(BakeryImage::getImageUrl)
+                        .toList())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class BreadInfo {
+        private String name;
+        private int price;
+        private String breadType;
+        private boolean signature;
+        private boolean estimatedSoldOut;
+        private int selloutMin;
+
+        public static BreadInfo from(Bread bread) {
+            return BreadInfo.builder()
+                    .name(bread.getName())
+                    .price(bread.getPrice())
+                    .breadType(bread.getBreadType() != null ? bread.getBreadType().name() : null)
+                    .signature(bread.isSignature())
+                    .estimatedSoldOut(bread.isEstimatedSoldOut())
+                    .selloutMin(bread.getSelloutMin())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class CrowdTimeInfo {
+        private String dayType;
+        private LocalTime peakStart;
+        private LocalTime peakEnd;
+        private String crowdLevel;
+        private Integer expectedWaitMin;
+
+        public static CrowdTimeInfo from(CrowdTime crowdTime) {
+            return CrowdTimeInfo.builder()
+                    .dayType(crowdTime.getDayType() != null ? crowdTime.getDayType().name() : null)
+                    .peakStart(crowdTime.getPeakStart())
+                    .peakEnd(crowdTime.getPeakEnd())
+                    .crowdLevel(crowdTime.getCrowdLevel() != null ? crowdTime.getCrowdLevel().name() : null)
+                    .expectedWaitMin(crowdTime.getExpectedWaitMin())
+                    .build();
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySummaryResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySummaryResponse.java
@@ -1,6 +1,7 @@
 package com.breadbread.bakery.dto;
 
 import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
 import com.breadbread.bakery.entity.BusinessHours;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ public class BakerySummaryResponse {
     private LocalTime closeTime;
     private int likeCount;
 
-    public static BakerySummaryResponse from(Bakery bakery) {
+    public static BakerySummaryResponse from(Bakery bakery, String thumbnailUrl) {
         BusinessHours bh = bakery.getBusinessHours();
         return BakerySummaryResponse.builder()
                 .id(bakery.getId())
@@ -30,6 +31,7 @@ public class BakerySummaryResponse {
                 .lat(bakery.getLatitude())
                 .lng(bakery.getLongitude())
                 .rating(bakery.getRating())
+                .thumbnailUrl(thumbnailUrl)
                 .openTime(bh != null ? bh.getTodayOpen() : null)
                 .closeTime(bh != null ? bh.getTodayClose() : null)
                 .build();

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/CreateBakeryRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/CreateBakeryRequest.java
@@ -56,4 +56,7 @@ public class CreateBakeryRequest {
 
     @Schema(description = "생산 빈도 (ALWAYS, ONCE_PER_DAY, TWICE_PER_DAY)")
     private Frequency frequency;
+
+    @Schema(description = "빵집 사진 URL 리스트(최대 5개 저장)")
+    private String[] imageUrls;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/UpdateBakeryRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/UpdateBakeryRequest.java
@@ -43,4 +43,5 @@ public class UpdateBakeryRequest {
     private Boolean drinkAvailable;
     private LocalTime appearanceTime;
     private Frequency frequency;
+    private String[] imageUrls;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/Bread.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/Bread.java
@@ -1,5 +1,6 @@
 package com.breadbread.bakery.entity;
 
+import com.breadbread.bakery.dto.UpdateBreadRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -42,13 +43,12 @@ public class Bread {
         this.selloutMin = selloutMin;
     }
 
-    public void update(String name, Integer price, String imageUrl,
-                       BreadType breadType, Boolean signature) {
-        if (name != null) this.name = name;
-        if (price != null) this.price = price;
-        if (imageUrl != null) this.imageUrl = imageUrl;
-        if (breadType != null) this.breadType = breadType;
-        if (signature != null) this.signature = signature;
+    public void update(UpdateBreadRequest req) {
+        if (req.getName() != null) this.name = req.getName();
+        if (req.getPrice() != null) this.price = req.getPrice();
+        if (req.getImageUrl() != null) this.imageUrl = req.getImageUrl();
+        if (req.getBreadType() != null) this.breadType = req.getBreadType();
+        if (req.getSignature() != null) this.signature = req.getSignature();
     }
 
     public void markSoldOut() {

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryImageRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryImageRepository.java
@@ -1,0 +1,13 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface BakeryImageRepository extends JpaRepository<BakeryImage, Long> {
+    void deleteAllByBakery(Bakery bakery);
+    List<BakeryImage> findAllByBakeryIdInAndDisplayOrder(Collection<Long> bakeryIds, int displayOrder);
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+
 @RequiredArgsConstructor
 public class BakeryRepositoryImpl implements BakeryRepositoryCustom {
 

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
@@ -3,5 +3,9 @@ package com.breadbread.bakery.repository;
 import com.breadbread.bakery.entity.Bread;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface BreadRepository extends JpaRepository<Bread, Long> {
+    List<Bread> findAllByBakeryIdIn(Collection<Long> bakeryIds);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/CrowdTimeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/CrowdTimeRepository.java
@@ -1,0 +1,11 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.entity.CrowdTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface CrowdTimeRepository extends JpaRepository<CrowdTime, Long> {
+    List<CrowdTime> findAllByBakeryIdIn(Collection<Long> bakeryIds);
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -124,10 +124,10 @@ public class BakeryService {
         if(request.getImageUrls()!=null){
             List<BakeryImage> images = new ArrayList<>();
             String[] urls = request.getImageUrls();
-            for(int i=1; i<= urls.length; i++){
+            for (int i = 0; i < urls.length; i++) {
                 images.add(BakeryImage.builder()
                         .imageUrl(urls[i])
-                        .displayOrder(i)
+                        .displayOrder(i + 1)
                         .bakery(saved)
                         .build());
             }
@@ -149,10 +149,10 @@ public class BakeryService {
             bakeryImageRepository.deleteAllByBakery(bakery);
             List<BakeryImage> images = new ArrayList<>();
             String[] urls = request.getImageUrls();
-            for (int i = 1; i <= urls.length; i++) {
+            for (int i = 0; i < urls.length; i++) {
                 images.add(BakeryImage.builder()
                         .imageUrl(urls[i])
-                        .displayOrder(i)
+                        .displayOrder(i + 1)
                         .bakery(bakery)
                         .build());
             }

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -2,11 +2,16 @@ package com.breadbread.bakery.service;
 
 import com.breadbread.bakery.dto.*;
 import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
 import com.breadbread.bakery.entity.Bread;
+import com.breadbread.bakery.entity.CrowdTime;
+import com.breadbread.bakery.repository.BakeryImageRepository;
 import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.bakery.repository.BreadRepository;
+import com.breadbread.bakery.repository.CrowdTimeRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.GcsService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
@@ -16,18 +21,54 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class BakeryService {
     private final BakeryRepository bakeryRepository;
     private final BreadRepository breadRepository;
     private final UserRepository userRepository;
+    private final CrowdTimeRepository crowdTimeRepository;
+    private final BakeryImageRepository bakeryImageRepository;
+    private final GcsService gcsService;
+
+    @Transactional(readOnly = true)
+    public List<BakeryAiResponse> findAllForAi() {
+        List<Bakery> bakeries = bakeryRepository.findAll();
+        List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
+
+        Map<Long, List<Bread>> breadMap = breadRepository.findAllByBakeryIdIn(ids)
+                .stream().collect(Collectors.groupingBy(b -> b.getBakery().getId()));
+
+        Map<Long, List<CrowdTime>> crowdTimeMap = crowdTimeRepository.findAllByBakeryIdIn(ids)
+                .stream().collect(Collectors.groupingBy(ct -> ct.getBakery().getId()));
+
+        return bakeries.stream()
+                .map(b -> BakeryAiResponse.from(b,
+                        breadMap.getOrDefault(b.getId(), List.of()),
+                        crowdTimeMap.getOrDefault(b.getId(), List.of())))
+                .toList();
+    }
 
     @Transactional(readOnly = true)
     public BakeryListResponse search(BakerySearch search, Pageable pageable) {
         Page<Bakery> result = bakeryRepository.search(search, pageable);
+        List<Bakery> bakeries = result.getContent();
+
+        List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
+        Map<Long, String> thumbnailMap = bakeryImageRepository
+                .findAllByBakeryIdInAndDisplayOrder(ids, 1)
+                .stream()
+                .collect(Collectors.toMap(img -> img.getBakery().getId(), BakeryImage::getImageUrl));
+
         return BakeryListResponse.builder()
-                .bakeries(result.getContent().stream().map(BakerySummaryResponse::from).toList())
+                .bakeries(bakeries.stream()
+                        .map(b -> BakerySummaryResponse.from(b, thumbnailMap.get(b.getId())))
+                        .toList())
                 .total((int) result.getTotalElements())
                 .page(pageable.getPageNumber())
                 .size(pageable.getPageSize())
@@ -77,17 +118,46 @@ public class BakeryService {
         if (user.getRole() == UserRole.ROLE_BUSINESS) {
             bakery.assignOwner(user);
         }
-        return bakeryRepository.save(bakery).getId();
+
+        Bakery saved = bakeryRepository.save(bakery);
+
+        if(request.getImageUrls()!=null){
+            List<BakeryImage> images = new ArrayList<>();
+            String[] urls = request.getImageUrls();
+            for(int i=1; i<= urls.length; i++){
+                images.add(BakeryImage.builder()
+                        .imageUrl(urls[i])
+                        .displayOrder(i)
+                        .bakery(saved)
+                        .build());
+            }
+            bakeryImageRepository.saveAll(images);
+        }
+
+        return saved.getId();
     }
 
     @Transactional
     public void updateBakery(Long userId, UserRole role, Long bakeryId, UpdateBakeryRequest request) {
         Bakery bakery = bakeryRepository.findById(bakeryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
         checkAuthority(bakery, userId, role);
-
         bakery.update(request);
+
+        if (request.getImageUrls() != null) {
+            bakery.getImages().forEach(img -> gcsService.deleteQuietly(img.getImageUrl()));
+            bakeryImageRepository.deleteAllByBakery(bakery);
+            List<BakeryImage> images = new ArrayList<>();
+            String[] urls = request.getImageUrls();
+            for (int i = 1; i <= urls.length; i++) {
+                images.add(BakeryImage.builder()
+                        .imageUrl(urls[i])
+                        .displayOrder(i)
+                        .bakery(bakery)
+                        .build());
+            }
+            bakeryImageRepository.saveAll(images);
+        }
     }
 
     @Transactional
@@ -96,6 +166,8 @@ public class BakeryService {
                 .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
 
         checkAuthority(bakery, userId, role);
+        bakery.getImages().forEach(img -> gcsService.deleteQuietly(img.getImageUrl()));
+        bakeryImageRepository.deleteAllByBakery(bakery);
         bakeryRepository.delete(bakery);
     }
 
@@ -128,8 +200,10 @@ public class BakeryService {
         Bread bread = breadRepository.findById(breadId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
 
-        bread.update(request.getName(), request.getPrice(), request.getImageUrl(),
-                request.getBreadType(), request.getSignature());
+        if (request.getImageUrl() != null && bread.getImageUrl() != null) {
+            gcsService.deleteQuietly(bread.getImageUrl());
+        }
+        bread.update(request);
     }
 
     @Transactional
@@ -142,6 +216,9 @@ public class BakeryService {
         Bread bread = breadRepository.findById(breadId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
 
+        if (bread.getImageUrl() != null) {
+            gcsService.deleteQuietly(bread.getImageUrl());
+        }
         breadRepository.delete(bread);
     }
 

--- a/apps/be/src/main/java/com/breadbread/global/controller/ImageController.java
+++ b/apps/be/src/main/java/com/breadbread/global/controller/ImageController.java
@@ -1,0 +1,33 @@
+package com.breadbread.global.controller;
+
+import com.breadbread.global.dto.ApiResponse;
+import com.breadbread.global.service.GcsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "이미지")
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final GcsService gcsService;
+
+    @Operation(summary = "이미지 선업로드", description = "폼 제출 전 이미지를 미리 업로드하고 URL 목록을 반환. folder 예시: bakeries, breads, reviews")
+    @RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<List<String>> upload(
+            @RequestPart List<MultipartFile> images,
+            @RequestParam(defaultValue = "common") String folder) {
+        return ApiResponse.ok(gcsService.uploadAll(images, folder));
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -56,7 +56,13 @@ public enum ErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E0601", "존재하지 않는 결제 내역입니다."),
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "E0602", "결제에 실패했습니다."),
     PAYMENT_ALREADY_DONE(HttpStatus.CONFLICT, "E0603", "이미 완료된 결제입니다."),
-    PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "E0604", "결제 취소에 실패했습니다.");
+    PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "E0604", "결제 취소에 실패했습니다."),
+
+    // 파일/GCS E07xx
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E0701", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E0702", "파일 삭제에 실패했습니다."),
+    INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "E0703", "유효하지 않은 파일 이름입니다."),
+    INVALID_GCS_URL(HttpStatus.BAD_REQUEST, "E0704", "유효하지 않은 파일 URL입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/be/src/main/java/com/breadbread/global/service/GcsService.java
+++ b/apps/be/src/main/java/com/breadbread/global/service/GcsService.java
@@ -1,0 +1,89 @@
+package com.breadbread.global.service;
+
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GcsService {
+
+    private final Storage storage;
+
+    @Value("${gcs.bucket}")
+    private String bucketName;
+
+    // 업로드
+    public String upload(MultipartFile file, String folder)  {
+        String originalFilename = Optional.ofNullable(file.getOriginalFilename())
+                .filter(name -> !name.isBlank())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_FILE_NAME));
+
+        String fileName = folder + "/" + UUID.randomUUID() + "_" + originalFilename;
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fileName)
+                .setContentType(file.getContentType())
+                .build();
+
+        try {
+            storage.create(blobInfo, file.getBytes());
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        return "https://storage.googleapis.com/" + bucketName + "/" + fileName;
+    }
+
+    public List<String> uploadAll(List<MultipartFile> files, String folder) {
+        List<String> uploadedUrls = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            try {
+                uploadedUrls.add(upload(file, folder));
+            } catch (CustomException e) {
+                uploadedUrls.forEach(this::deleteQuietly);  // 부분 성공 롤백
+                throw e;
+            }
+        }
+
+        return uploadedUrls;
+    }
+
+    // 삭제
+    public void delete(String fileUrl) {
+        String prefix = "https://storage.googleapis.com/" + bucketName + "/";
+        if (!fileUrl.startsWith(prefix)) {
+            throw new CustomException(ErrorCode.INVALID_GCS_URL);
+        }
+
+        String fileName = fileUrl.substring(prefix.length());
+
+        try {
+            storage.delete(BlobId.of(bucketName, fileName));
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    public void deleteQuietly(String url) {
+        try {
+            delete(url);
+        } catch (Exception e) {
+            log.warn("GCS 파일 삭제 실패 (무시됨): {}", url, e);
+        }
+    }
+}

--- a/apps/be/src/main/resources/application-prod.yml
+++ b/apps/be/src/main/resources/application-prod.yml
@@ -5,5 +5,15 @@ spring:
     password: ${DB_PASSWORD:bread1234}
     driver-class-name: org.postgresql.Driver
 
+  cloud:
+    gcp:
+      project-id: ${GCP_PROJECT_ID}
+      sql:
+        enabled: false
+
+gcs:
+  bucket: ${GCS_BUCKET}
+
 server:
   port: ${PORT:8080}
+  forward-headers-strategy: framework

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -23,6 +23,24 @@ spring:
   security:
     enabled: false  # 개발 중 임시 비활성화
 
+  cloud:
+    gcp:
+      project-id: ${GCP_PROJECT_ID:your-project-id}
+      sql:
+        enabled: false
+      storage:
+        credentials:
+          location: ${GCP_CREDENTIALS_PATH:classpath:key.json}
+
+  servlet:
+    multipart:
+      max-file-size: 10MB        # 파일 1개당 최대 크기
+      max-request-size: 50MB    # 요청 전체 크기 (여러 파일)
+      enabled: true
+
+gcs:
+  bucket: ${GCS_BUCKET:your-bucket-name}
+
 jwt:
   secret: ${JWT_SECRET:temp-access-secret-key-minimum-32-characters-x}
   expires-in: ${JWT_EXPIRES_IN:3600}
@@ -30,7 +48,7 @@ jwt:
   refresh-expires-in: ${JWT_REFRESH_EXPIRES_IN:604800}
 
 server:
-  port: ${PORT:8000}
+  port: ${PORT:8080}
 
 coolsms:
   api:

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -28,9 +28,6 @@ spring:
       project-id: ${GCP_PROJECT_ID:your-project-id}
       sql:
         enabled: false
-      storage:
-        credentials:
-          location: ${GCP_CREDENTIALS_PATH:classpath:key.json}
 
   servlet:
     multipart:

--- a/apps/be/src/test/java/com/breadbread/BreadbreadApplicationTests.java
+++ b/apps/be/src/test/java/com/breadbread/BreadbreadApplicationTests.java
@@ -1,12 +1,17 @@
 package com.breadbread;
 
+import com.google.cloud.storage.Storage;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
-@SpringBootTest
+@SpringBootTest(properties = "spring.cloud.gcp.sql.enabled=false")
 class BreadbreadApplicationTests {
+
+	@MockitoBean
+	Storage storage;
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION

## Task
- GCS 이미지 선업로드 API 추가 (POST /api/images)
- 빵집 생성/수정 시 이미지 저장 및 교체 로직 구현
- 빵집/빵 삭제 및 이미지 교체 시 GCS 파일 삭제 처리
- AI 코스 추천용 빵집 전체 조회 API 추가 (GET /api/bakeries/ai)
- Bread.update() DTO 방식으로 리팩토링
- 배포 환경 Swagger HTTPS 요청 오류 수정 (forward-headers-strategy: framework)

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [x] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [ ] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #79 
