### PR TITLE
feat: 마이페이지 활동 내역 조회 API 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/dto/MyReviewListResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/MyReviewListResponse.java
@@ -1,0 +1,15 @@
+package com.breadbread.bakery.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyReviewListResponse {
+    private List<MyReviewResponse> reviews;
+    private int total;
+    private int page;
+    private int size;
+    private boolean hasNext;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/MyReviewResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/MyReviewResponse.java
@@ -1,0 +1,31 @@
+package com.breadbread.bakery.dto;
+
+import com.breadbread.bakery.entity.Review;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyReviewResponse {
+    private Long reviewId;
+    private Long bakeryId;
+    private String bakeryName;
+    private int rating;
+    private String content;
+    private List<String> imageUrls;
+    private LocalDateTime createdAt;
+
+    public static MyReviewResponse from(Review review) {
+        return MyReviewResponse.builder()
+                .reviewId(review.getId())
+                .bakeryId(review.getBakery().getId())
+                .bakeryName(review.getBakery().getName())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .imageUrls(review.getImageUrls())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryLikeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryLikeRepository.java
@@ -4,6 +4,8 @@ import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryLike;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +27,9 @@ public interface BakeryLikeRepository extends JpaRepository<BakeryLike, Long> {
             "SELECT bl.bakery.id FROM BakeryLike bl WHERE bl.bakery.id IN :bakeryIds AND bl.user.id = :userId")
     List<Long> findLikedBakeryIdsByUserId(
             @Param("bakeryIds") List<Long> bakeryIds, @Param("userId") Long userId);
+
+    @Query(
+            value = "SELECT bl FROM BakeryLike bl JOIN FETCH bl.bakery WHERE bl.user.id = :userId",
+            countQuery = "SELECT COUNT(bl) FROM BakeryLike bl WHERE bl.user.id = :userId")
+    Page<BakeryLike> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.breadbread.bakery.repository;
 
 import com.breadbread.bakery.entity.Review;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT AVG(r.rating) FROM Review r WHERE r.bakery.id = :bakeryId")
     Optional<Double> findAverageRatingByBakeryId(@Param("bakeryId") Long bakeryId);
+
+    List<Review> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
@@ -19,4 +19,17 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Double> findAverageRatingByBakeryId(@Param("bakeryId") Long bakeryId);
 
     List<Review> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query(
+            value = "SELECT r.id FROM Review r WHERE r.user.id = :userId ORDER BY r.createdAt DESC",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.user.id = :userId")
+    Page<Long> findPageIdsByUserIdOrderByCreatedAtDesc(
+            @Param("userId") Long userId, Pageable pageable);
+
+    @Query(
+            "SELECT DISTINCT r FROM Review r "
+                    + "JOIN FETCH r.bakery "
+                    + "LEFT JOIN FETCH r.imageUrls "
+                    + "WHERE r.id IN :reviewIds")
+    List<Review> findAllWithBakeryAndImagesByIdIn(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseLikeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseLikeRepository.java
@@ -4,6 +4,8 @@ import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseLike;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +27,9 @@ public interface CourseLikeRepository extends JpaRepository<CourseLike, Long> {
             "SELECT bl.course.id FROM CourseLike bl WHERE bl.course.id IN :courseIds AND bl.user.id = :userId")
     List<Long> findLikedCourseIdsByUserId(
             @Param("courseIds") List<Long> courseIds, @Param("userId") Long userId);
+
+    @Query(
+            value = "SELECT cl FROM CourseLike cl JOIN FETCH cl.course WHERE cl.user.id = :userId",
+            countQuery = "SELECT COUNT(cl) FROM CourseLike cl WHERE cl.user.id = :userId")
+    Page<CourseLike> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
@@ -4,6 +4,7 @@ import com.breadbread.course.entity.Course;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CourseRepository extends JpaRepository<Course, Long>, CourseRepositoryCustom {
     @Query(
@@ -13,4 +14,11 @@ public interface CourseRepository extends JpaRepository<Course, Long>, CourseRep
                     + "LEFT JOIN FETCH c.courseLikes "
                     + "WHERE c.shared = true")
     List<Course> findAllSharedWithDetails();
+
+    @Query(
+            "SELECT DISTINCT c FROM Course c "
+                    + "LEFT JOIN FETCH c.courseBakeries cb "
+                    + "LEFT JOIN FETCH cb.bakery "
+                    + "WHERE c.id IN :courseIds")
+    List<Course> findAllWithBakeriesByIdIn(@Param("courseIds") List<Long> courseIds);
 }

--- a/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.breadbread.global.exception;
 
 import com.breadbread.global.dto.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,18 @@ public class GlobalExceptionHandler {
                         ApiResponse.fail(
                                 ErrorCode.INVALID_INPUT_VALUE.getCode(),
                                 "올바르지 않은 값입니다: " + e.getValue()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(
+            ConstraintViolationException e) {
+        log.warn("ConstraintViolation: {}", e.getMessage());
+        String message =
+                e.getConstraintViolations().stream()
+                        .map(violation -> violation.getMessage())
+                        .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), message));
     }
 
     @ExceptionHandler(BadCredentialsException.class)

--- a/apps/be/src/main/java/com/breadbread/global/validator/PaginationValidator.java
+++ b/apps/be/src/main/java/com/breadbread/global/validator/PaginationValidator.java
@@ -1,0 +1,14 @@
+package com.breadbread.global.validator;
+
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+
+public final class PaginationValidator {
+    private PaginationValidator() {}
+
+    public static void validate(int page, int size) {
+        if (page < 0 || size <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.breadbread.user.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
+import com.breadbread.bakery.dto.MyReviewResponse;
 import com.breadbread.global.dto.ApiResponse;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -95,6 +97,13 @@ public class UserController {
     public ApiResponse<PreferenceResponse> getPreference(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.ok(userService.getPreference(userDetails.getId()));
+    }
+
+    @Operation(summary = "내가 쓴 리뷰 목록 조회")
+    @GetMapping("/me/reviews")
+    public ApiResponse<List<MyReviewResponse>> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(userService.getMyReviews(userDetails.getId()));
     }
 
     @Operation(summary = "선호도 수정")

--- a/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.breadbread.user.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
-import com.breadbread.bakery.dto.MyReviewResponse;
+import com.breadbread.bakery.dto.BakeryListResponse;
+import com.breadbread.bakery.dto.MyReviewListResponse;
+import com.breadbread.course.dto.CourseListResponse;
 import com.breadbread.global.dto.ApiResponse;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
@@ -16,8 +18,9 @@ import com.breadbread.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import java.util.List;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -101,9 +104,29 @@ public class UserController {
 
     @Operation(summary = "내가 쓴 리뷰 목록 조회")
     @GetMapping("/me/reviews")
-    public ApiResponse<List<MyReviewResponse>> getMyReviews(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ApiResponse.ok(userService.getMyReviews(userDetails.getId()));
+    public ApiResponse<MyReviewListResponse> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Positive int size) {
+        return ApiResponse.ok(userService.getMyReviews(userDetails.getId(), page, size));
+    }
+
+    @Operation(summary = "좋아요한 빵집 목록 조회")
+    @GetMapping("/me/liked/bakeries")
+    public ApiResponse<BakeryListResponse> getLikedBakeries(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Positive int size) {
+        return ApiResponse.ok(userService.getLikedBakeries(userDetails.getId(), page, size));
+    }
+
+    @Operation(summary = "좋아요한 코스 목록 조회")
+    @GetMapping("/me/liked/courses")
+    public ApiResponse<CourseListResponse> getLikedCourses(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Positive int size) {
+        return ApiResponse.ok(userService.getLikedCourses(userDetails.getId(), page, size));
     }
 
     @Operation(summary = "선호도 수정")

--- a/apps/be/src/main/java/com/breadbread/user/service/UserService.java
+++ b/apps/be/src/main/java/com/breadbread/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.breadbread.auth.entity.VerificationPurpose;
 import com.breadbread.auth.redis.PhoneVerificationCache;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
+import com.breadbread.bakery.dto.MyReviewResponse;
+import com.breadbread.bakery.repository.ReviewRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.dto.ChangePasswordRequest;
@@ -17,6 +19,7 @@ import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserPreference;
 import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -33,6 +36,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final PhoneVerificationRedisService phoneVerificationRedisService;
     private final TokenService tokenService;
+    private final ReviewRepository reviewRepository;
 
     @Transactional
     public void savePreference(Long userId, CreatePreferenceRequest request) {
@@ -176,5 +180,12 @@ public class UserService {
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
         tokenService.invalidateByUserId(userId);
         log.info("비밀번호 변경: userId={}", userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyReviewResponse> getMyReviews(Long userId) {
+        return reviewRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(MyReviewResponse::from)
+                .toList();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/user/service/UserService.java
+++ b/apps/be/src/main/java/com/breadbread/user/service/UserService.java
@@ -4,10 +4,29 @@ import com.breadbread.auth.entity.VerificationPurpose;
 import com.breadbread.auth.redis.PhoneVerificationCache;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
+import com.breadbread.bakery.dto.BakeryListResponse;
+import com.breadbread.bakery.dto.BakerySummaryResponse;
+import com.breadbread.bakery.dto.MyReviewListResponse;
 import com.breadbread.bakery.dto.MyReviewResponse;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
+import com.breadbread.bakery.entity.BakeryLike;
+import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.repository.BakeryImageRepository;
+import com.breadbread.bakery.repository.BakeryLikeRepository;
 import com.breadbread.bakery.repository.ReviewRepository;
+import com.breadbread.course.dto.CourseBakerySummary;
+import com.breadbread.course.dto.CourseListResponse;
+import com.breadbread.course.dto.CourseSummaryResponse;
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.CourseLike;
+import com.breadbread.course.repository.CourseLikeRepository;
+import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.course.repository.RouteRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.validator.PaginationValidator;
 import com.breadbread.user.dto.ChangePasswordRequest;
 import com.breadbread.user.dto.ChangePhoneRequest;
 import com.breadbread.user.dto.CreatePreferenceRequest;
@@ -19,10 +38,17 @@ import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserPreference;
 import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +63,11 @@ public class UserService {
     private final PhoneVerificationRedisService phoneVerificationRedisService;
     private final TokenService tokenService;
     private final ReviewRepository reviewRepository;
+    private final BakeryLikeRepository bakeryLikeRepository;
+    private final BakeryImageRepository bakeryImageRepository;
+    private final CourseLikeRepository courseLikeRepository;
+    private final CourseRepository courseRepository;
+    private final RouteRepository routeRepository;
 
     @Transactional
     public void savePreference(Long userId, CreatePreferenceRequest request) {
@@ -183,9 +214,168 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<MyReviewResponse> getMyReviews(Long userId) {
-        return reviewRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
-                .map(MyReviewResponse::from)
-                .toList();
+    public MyReviewListResponse getMyReviews(Long userId, int page, int size) {
+        PaginationValidator.validate(page, size);
+
+        Page<Long> reviewIdsPage =
+                reviewRepository.findPageIdsByUserIdOrderByCreatedAtDesc(
+                        userId, PageRequest.of(page, size));
+        List<Long> reviewIds = reviewIdsPage.getContent();
+
+        Map<Long, Review> reviewsById =
+                reviewIds.isEmpty()
+                        ? Map.of()
+                        : reviewRepository.findAllWithBakeryAndImagesByIdIn(reviewIds).stream()
+                                .collect(Collectors.toMap(Review::getId, review -> review));
+
+        List<MyReviewResponse> reviews =
+                reviewIds.stream().map(reviewsById::get).map(MyReviewResponse::from).toList();
+
+        return MyReviewListResponse.builder()
+                .reviews(reviews)
+                .total((int) reviewIdsPage.getTotalElements())
+                .page(page)
+                .size(size)
+                .hasNext(reviewIdsPage.hasNext())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public BakeryListResponse getLikedBakeries(Long userId, int page, int size) {
+        PaginationValidator.validate(page, size);
+
+        Page<BakeryLike> likes =
+                bakeryLikeRepository.findByUserId(
+                        userId, PageRequest.of(page, size, Sort.by("id").descending()));
+        List<Bakery> bakeries = likes.getContent().stream().map(BakeryLike::getBakery).toList();
+        List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
+
+        Map<Long, String> thumbnailMap =
+                ids.isEmpty()
+                        ? Map.of()
+                        : bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(ids, 1).stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                img -> img.getBakery().getId(),
+                                                BakeryImage::getImageUrl));
+        Map<Long, Long> likeCountMap =
+                ids.isEmpty()
+                        ? Map.of()
+                        : bakeryLikeRepository.countByBakeryIdIn(ids).stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                row -> (Long) row[0], row -> (Long) row[1]));
+
+        return BakeryListResponse.builder()
+                .bakeries(
+                        bakeries.stream()
+                                .map(
+                                        b ->
+                                                BakerySummaryResponse.from(
+                                                        b,
+                                                        thumbnailMap.get(b.getId()),
+                                                        likeCountMap.getOrDefault(b.getId(), 0L),
+                                                        true))
+                                .toList())
+                .total((int) likes.getTotalElements())
+                .page(page)
+                .size(size)
+                .hasNext(likes.hasNext())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public CourseListResponse getLikedCourses(Long userId, int page, int size) {
+        PaginationValidator.validate(page, size);
+
+        Page<CourseLike> likes =
+                courseLikeRepository.findByUserId(
+                        userId, PageRequest.of(page, size, Sort.by("id").descending()));
+        List<Long> courseIds =
+                likes.getContent().stream().map(CourseLike::getCourse).map(Course::getId).toList();
+        Map<Long, Course> likedCoursesById =
+                likes.getContent().stream()
+                        .map(CourseLike::getCourse)
+                        .collect(Collectors.toMap(Course::getId, course -> course));
+        Map<Long, Course> coursesById =
+                courseIds.isEmpty()
+                        ? Map.of()
+                        : courseRepository.findAllWithBakeriesByIdIn(courseIds).stream()
+                                .collect(Collectors.toMap(Course::getId, course -> course));
+        List<Course> courses =
+                courseIds.stream()
+                        .map(id -> coursesById.getOrDefault(id, likedCoursesById.get(id)))
+                        .toList();
+
+        List<Long> allBakeryIds =
+                courses.stream()
+                        .flatMap(course -> course.getCourseBakeries().stream())
+                        .map(cb -> cb.getBakery().getId())
+                        .distinct()
+                        .toList();
+
+        Map<Long, String> thumbnailMap =
+                allBakeryIds.isEmpty()
+                        ? Map.of()
+                        : bakeryImageRepository
+                                .findAllByBakeryIdInAndDisplayOrder(allBakeryIds, 1)
+                                .stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                img -> img.getBakery().getId(),
+                                                BakeryImage::getImageUrl));
+
+        Map<Long, Integer> likeCountMap =
+                courseIds.isEmpty()
+                        ? Map.of()
+                        : courseLikeRepository.countByCourseIdIn(courseIds).stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                row -> (Long) row[0],
+                                                row -> ((Long) row[1]).intValue()));
+
+        HashSet<Long> savedCourseIds =
+                courseIds.isEmpty()
+                        ? new HashSet<>()
+                        : new HashSet<>(
+                                routeRepository.findLikedCourseIdsByUserId(courseIds, userId));
+
+        List<CourseSummaryResponse> summaries =
+                courses.stream()
+                        .map(
+                                course ->
+                                        toCourseSummary(
+                                                course, thumbnailMap, likeCountMap, savedCourseIds))
+                        .toList();
+
+        return CourseListResponse.builder()
+                .courses(summaries)
+                .total((int) likes.getTotalElements())
+                .page(page)
+                .size(size)
+                .hasNext(likes.hasNext())
+                .build();
+    }
+
+    private CourseSummaryResponse toCourseSummary(
+            Course course,
+            Map<Long, String> thumbnailMap,
+            Map<Long, Integer> likeCountMap,
+            HashSet<Long> savedCourseIds) {
+        List<CourseBakerySummary> bakeries =
+                course.getCourseBakeries().stream()
+                        .sorted(Comparator.comparingInt(CourseBakery::getVisitOrder))
+                        .map(
+                                cb ->
+                                        CourseBakerySummary.from(
+                                                cb.getBakery(),
+                                                thumbnailMap.get(cb.getBakery().getId())))
+                        .toList();
+        return CourseSummaryResponse.from(
+                course,
+                likeCountMap.getOrDefault(course.getId(), 0),
+                true,
+                savedCourseIds.contains(course.getId()),
+                bakeries);
     }
 }

--- a/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
@@ -3,6 +3,8 @@ package com.breadbread.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,11 +15,22 @@ import com.breadbread.auth.redis.PhoneVerificationCache;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
 import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
+import com.breadbread.bakery.entity.BakeryLike;
 import com.breadbread.bakery.entity.BakeryPersonality;
 import com.breadbread.bakery.entity.BakeryType;
 import com.breadbread.bakery.entity.BakeryUseType;
 import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.repository.BakeryImageRepository;
+import com.breadbread.bakery.repository.BakeryLikeRepository;
 import com.breadbread.bakery.repository.ReviewRepository;
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.CourseLike;
+import com.breadbread.course.entity.ManualCourseInfo;
+import com.breadbread.course.repository.CourseLikeRepository;
+import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.course.repository.RouteRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.dto.ChangePasswordRequest;
@@ -31,6 +44,7 @@ import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.entity.WaitingTolerance;
 import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -40,6 +54,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -52,6 +69,11 @@ class UserServiceTest {
     @Mock private PhoneVerificationRedisService phoneVerificationRedisService;
     @Mock private TokenService tokenService;
     @Mock private ReviewRepository reviewRepository;
+    @Mock private BakeryLikeRepository bakeryLikeRepository;
+    @Mock private BakeryImageRepository bakeryImageRepository;
+    @Mock private CourseLikeRepository courseLikeRepository;
+    @Mock private CourseRepository courseRepository;
+    @Mock private RouteRepository routeRepository;
 
     @InjectMocks private UserService userService;
 
@@ -606,12 +628,15 @@ class UserServiceTest {
     // ───────────────────────────── getMyReviews ─────────────────────────────
 
     @Test
-    void getMyReviews_returns_emptyList_whenNoReviews() {
-        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L)).thenReturn(List.of());
+    void getMyReviews_returns_empty_page_whenNoReviews() {
+        when(reviewRepository.findPageIdsByUserIdOrderByCreatedAtDesc(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
 
-        var result = userService.getMyReviews(1L);
+        var result = userService.getMyReviews(1L, 0, 10);
 
-        assertThat(result).isEmpty();
+        assertThat(result.getReviews()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.isHasNext()).isFalse();
     }
 
     @Test
@@ -620,17 +645,20 @@ class UserServiceTest {
         Bakery bakery = bakery(10L, "소금빵집");
         Review review1 = review(100L, user, bakery, 5, "맛있어요");
         Review review2 = review(101L, user, bakery, 4, "또 오고싶어요");
-        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+        when(reviewRepository.findPageIdsByUserIdOrderByCreatedAtDesc(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(100L, 101L), PageRequest.of(0, 10), 2));
+        when(reviewRepository.findAllWithBakeryAndImagesByIdIn(List.of(100L, 101L)))
                 .thenReturn(List.of(review1, review2));
 
-        var result = userService.getMyReviews(1L);
+        var result = userService.getMyReviews(1L, 0, 10);
 
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getReviewId()).isEqualTo(100L);
-        assertThat(result.get(0).getBakeryId()).isEqualTo(10L);
-        assertThat(result.get(0).getBakeryName()).isEqualTo("소금빵집");
-        assertThat(result.get(0).getRating()).isEqualTo(5);
-        assertThat(result.get(0).getContent()).isEqualTo("맛있어요");
+        assertThat(result.getReviews()).hasSize(2);
+        assertThat(result.getReviews().get(0).getReviewId()).isEqualTo(100L);
+        assertThat(result.getReviews().get(0).getBakeryId()).isEqualTo(10L);
+        assertThat(result.getReviews().get(0).getBakeryName()).isEqualTo("소금빵집");
+        assertThat(result.getReviews().get(0).getRating()).isEqualTo(5);
+        assertThat(result.getReviews().get(0).getContent()).isEqualTo("맛있어요");
+        assertThat(result.getTotal()).isEqualTo(2);
     }
 
     @Test
@@ -639,13 +667,15 @@ class UserServiceTest {
         Bakery bakery = bakery(10L, "소금빵집");
         Review review1 = review(100L, user, bakery, 5, "첫 번째 리뷰");
         Review review2 = review(101L, user, bakery, 3, "두 번째 리뷰");
-        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
-                .thenReturn(List.of(review2, review1));
+        when(reviewRepository.findPageIdsByUserIdOrderByCreatedAtDesc(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(101L, 100L), PageRequest.of(0, 10), 2));
+        when(reviewRepository.findAllWithBakeryAndImagesByIdIn(List.of(101L, 100L)))
+                .thenReturn(List.of(review1, review2));
 
-        var result = userService.getMyReviews(1L);
+        var result = userService.getMyReviews(1L, 0, 10);
 
-        assertThat(result.get(0).getReviewId()).isEqualTo(101L);
-        assertThat(result.get(1).getReviewId()).isEqualTo(100L);
+        assertThat(result.getReviews().get(0).getReviewId()).isEqualTo(101L);
+        assertThat(result.getReviews().get(1).getReviewId()).isEqualTo(100L);
     }
 
     private static Bakery bakery(long id, String name) {
@@ -677,5 +707,178 @@ class UserServiceTest {
                 .verificationToken(token)
                 .code("123456")
                 .build();
+    }
+
+    // ───────────────────────────── getLikedBakeries ─────────────────────────────
+
+    @Test
+    void getLikedBakeries_returns_empty_page_when_no_likes() {
+        when(bakeryLikeRepository.findByUserId(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        var result = userService.getLikedBakeries(1L, 0, 10);
+
+        assertThat(result.getBakeries()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void getLikedBakeries_maps_thumbnail_and_likeCount() {
+        Bakery bakery = bakery(10L, "소금빵집");
+        User user = user(1L);
+        BakeryLike like = BakeryLike.builder().bakery(bakery).user(user).build();
+        when(bakeryLikeRepository.findByUserId(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(like), PageRequest.of(0, 10), 1));
+        BakeryImage thumb =
+                BakeryImage.builder().imageUrl("thumb.jpg").displayOrder(1).bakery(bakery).build();
+        when(bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(List.of(10L), 1))
+                .thenReturn(List.of(thumb));
+        when(bakeryLikeRepository.countByBakeryIdIn(List.of(10L)))
+                .thenReturn(Collections.singletonList(new Object[] {10L, 5L}));
+
+        var result = userService.getLikedBakeries(1L, 0, 10);
+
+        assertThat(result.getBakeries()).hasSize(1);
+        assertThat(result.getBakeries().get(0).getThumbnailUrl()).isEqualTo("thumb.jpg");
+        assertThat(result.getBakeries().get(0).getLikeCount()).isEqualTo(5L);
+        assertThat(result.getBakeries().get(0).isLiked()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getPage()).isZero();
+        assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void getLikedBakeries_sets_liked_true_for_all_items() {
+        Bakery b1 = bakery(1L, "빵집A");
+        Bakery b2 = bakery(2L, "빵집B");
+        User user = user(5L);
+        List<BakeryLike> likes =
+                List.of(
+                        BakeryLike.builder().bakery(b1).user(user).build(),
+                        BakeryLike.builder().bakery(b2).user(user).build());
+        when(bakeryLikeRepository.findByUserId(eq(5L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(likes, PageRequest.of(0, 10), 2));
+        when(bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(anyList(), eq(1)))
+                .thenReturn(List.of());
+        when(bakeryLikeRepository.countByBakeryIdIn(anyList())).thenReturn(List.of());
+
+        var result = userService.getLikedBakeries(5L, 0, 10);
+
+        assertThat(result.getBakeries()).hasSize(2);
+        assertThat(result.getBakeries()).allSatisfy(b -> assertThat(b.isLiked()).isTrue());
+    }
+
+    @Test
+    void getLikedBakeries_reflects_hasNext_when_more_pages_exist() {
+        Bakery bakery = bakery(99L, "빵집");
+        User user = user(7L);
+        BakeryLike like = BakeryLike.builder().bakery(bakery).user(user).build();
+        when(bakeryLikeRepository.findByUserId(eq(7L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(like), PageRequest.of(0, 1), 5));
+        when(bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(anyList(), eq(1)))
+                .thenReturn(List.of());
+        when(bakeryLikeRepository.countByBakeryIdIn(anyList())).thenReturn(List.of());
+
+        var result = userService.getLikedBakeries(7L, 0, 1);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(5);
+    }
+
+    // ───────────────────────────── getLikedCourses ─────────────────────────────
+
+    @Test
+    void getLikedCourses_returns_empty_page_when_no_likes() {
+        when(courseLikeRepository.findByUserId(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        var result = userService.getLikedCourses(1L, 0, 10);
+
+        assertThat(result.getCourses()).isEmpty();
+        assertThat(result.getTotal()).isZero();
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void getLikedCourses_maps_thumbnail_likeCount_and_saved_status() {
+        Course course = course(1L, "서울 코스");
+        Bakery bakery = bakery(10L, "A빵집");
+        course.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(bakery).build());
+        CourseLike like = CourseLike.builder().course(course).user(user(3L)).build();
+
+        when(courseLikeRepository.findByUserId(eq(3L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(like), PageRequest.of(0, 10), 1));
+        when(bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(List.of(10L), 1))
+                .thenReturn(
+                        List.of(
+                                BakeryImage.builder()
+                                        .imageUrl("t.jpg")
+                                        .displayOrder(1)
+                                        .bakery(bakery)
+                                        .build()));
+        when(courseLikeRepository.countByCourseIdIn(List.of(1L)))
+                .thenReturn(Collections.singletonList(new Object[] {1L, 4L}));
+        when(routeRepository.findLikedCourseIdsByUserId(List.of(1L), 3L)).thenReturn(List.of(1L));
+
+        var result = userService.getLikedCourses(3L, 0, 10);
+
+        assertThat(result.getCourses()).hasSize(1);
+        assertThat(result.getCourses().get(0).isLiked()).isTrue();
+        assertThat(result.getCourses().get(0).isSaved()).isTrue();
+        assertThat(result.getCourses().get(0).getLikeCount()).isEqualTo(4);
+        assertThat(result.getCourses().get(0).getBakeries().get(0).getThumbnailUrl())
+                .isEqualTo("t.jpg");
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.getPage()).isZero();
+        assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void getLikedCourses_sets_saved_false_when_not_in_routes() {
+        Course course = course(2L, "코스");
+        CourseLike like = CourseLike.builder().course(course).user(user(5L)).build();
+
+        when(courseLikeRepository.findByUserId(eq(5L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(like), PageRequest.of(0, 10), 1));
+        when(courseLikeRepository.countByCourseIdIn(List.of(2L))).thenReturn(List.of());
+        when(routeRepository.findLikedCourseIdsByUserId(List.of(2L), 5L)).thenReturn(List.of());
+
+        var result = userService.getLikedCourses(5L, 0, 10);
+
+        assertThat(result.getCourses().get(0).isLiked()).isTrue();
+        assertThat(result.getCourses().get(0).isSaved()).isFalse();
+    }
+
+    @Test
+    void getLikedCourses_reflects_hasNext_when_more_pages_exist() {
+        Course course = course(3L, "다음 페이지");
+        CourseLike like = CourseLike.builder().course(course).user(user(9L)).build();
+
+        when(courseLikeRepository.findByUserId(eq(9L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(like), PageRequest.of(0, 1), 3));
+        when(courseLikeRepository.countByCourseIdIn(anyList())).thenReturn(List.of());
+        when(routeRepository.findLikedCourseIdsByUserId(anyList(), eq(9L))).thenReturn(List.of());
+
+        var result = userService.getLikedCourses(9L, 0, 1);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(3);
+    }
+
+    private static Course course(long id, String name) {
+        Course c =
+                Course.createManual(
+                        name,
+                        null,
+                        "1h",
+                        1000L,
+                        "테마",
+                        "서울",
+                        ManualCourseInfo.builder().editorPick(false).build());
+        ReflectionTestUtils.setField(c, "id", id);
+        return c;
     }
 }

--- a/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
@@ -12,9 +12,12 @@ import com.breadbread.auth.entity.VerificationPurpose;
 import com.breadbread.auth.redis.PhoneVerificationCache;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
+import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryPersonality;
 import com.breadbread.bakery.entity.BakeryType;
 import com.breadbread.bakery.entity.BakeryUseType;
+import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.repository.ReviewRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.dto.ChangePasswordRequest;
@@ -48,6 +51,7 @@ class UserServiceTest {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private PhoneVerificationRedisService phoneVerificationRedisService;
     @Mock private TokenService tokenService;
+    @Mock private ReviewRepository reviewRepository;
 
     @InjectMocks private UserService userService;
 
@@ -597,6 +601,71 @@ class UserServiceTest {
         ReflectionTestUtils.setField(request, "newPassword", newPw);
         ReflectionTestUtils.setField(request, "newPasswordConfirm", confirm);
         return request;
+    }
+
+    // ───────────────────────────── getMyReviews ─────────────────────────────
+
+    @Test
+    void getMyReviews_returns_emptyList_whenNoReviews() {
+        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L)).thenReturn(List.of());
+
+        var result = userService.getMyReviews(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getMyReviews_returns_reviews_withBakeryInfo() {
+        User user = user(1L);
+        Bakery bakery = bakery(10L, "소금빵집");
+        Review review1 = review(100L, user, bakery, 5, "맛있어요");
+        Review review2 = review(101L, user, bakery, 4, "또 오고싶어요");
+        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of(review1, review2));
+
+        var result = userService.getMyReviews(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getReviewId()).isEqualTo(100L);
+        assertThat(result.get(0).getBakeryId()).isEqualTo(10L);
+        assertThat(result.get(0).getBakeryName()).isEqualTo("소금빵집");
+        assertThat(result.get(0).getRating()).isEqualTo(5);
+        assertThat(result.get(0).getContent()).isEqualTo("맛있어요");
+    }
+
+    @Test
+    void getMyReviews_returns_reviews_orderedByCreatedAtDesc() {
+        User user = user(1L);
+        Bakery bakery = bakery(10L, "소금빵집");
+        Review review1 = review(100L, user, bakery, 5, "첫 번째 리뷰");
+        Review review2 = review(101L, user, bakery, 3, "두 번째 리뷰");
+        when(reviewRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+                .thenReturn(List.of(review2, review1));
+
+        var result = userService.getMyReviews(1L);
+
+        assertThat(result.get(0).getReviewId()).isEqualTo(101L);
+        assertThat(result.get(1).getReviewId()).isEqualTo(100L);
+    }
+
+    private static Bakery bakery(long id, String name) {
+        Bakery bakery =
+                Bakery.builder()
+                        .name(name)
+                        .address("대전시 유성구")
+                        .region("유성구")
+                        .phone("042-000-0000")
+                        .bakeryType(BakeryType.CLASSIC)
+                        .build();
+        ReflectionTestUtils.setField(bakery, "id", id);
+        return bakery;
+    }
+
+    private static Review review(long id, User user, Bakery bakery, int rating, String content) {
+        Review review =
+                Review.builder().user(user).bakery(bakery).rating(rating).content(content).build();
+        ReflectionTestUtils.setField(review, "id", id);
+        return review;
     }
 
     private static PhoneVerificationCache verifiedCache(


### PR DESCRIPTION
## Task
- 마이페이지 활동 내역 조회 API 추가 (작성 리뷰, 좋아요한 빵집/코스 목록)

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #165 
