### PR TITLE
chore: Cloud Run 시크릿 주입 방식으로 배포 설정 변경

### DIFF
--- a/.github/workflows/cd-cloud-run.yml
+++ b/.github/workflows/cd-cloud-run.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: "access_token"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
@@ -56,31 +57,32 @@ jobs:
             --cpu-boost
           env_vars: |
             SPRING_PROFILES_ACTIVE=prod
-            GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }}
+            GCP_PROJECT_ID=${{ env.PROJECT_ID }}
             GCP_REGION=${{ env.REGION }}
             CLOUD_SQL_INSTANCE=${{ secrets.CLOUD_SQL_INSTANCE }}
             GCS_BUCKET=${{ secrets.GCS_BUCKET }}
-            DB_NAME=${{ secrets.DB_NAME }}
-            DB_USERNAME=${{ secrets.DB_USERNAME }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-            REDIS_HOST=${{ secrets.REDIS_HOST }}
             REDIS_PORT=${{ secrets.REDIS_PORT }}
-            REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
-            JWT_REFRESH_SECRET=${{ secrets.JWT_REFRESH_SECRET }}
             JWT_EXPIRES_IN=${{ secrets.JWT_EXPIRES_IN }}
             JWT_REFRESH_EXPIRES_IN=${{ secrets.JWT_REFRESH_EXPIRES_IN }}
-            COOLSMS_API_KEY=${{ secrets.COOLSMS_API_KEY }}
-            COOLSMS_API_SECRET=${{ secrets.COOLSMS_API_SECRET }}
-            COOLSMS_SENDER=${{ secrets.COOLSMS_SENDER }}
-            GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-            GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
-            NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }}
-            NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }}
-            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
-            KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
-            AI_COURSE_WEBHOOK_URL=${{ secrets.AI_COURSE_WEBHOOK_URL }}
-            PORTONE_API_SECRET=${{ secrets.PORTONE_API_SECRET }}
-            PORTONE_STORE_ID=${{ secrets.PORTONE_STORE_ID }}
-            PORTONE_CHANNEL_KEY=${{ secrets.PORTONE_CHANNEL_KEY }}
-            PORTONE_WEBHOOK_SECRET=${{ secrets.PORTONE_WEBHOOK_SECRET }}
+          secrets: |
+            DB_NAME=DB_NAME:latest
+            DB_USERNAME=DB_USERNAME:latest
+            DB_PASSWORD=DB_PASSWORD:latest
+            REDIS_HOST=REDIS_HOST:latest
+            REDIS_PASSWORD=REDIS_PASSWORD:latest
+            JWT_SECRET=JWT_SECRET:latest
+            JWT_REFRESH_SECRET=JWT_REFRESH_SECRET:latest
+            COOLSMS_API_KEY=COOLSMS_API_KEY:latest
+            COOLSMS_API_SECRET=COOLSMS_API_SECRET:latest
+            COOLSMS_SENDER=COOLSMS_SENDER:latest
+            GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest
+            GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest
+            NAVER_CLIENT_ID=NAVER_CLIENT_ID:latest
+            NAVER_CLIENT_SECRET=NAVER_CLIENT_SECRET:latest
+            KAKAO_CLIENT_ID=KAKAO_CLIENT_ID:latest
+            KAKAO_CLIENT_SECRET=KAKAO_CLIENT_SECRET:latest
+            AI_COURSE_WEBHOOK_URL=AI_COURSE_WEBHOOK_URL:latest
+            PORTONE_API_SECRET=PORTONE_API_SECRET:latest
+            PORTONE_STORE_ID=PORTONE_STORE_ID:latest
+            PORTONE_CHANNEL_KEY=PORTONE_CHANNEL_KEY:latest
+            PORTONE_WEBHOOK_SECRET=PORTONE_WEBHOOK_SECRET:latest


### PR DESCRIPTION
## Task
- GitHub Actions 기반 Cloud Run 배포 시 앱 민감정보를 GitHub Secrets 대신 GCP Secret Manager에서 주입받도록 배포 워크플로 수정
- `JWT_EXPIRES_IN`, `JWT_REFRESH_EXPIRES_IN`, `REDIS_PORT`, `GCS_BUCKET`만 일반 환경변수로 유지하고, 나머지 런타임 민감정보는 Secret Manager 참조로 전환

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [ ] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [ ] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
