### PR TITLE
refactor: AI 웹훅 클라이언트 에러 처리를 CustomException으로 통일

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/client/AiWebhookClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/AiWebhookClient.java
@@ -3,6 +3,8 @@ package com.breadbread.course.client;
 import com.breadbread.course.dto.ai.AiCourseWebhookRequest;
 import com.breadbread.course.dto.ai.AiCourseWebhookResponse;
 import com.breadbread.global.config.AiProperties;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
@@ -48,11 +50,9 @@ public class AiWebhookClient {
                                                                         jobId,
                                                                         res.statusCode());
                                                                 return Mono.error(
-                                                                        new IllegalStateException(
-                                                                                "AI 웹훅 HTTP 오류 ("
-                                                                                        + res
-                                                                                                .statusCode()
-                                                                                        + "). n8n 워크플로 실행·URL을 확인하세요."));
+                                                                        new CustomException(
+                                                                                ErrorCode
+                                                                                        .AI_WEBHOOK_HTTP_ERROR));
                                                             }))
                             .bodyToMono(String.class)
                             .timeout(Duration.ofSeconds(aiProperties.getWebhookTimeoutSeconds()))
@@ -61,7 +61,7 @@ public class AiWebhookClient {
                     "[AI 웹훅] 응답 수신 완료: jobId={}, elapsed={}ms",
                     jobId,
                     System.currentTimeMillis() - start);
