### PR TITLE
chore: GitHub Actions CI 캐시 활성화 및 GCP 인증을 Workload Identity로 전환

### DIFF
--- a/.github/workflows/cd-cloud-run.yml
+++ b/.github/workflows/cd-cloud-run.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -33,8 +34,11 @@ jobs:
       - name: Build and push to Artifact Registry
         run: |
           gcloud auth configure-docker $REGION-docker.pkg.dev
-          docker build -t $IMAGE_REPO:${{ github.sha }} apps/be
+          docker build -t $IMAGE_REPO:${{ github.sha }} \
+                      -t $IMAGE_REPO:latest \
+                      apps/be
           docker push $IMAGE_REPO:${{ github.sha }}
+          docker push $IMAGE_REPO:latest
 
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-disabled: true
       - run: chmod +x gradlew
       - run: ./gradlew spotlessCheck
       - run: ./gradlew build -x test


### PR DESCRIPTION
## Task
- GitHub Actions CI 캐시 활성화 및 GitHub Actions의 GCP 인증 방식을 서비스 계정 키 기반에서 Workload Identity Federation 기반으로 전환

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