-        } catch (IllegalStateException e) {
+        } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
             log.error(
@@ -69,21 +69,21 @@ public class AiWebhookClient {
                     jobId,
                     System.currentTimeMillis() - start,
                     e);
-            long timeoutSec = aiProperties.getWebhookTimeoutSeconds();
             if (e instanceof java.util.concurrent.TimeoutException
                     || (e.getMessage() != null && e.getMessage().contains("Timeout"))) {
-                throw new IllegalStateException(
-                        "AI 처리 시간 초과 ("
-                                + timeoutSec
-                                + "초). n8n/Dify 실행 시간을 줄이거나 서버 AI_WEBHOOK_TIMEOUT_SECONDS를 늘려 주세요.");
+                long timeoutSec = aiProperties.getWebhookTimeoutSeconds();
+                log.warn(
+                        "[AI 웹훅] 타임아웃 발생: jobId={}, timeoutSeconds={}",
+                        jobId,
+                        timeoutSec);
+                throw new CustomException(ErrorCode.AI_WEBHOOK_TIMEOUT);
             }
-            throw new IllegalStateException(
-                    "AI 웹훅에 연결하지 못했습니다. AI_COURSE_WEBHOOK_URL·n8n 워크플로 상태를 확인하세요.");
+            throw new CustomException(ErrorCode.AI_WEBHOOK_CONNECTION_ERROR);
         }
 
         if (rawBody == null || rawBody.isBlank()) {
             log.error("[AI 웹훅] 응답 body가 비어있음");
-            throw new IllegalStateException("AI 웹훅 응답이 비어 있습니다. n8n 마지막 노드가 JSON 본문을 반환하는지 확인하세요.");
+            throw new CustomException(ErrorCode.AI_WEBHOOK_EMPTY_RESPONSE);
         }
 
         try {
@@ -97,8 +97,7 @@ public class AiWebhookClient {
             return response;
         } catch (Exception e) {
             log.error("[AI 웹훅] JSON 파싱 실패: jobId={}", jobId, e);
-            throw new IllegalStateException(
-                    "AI 응답 JSON 형식이 맞지 않습니다. Dify/n8n 마지막 노드가 백엔드 스키마(JSON)를 반환하는지 확인하세요.");
+            throw new CustomException(ErrorCode.AI_WEBHOOK_PARSE_ERROR);
         }
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/client/AiWebhookClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/AiWebhookClient.java
@@ -72,10 +72,7 @@ public class AiWebhookClient {
             if (e instanceof java.util.concurrent.TimeoutException
                     || (e.getMessage() != null && e.getMessage().contains("Timeout"))) {
                 long timeoutSec = aiProperties.getWebhookTimeoutSeconds();
-                log.warn(
-                        "[AI 웹훅] 타임아웃 발생: jobId={}, timeoutSeconds={}",
-                        jobId,
-                        timeoutSec);
+                log.warn("[AI 웹훅] 타임아웃 발생: jobId={}, timeoutSeconds={}", jobId, timeoutSec);
                 throw new CustomException(ErrorCode.AI_WEBHOOK_TIMEOUT);
             }
             throw new CustomException(ErrorCode.AI_WEBHOOK_CONNECTION_ERROR);

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
@@ -153,8 +153,8 @@ public class AiCourseAsyncService {
 
                                 if (bakeryMap.size() != recommendedIds.size()) {
                                     log.error("[AI 코스 생성] DB에 없는 빵집 ID 포함 jobId={}", jobId);
-                                    throw new IllegalStateException(
-                                            "AI가 추천한 빵집 ID가 DB에 없습니다. 응답의 bakeries[].id는 요청에 포함된 빵집 id만 사용해야 합니다.");
+                                    throw new CustomException(
+                                            ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
                                 }
 
                                 AiCourseInfo aiCourseInfo =
@@ -224,17 +224,9 @@ public class AiCourseAsyncService {
         } catch (CustomException e) {
             log.error("[AI 코스 생성] 실패 jobId={}", jobId, e);
             aiCourseRedisService.saveFailed(jobId, e.getMessage());
-        } catch (IllegalStateException e) {
-            log.error("[AI 코스 생성] 실패 jobId={}", jobId, e);
-            aiCourseRedisService.saveFailed(jobId, e.getMessage());
         } catch (Exception e) {
             log.error("[AI 코스 생성] 예외 발생 jobId={}", jobId, e);
-            String detail = e.getMessage();
-            aiCourseRedisService.saveFailed(
-                    jobId,
-                    detail != null && !detail.isBlank()
-                            ? detail
-                            : ErrorCode.AI_SERVER_ERROR.getMessage());
+            aiCourseRedisService.saveFailed(jobId, ErrorCode.AI_SERVER_ERROR.getMessage());
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -64,6 +64,18 @@ public enum ErrorCode {
     ROUTE_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "E0413", "경로를 찾을 수 없습니다."),
     ROUTE_INSUFFICIENT_WAYPOINTS(
             HttpStatus.UNPROCESSABLE_ENTITY, "E0414", "경로를 생성하려면 최소 2개의 지점이 필요합니다."),
+    AI_RECOMMENDED_BAKERY_NOT_FOUND(
+            HttpStatus.INTERNAL_SERVER_ERROR, "E0415", "AI가 추천한 빵집이 존재하지 않거나 더 이상 활성 상태가 아닙니다."),
+    AI_WEBHOOK_HTTP_ERROR(
+            HttpStatus.BAD_GATEWAY, "E0416", "AI 웹훅 HTTP 오류가 발생했습니다."),
+    AI_WEBHOOK_TIMEOUT(
+            HttpStatus.GATEWAY_TIMEOUT, "E0417", "AI 처리 시간이 초과되었습니다."),
+    AI_WEBHOOK_CONNECTION_ERROR(
+            HttpStatus.SERVICE_UNAVAILABLE, "E0418", "AI 웹훅에 연결할 수 없습니다."),
+    AI_WEBHOOK_EMPTY_RESPONSE(
+            HttpStatus.BAD_GATEWAY, "E0419", "AI 웹훅 응답이 비어 있습니다."),
+    AI_WEBHOOK_PARSE_ERROR(
+            HttpStatus.UNPROCESSABLE_ENTITY, "E0420", "AI 응답 JSON 형식이 올바르지 않습니다."),
 
     // 예약 E05xx
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E0501", "존재하지 않는 예약입니다."),

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -66,16 +66,11 @@ public enum ErrorCode {
             HttpStatus.UNPROCESSABLE_ENTITY, "E0414", "경로를 생성하려면 최소 2개의 지점이 필요합니다."),
     AI_RECOMMENDED_BAKERY_NOT_FOUND(
             HttpStatus.INTERNAL_SERVER_ERROR, "E0415", "AI가 추천한 빵집이 존재하지 않거나 더 이상 활성 상태가 아닙니다."),
-    AI_WEBHOOK_HTTP_ERROR(
-            HttpStatus.BAD_GATEWAY, "E0416", "AI 웹훅 HTTP 오류가 발생했습니다."),
-    AI_WEBHOOK_TIMEOUT(
-            HttpStatus.GATEWAY_TIMEOUT, "E0417", "AI 처리 시간이 초과되었습니다."),
-    AI_WEBHOOK_CONNECTION_ERROR(
-            HttpStatus.SERVICE_UNAVAILABLE, "E0418", "AI 웹훅에 연결할 수 없습니다."),
-    AI_WEBHOOK_EMPTY_RESPONSE(
-            HttpStatus.BAD_GATEWAY, "E0419", "AI 웹훅 응답이 비어 있습니다."),
-    AI_WEBHOOK_PARSE_ERROR(
-            HttpStatus.UNPROCESSABLE_ENTITY, "E0420", "AI 응답 JSON 형식이 올바르지 않습니다."),
+    AI_WEBHOOK_HTTP_ERROR(HttpStatus.BAD_GATEWAY, "E0416", "AI 웹훅 HTTP 오류가 발생했습니다."),
+    AI_WEBHOOK_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "E0417", "AI 처리 시간이 초과되었습니다."),
+    AI_WEBHOOK_CONNECTION_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "E0418", "AI 웹훅에 연결할 수 없습니다."),
+    AI_WEBHOOK_EMPTY_RESPONSE(HttpStatus.BAD_GATEWAY, "E0419", "AI 웹훅 응답이 비어 있습니다."),
+    AI_WEBHOOK_PARSE_ERROR(HttpStatus.UNPROCESSABLE_ENTITY, "E0420", "AI 응답 JSON 형식이 올바르지 않습니다."),
 
     // 예약 E05xx
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E0501", "존재하지 않는 예약입니다."),

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
@@ -21,6 +21,7 @@ import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.FlexibilityLevel;
 import com.breadbread.course.entity.TravelType;
 import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.notification.service.FcmService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserPreference;
@@ -123,11 +124,11 @@ class AiCourseAsyncServiceTest {
         when(breadRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
         when(crowdTimeRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
         when(aiWebhookClient.requestCourse(eq("job-throw"), any()))
-                .thenThrow(new IllegalStateException("portone down"));
+                .thenThrow(new RuntimeException("portone down"));
 
         aiCourseAsyncService.processAiCourse("job-throw", 1L, aiRequest()).join();
 
-        verify(aiCourseRedisService).saveFailed(eq("job-throw"), eq("portone down"));
+        verify(aiCourseRedisService).saveFailed(eq("job-throw"), eq(ErrorCode.AI_SERVER_ERROR.getMessage()));
     }
 
     @Test
@@ -182,7 +183,7 @@ class AiCourseAsyncServiceTest {
         verify(aiCourseRedisService)
                 .saveFailed(
                         eq("job-e"),
-                        eq("AI가 추천한 빵집 ID가 DB에 없습니다. 응답의 bakeries[].id는 요청에 포함된 빵집 id만 사용해야 합니다."));
+                        eq(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND.getMessage()));
     }
 
     private static AiCourseWebhookResponse validWebhookResponse(long bakeryId) {

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
@@ -128,7 +128,8 @@ class AiCourseAsyncServiceTest {
 
         aiCourseAsyncService.processAiCourse("job-throw", 1L, aiRequest()).join();
 
-        verify(aiCourseRedisService).saveFailed(eq("job-throw"), eq(ErrorCode.AI_SERVER_ERROR.getMessage()));
+        verify(aiCourseRedisService)
+                .saveFailed(eq("job-throw"), eq(ErrorCode.AI_SERVER_ERROR.getMessage()));
     }
 
     @Test
@@ -182,8 +183,7 @@ class AiCourseAsyncServiceTest {
 
         verify(aiCourseRedisService)
                 .saveFailed(
-                        eq("job-e"),
-                        eq(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND.getMessage()));
+                        eq("job-e"), eq(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND.getMessage()));
     }
 
     private static AiCourseWebhookResponse validWebhookResponse(long bakeryId) {


### PR DESCRIPTION
## Task
- AI 웹훅 클라이언트의 모든 예외 처리를 IllegalStateException에서 CustomException으로 변경하여 일관성 있는 에러 응답 제공

## What's Changed
- [ ] 기능 추가
- [] 기능 삭제
- [x] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
