### PR TITLE
feat: AI용 빵집 목록 필터링 및 상세 조회 API 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -108,6 +108,13 @@ public class BakeryController {
         return ApiResponse.ok(bakeryService.search(search, PageRequest.of(page, size), userId));
     }
 
+    @Operation(summary = "AI용 빵집 상세 조회", description = "평일/주말 혼잡도·영업시간 전체 반환, null 필드 제외")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
+    @GetMapping("/ai/{id}")
+    public ApiResponse<BakeryAiResponse> findOneForAi(@PathVariable Long id) {
+        return ApiResponse.ok(bakeryService.findOneForAi(id));
+    }
+
     @Operation(summary = "빵집 상세 조회")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
     @GetMapping("/{id}")

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -2,7 +2,10 @@ package com.breadbread.bakery.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.bakery.dto.*;
+import com.breadbread.bakery.entity.BakeryPersonality;
 import com.breadbread.bakery.entity.BakerySortType;
+import com.breadbread.bakery.entity.BakeryType;
+import com.breadbread.bakery.entity.BakeryUseType;
 import com.breadbread.bakery.entity.ReviewSortType;
 import com.breadbread.bakery.service.BakeryService;
 import com.breadbread.global.dto.ApiResponse;
@@ -11,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -25,11 +30,51 @@ public class BakeryController {
 
     private final BakeryService bakeryService;
 
-    @Operation(summary = "AI용 빵집 전체 조회")
+    @Operation(
+            summary = "AI용 빵집 목록 조회",
+            description = "키워드, 지역구, 영업중, 음료판매, 매장취식, 빵집유형, 이용유형, 분위기 필터 지원")
+    @Parameters({
+        @Parameter(name = "keyword", description = "빵집 이름 검색어"),
+        @Parameter(
+                name = "open",
+                description =
+                        "true 시 지정한 날짜·시각 기준 영업 중인 빵집만 반환, 혼잡도도 해당 요일(평일/주말)만 포함. false 시 혼잡도 전체 반환 (기본값: false)"),
+        @Parameter(name = "visitDate", description = "영업중 판단 기준 날짜 (미입력 시 오늘, 형식: yyyy-MM-dd)"),
+        @Parameter(name = "visitTime", description = "영업중 판단 기준 시각 (미입력 시 현재 시각, 형식: HH:mm)"),
+        @Parameter(name = "region", description = "지    역구 필터", example = "대전 중구"),
+        @Parameter(name = "drinkAvailable", description = "음료 판매 여부 필터"),
+        @Parameter(name = "dineInAvailable", description = "매장 취식 여부 필터"),
+        @Parameter(name = "bakeryType", description = "빵집 유형 필터"),
+        @Parameter(name = "bakeryUseTypes", description = "이용 유형 필터 (복수 선택 가능, OR 조건)"),
+        @Parameter(name = "bakeryPersonalities", description = "분위기 필터 (복수 선택 가능, OR 조건)")
+    })
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
     @GetMapping("/ai")
-    public ApiResponse<java.util.List<BakeryAiResponse>> findAllForAi() {
-        return ApiResponse.ok(bakeryService.findAllForAi());
+    public ApiResponse<java.util.List<BakeryAiResponse>> findAllForAi(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "false") boolean open,
+            @RequestParam(required = false) LocalDate visitDate,
+            @RequestParam(required = false) LocalTime visitTime,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) Boolean drinkAvailable,
+            @RequestParam(required = false) Boolean dineInAvailable,
+            @RequestParam(required = false) BakeryType bakeryType,
+            @RequestParam(required = false) java.util.List<BakeryUseType> bakeryUseTypes,
+            @RequestParam(required = false) java.util.List<BakeryPersonality> bakeryPersonalities) {
+        BakeryAiSearch search =
+                BakeryAiSearch.builder()
+                        .keyword(keyword)
+                        .open(open)
+                        .visitDate(visitDate)
+                        .visitTime(visitTime)
+                        .region(region)
+                        .drinkAvailable(drinkAvailable)
+                        .dineInAvailable(dineInAvailable)
+                        .bakeryType(bakeryType)
+                        .bakeryUseTypes(bakeryUseTypes)
+                        .bakeryPersonalities(bakeryPersonalities)
+                        .build();
+        return ApiResponse.ok(bakeryService.findAllForAi(search));
     }
 
     @Operation(summary = "빵집 목록 조회", description = "키워드 검색, 지역 필터, 정렬, 영업 중 우선 배치, 페이징 지원")

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
@@ -1,6 +1,7 @@
 package com.breadbread.bakery.dto;
 
 import com.breadbread.bakery.entity.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
@@ -11,6 +12,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BakeryAiResponse {
 
     private Long id;
@@ -41,8 +43,10 @@ public class BakeryAiResponse {
     private List<CrowdTimeInfo> crowdTimes;
 
     public static BakeryAiResponse from(
-            Bakery bakery, List<Bread> breads, List<CrowdTime> crowdTimes) {
+            Bakery bakery, List<Bread> breads, List<CrowdTime> crowdTimes, DayType dayType) {
         BusinessHours bh = bakery.getBusinessHours();
+        boolean showWeekday = dayType == null || dayType == DayType.WEEKDAY;
+        boolean showWeekend = dayType == null || dayType == DayType.WEEKEND;
         return BakeryAiResponse.builder()
                 .id(bakery.getId())
                 .name(bakery.getName())
@@ -71,10 +75,10 @@ public class BakeryAiResponse {
                         bakery.getBakeryPersonalities().stream()
                                 .map(BakeryPersonality::name)
                                 .toList())
-                .weekdayOpen(bh != null ? bh.getWeekdayOpen() : null)
-                .weekdayClose(bh != null ? bh.getWeekdayClose() : null)
-                .weekendOpen(bh != null ? bh.getWeekendOpen() : null)
-                .weekendClose(bh != null ? bh.getWeekendClose() : null)
+                .weekdayOpen(showWeekday && bh != null ? bh.getWeekdayOpen() : null)
+                .weekdayClose(showWeekday && bh != null ? bh.getWeekdayClose() : null)
+                .weekendOpen(showWeekend && bh != null ? bh.getWeekendOpen() : null)
+                .weekendClose(showWeekend && bh != null ? bh.getWeekendClose() : null)
                 .lastOrderTime(bh != null ? bh.getLastOrderTime() : null)
                 .holidayClosed(bh != null && bh.isHolidayClosed())
                 .breads(breads.stream().map(BreadInfo::from).toList())

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiResponse.java
@@ -25,6 +25,7 @@ public class BakeryAiResponse {
     private boolean dineInAvailable;
     private boolean parkingAvailable;
     private boolean drinkAvailable;
+    private int estimatedStayMinutes;
     private String bakeryType;
     private LocalTime appearanceTime;
     private String frequency;
@@ -58,6 +59,7 @@ public class BakeryAiResponse {
                 .dineInAvailable(bakery.isDineInAvailable())
                 .parkingAvailable(bakery.isParkingAvailable())
                 .drinkAvailable(bakery.isDrinkAvailable())
+                .estimatedStayMinutes(bakery.getEstimatedStayMinutes())
                 .bakeryType(bakery.getBakeryType() != null ? bakery.getBakeryType().name() : null)
                 .appearanceTime(bakery.getAppearanceTime())
                 .frequency(bakery.getFrequency() != null ? bakery.getFrequency().name() : null)

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiSearch.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiSearch.java
@@ -1,0 +1,25 @@
+package com.breadbread.bakery.dto;
+
+import com.breadbread.bakery.entity.BakeryPersonality;
+import com.breadbread.bakery.entity.BakeryType;
+import com.breadbread.bakery.entity.BakeryUseType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BakeryAiSearch {
+    private String keyword;
+    private boolean open;
+    private LocalDate visitDate;
+    private LocalTime visitTime;
+    private String region;
+    private Boolean drinkAvailable;
+    private Boolean dineInAvailable;
+    private BakeryType bakeryType;
+    private List<BakeryUseType> bakeryUseTypes;
+    private List<BakeryPersonality> bakeryPersonalities;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Set;
 import lombok.*;
 
@@ -60,11 +61,15 @@ public class BusinessHours {
     }
 
     public LocalTime getTodayOpen() {
-        return isWeekend(LocalDate.now().getDayOfWeek()) ? weekendOpen : weekdayOpen;
+        return isWeekend(LocalDate.now(ZoneId.of("Asia/Seoul")).getDayOfWeek())
+                ? weekendOpen
+                : weekdayOpen;
     }
 
     public LocalTime getTodayClose() {
-        return isWeekend(LocalDate.now().getDayOfWeek()) ? weekendClose : weekdayClose;
+        return isWeekend(LocalDate.now(ZoneId.of("Asia/Seoul")).getDayOfWeek())
+                ? weekendClose
+                : weekdayClose;
     }
 
     private boolean isWeekend(DayOfWeek day) {

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryCustom.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.breadbread.bakery.repository;
 
+import com.breadbread.bakery.dto.BakeryAiSearch;
 import com.breadbread.bakery.dto.BakerySearch;
 import com.breadbread.bakery.entity.Bakery;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BakeryRepositoryCustom {
     Page<Bakery> search(BakerySearch bakerySearch, Pageable pageable);
+
+    List<Bakery> searchForAi(BakeryAiSearch search);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.breadbread.bakery.repository;
 
+import com.breadbread.bakery.dto.BakeryAiSearch;
 import com.breadbread.bakery.dto.BakerySearch;
 import com.breadbread.bakery.entity.*;
 import com.querydsl.core.types.Order;
@@ -13,6 +14,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -119,17 +122,11 @@ public class BakeryRepositoryImpl implements BakeryRepositoryCustom {
         if (!StringUtils.hasText(keyword)) {
             return null;
         }
-        BooleanExpression byName = bakery.name.contains(keyword);
-        BooleanExpression byAddress =
-                bakery.address.isNotNull().and(bakery.address.contains(keyword));
-        BooleanExpression byRegion = bakery.region.isNotNull().and(bakery.region.contains(keyword));
-        return byName.or(byAddress).or(byRegion);
+        return bakery.name.contains(keyword);
     }
 
-    private BooleanExpression isOpenNow(QBakery bakery) {
-        DayOfWeek today = LocalDate.now().getDayOfWeek();
-        LocalTime now = LocalTime.now();
-        boolean isWeekend = (today == DayOfWeek.SATURDAY || today == DayOfWeek.SUNDAY);
+    private BooleanExpression isOpenAt(QBakery bakery, DayOfWeek dayOfWeek, LocalTime time) {
+        boolean isWeekend = (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY);
 
         BooleanExpression hoursNotNull =
                 isWeekend
@@ -146,14 +143,14 @@ public class BakeryRepositoryImpl implements BakeryRepositoryCustom {
                 isWeekend
                         ? bakery.businessHours
                                 .weekendOpen
-                                .loe(now)
-                                .and(bakery.businessHours.weekendClose.goe(now))
+                                .loe(time)
+                                .and(bakery.businessHours.weekendClose.goe(time))
                         : bakery.businessHours
                                 .weekdayOpen
-                                .loe(now)
-                                .and(bakery.businessHours.weekdayClose.goe(now));
+                                .loe(time)
+                                .and(bakery.businessHours.weekdayClose.goe(time));
 
-        return hoursNotNull.and(bakery.closedDays.contains(today).not()).and(timeCondition);
+        return hoursNotNull.and(bakery.closedDays.contains(dayOfWeek).not()).and(timeCondition);
     }
 
     // 영업 중 우선 정렬 (open=true면 영업 중 먼저, false면 순서 무관)
@@ -161,12 +158,82 @@ public class BakeryRepositoryImpl implements BakeryRepositoryCustom {
         if (!open) return new OrderSpecifier<>(Order.ASC, Expressions.constant(0));
 
         NumberExpression<Integer> openScore =
-                new CaseBuilder().when(isOpenNow(bakery)).then(0).otherwise(1);
+                new CaseBuilder()
+                        .when(
+                                isOpenAt(
+                                        bakery,
+                                        LocalDate.now(ZoneId.of("Asia/Seoul")).getDayOfWeek(),
+                                        LocalTime.now(ZoneId.of("Asia/Seoul"))))
+                        .then(0)
+                        .otherwise(1);
 
         return openScore.asc();
     }
 
     private BooleanExpression eqRegion(QBakery bakery, String region) {
         return StringUtils.hasText(region) ? bakery.region.eq(region) : null;
+    }
+
+    @Override
+    public List<Bakery> searchForAi(BakeryAiSearch search) {
+        QBakery bakery = QBakery.bakery;
+
+        List<BooleanExpression> conditions = new ArrayList<>();
+        conditions.add(bakery.active.isTrue());
+        conditions.add(containKeyword(bakery, search.getKeyword()));
+        conditions.add(eqRegion(bakery, search.getRegion()));
+        conditions.add(eqDrinkAvailable(bakery, search.getDrinkAvailable()));
+        conditions.add(eqDineInAvailable(bakery, search.getDineInAvailable()));
+        conditions.add(eqBakeryType(bakery, search.getBakeryType()));
+        conditions.add(containsAnyUseType(bakery, search.getBakeryUseTypes()));
+        conditions.add(containsAnyPersonality(bakery, search.getBakeryPersonalities()));
+        if (search.isOpen()) {
+            DayOfWeek dayOfWeek =
+                    (search.getVisitDate() != null
+                                    ? search.getVisitDate()
+                                    : LocalDate.now(ZoneId.of("Asia/Seoul")))
+                            .getDayOfWeek();
+            LocalTime time =
+                    search.getVisitTime() != null
+                            ? search.getVisitTime()
+                            : LocalTime.now(ZoneId.of("Asia/Seoul"));
+            conditions.add(isOpenAt(bakery, dayOfWeek, time));
+        }
+
+        BooleanExpression[] where =
+                conditions.stream().filter(c -> c != null).toArray(BooleanExpression[]::new);
+
+        return queryFactory.selectFrom(bakery).where(where).orderBy(bakery.id.desc()).fetch();
+    }
+
+    private BooleanExpression eqDrinkAvailable(QBakery bakery, Boolean drinkAvailable) {
+        return drinkAvailable != null ? bakery.drinkAvailable.eq(drinkAvailable) : null;
+    }
+
+    private BooleanExpression eqDineInAvailable(QBakery bakery, Boolean dineInAvailable) {
+        return dineInAvailable != null ? bakery.dineInAvailable.eq(dineInAvailable) : null;
+    }
+
+    private BooleanExpression eqBakeryType(QBakery bakery, BakeryType bakeryType) {
+        return bakeryType != null ? bakery.bakeryType.eq(bakeryType) : null;
+    }
+
+    private BooleanExpression containsAnyUseType(QBakery bakery, List<BakeryUseType> useTypes) {
+        if (useTypes == null || useTypes.isEmpty()) return null;
+        BooleanExpression expr = bakery.bakeryUseTypes.any().eq(useTypes.get(0));
+        for (int i = 1; i < useTypes.size(); i++) {
+            expr = expr.or(bakery.bakeryUseTypes.any().eq(useTypes.get(i)));
+        }
+        return expr;
+    }
+
+    private BooleanExpression containsAnyPersonality(
+            QBakery bakery, List<BakeryPersonality> personalities) {
+        if (personalities == null || personalities.isEmpty()) return null;
+        BooleanExpression expr = bakery.bakeryPersonalities.any().eq(personalities.get(0));
+        for (int i = 1; i < personalities.size(); i++) {
+            expr = expr.or(bakery.bakeryPersonalities.any().eq(personalities.get(i)));
+        }
+        return expr;
     }
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -89,6 +89,18 @@ public class BakeryService {
     }
 
     @Transactional(readOnly = true)
+    public BakeryAiResponse findOneForAi(Long id) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+        List<Long> ids = List.of(id);
+        List<Bread> breads = breadRepository.findAllByBakeryIdIn(ids);
+        List<CrowdTime> crowdTimes = crowdTimeRepository.findAllByBakeryIdIn(ids);
+        return BakeryAiResponse.from(bakery, breads, crowdTimes, null);
+    }
+
+    @Transactional(readOnly = true)
     public BakeryListResponse search(BakerySearch search, Pageable pageable, Long userId) {
         Page<Bakery> result = bakeryRepository.search(search, pageable);
         List<Bakery> bakeries = result.getContent();

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -11,6 +11,9 @@ import com.breadbread.global.service.GcsService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +42,8 @@ public class BakeryService {
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
 
     @Transactional(readOnly = true)
-    public List<BakeryAiResponse> findAllForAi() {
-        List<Bakery> bakeries = bakeryRepository.findAllByActiveTrue();
+    public List<BakeryAiResponse> findAllForAi(BakeryAiSearch search) {
+        List<Bakery> bakeries = bakeryRepository.searchForAi(search);
         List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
 
         Map<Long, List<Bread>> breadMap =
@@ -51,13 +54,37 @@ public class BakeryService {
                 crowdTimeRepository.findAllByBakeryIdIn(ids).stream()
                         .collect(Collectors.groupingBy(ct -> ct.getBakery().getId()));
 
+        DayType targetDayType = null;
+        if (search.isOpen()) {
+            LocalDate date =
+                    search.getVisitDate() != null
+                            ? search.getVisitDate()
+                            : LocalDate.now(ZoneId.of("Asia/Seoul"));
+            DayOfWeek dow = date.getDayOfWeek();
+            targetDayType =
+                    (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY)
+                            ? DayType.WEEKEND
+                            : DayType.WEEKDAY;
+        }
+
+        final DayType dayTypeFilter = targetDayType;
         return bakeries.stream()
                 .map(
-                        b ->
-                                BakeryAiResponse.from(
-                                        b,
-                                        breadMap.getOrDefault(b.getId(), List.of()),
-                                        crowdTimeMap.getOrDefault(b.getId(), List.of())))
+                        b -> {
+                            List<CrowdTime> crowdTimes =
+                                    crowdTimeMap.getOrDefault(b.getId(), List.of());
+                            if (dayTypeFilter != null) {
+                                crowdTimes =
+                                        crowdTimes.stream()
+                                                .filter(ct -> ct.getDayType() == dayTypeFilter)
+                                                .toList();
+                            }
+                            return BakeryAiResponse.from(
+                                    b,
+                                    breadMap.getOrDefault(b.getId(), List.of()),
+                                    crowdTimes,
+                                    dayTypeFilter);
+                        })
                 .toList();
     }
 

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
@@ -97,7 +97,8 @@ public class AiCourseAsyncService {
                                                                                 List.of()),
                                                                         crowdTimeMap.getOrDefault(
                                                                                 b.getId(),
-                                                                                List.of())))
+                                                                                List.of()),
+                                                                        null))
                                                 .toList();
 
                                 return AiCourseWebhookRequest.builder()

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -242,6 +242,44 @@ class BakeryServiceTest {
     }
 
     @Test
+    void findOneForAi_returns_response_with_all_breads_and_crowd_times() {
+        Bakery b = bakeryWithId(1L);
+        Bread bread =
+                Bread.builder()
+                        .name("소금빵")
+                        .price(2500)
+                        .imageUrl(null)
+                        .bakery(b)
+                        .breadType(BreadType.BREAD)
+                        .signature(true)
+                        .selloutMin(0)
+                        .build();
+        CrowdTime weekday = crowdTimeOf(b, DayType.WEEKDAY);
+        CrowdTime weekend = crowdTimeOf(b, DayType.WEEKEND);
+
+        when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of(bread));
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L)))
+                .thenReturn(List.of(weekday, weekend));
+
+        var result = bakeryService.findOneForAi(1L);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getBreads()).hasSize(1);
+        assertThat(result.getCrowdTimes()).hasSize(2);
+    }
+
+    @Test
+    void findOneForAi_throws_when_bakery_missing() {
+        when(bakeryRepository.findByIdAndActiveTrue(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bakeryService.findOneForAi(99L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+    }
+
+    @Test
     void findAllForAi_returns_empty_when_no_bakeries() {
         BakeryAiSearch search = BakeryAiSearch.builder().build();
         when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of());

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.breadbread.bakery.dto.BakeryAiSearch;
 import com.breadbread.bakery.dto.BakerySearch;
 import com.breadbread.bakery.dto.CreateBakeryRequest;
 import com.breadbread.bakery.dto.CreateBreadRequest;
@@ -21,6 +22,7 @@ import com.breadbread.bakery.entity.BakeryImage;
 import com.breadbread.bakery.entity.BakeryLike;
 import com.breadbread.bakery.entity.Bread;
 import com.breadbread.bakery.entity.BreadType;
+import com.breadbread.bakery.entity.BusinessHours;
 import com.breadbread.bakery.entity.CrowdLevel;
 import com.breadbread.bakery.entity.CrowdTime;
 import com.breadbread.bakery.entity.DayType;
@@ -40,6 +42,8 @@ import com.breadbread.global.service.GcsService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -86,27 +90,167 @@ class BakeryServiceTest {
                         .signature(false)
                         .selloutMin(0)
                         .build();
-        CrowdTime crowd =
-                CrowdTime.builder()
-                        .dayType(DayType.WEEKDAY)
-                        .crowdLevel(CrowdLevel.LOW)
-                        .peakStart(null)
-                        .peakEnd(null)
-                        .expectedWaitMin(null)
-                        .sourceType("test")
-                        .bakery(b)
-                        .build();
+        CrowdTime crowd = crowdTimeOf(b, DayType.WEEKDAY);
 
-        when(bakeryRepository.findAllByActiveTrue()).thenReturn(List.of(b));
+        BakeryAiSearch search = BakeryAiSearch.builder().build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
         when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of(bread));
         when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of(crowd));
 
-        var responses = bakeryService.findAllForAi();
+        var responses = bakeryService.findAllForAi(search);
 
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getId()).isEqualTo(1L);
         assertThat(responses.get(0).getBreads()).hasSize(1);
         assertThat(responses.get(0).getCrowdTimes()).hasSize(1);
+    }
+
+    @Test
+    void findAllForAi_returns_all_crowd_times_when_open_false() {
+        Bakery b = bakeryWithId(1L);
+        CrowdTime weekday = crowdTimeOf(b, DayType.WEEKDAY);
+        CrowdTime weekend = crowdTimeOf(b, DayType.WEEKEND);
+
+        BakeryAiSearch search = BakeryAiSearch.builder().open(false).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L)))
+                .thenReturn(List.of(weekday, weekend));
+
+        var responses = bakeryService.findAllForAi(search);
+
+        assertThat(responses.get(0).getCrowdTimes()).hasSize(2);
+    }
+
+    @Test
+    void findAllForAi_filters_crowd_times_to_weekday_when_weekday_open() {
+        Bakery b = bakeryWithId(1L);
+        CrowdTime weekday = crowdTimeOf(b, DayType.WEEKDAY);
+        CrowdTime weekend = crowdTimeOf(b, DayType.WEEKEND);
+
+        // 2025-05-19 is Monday
+        BakeryAiSearch search =
+                BakeryAiSearch.builder().open(true).visitDate(LocalDate.of(2025, 5, 19)).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L)))
+                .thenReturn(List.of(weekday, weekend));
+
+        var responses = bakeryService.findAllForAi(search);
+
+        assertThat(responses.get(0).getCrowdTimes()).hasSize(1);
+        assertThat(responses.get(0).getCrowdTimes().get(0).getDayType()).isEqualTo("WEEKDAY");
+    }
+
+    @Test
+    void findAllForAi_filters_crowd_times_to_weekend_when_weekend_open() {
+        Bakery b = bakeryWithId(1L);
+        CrowdTime weekday = crowdTimeOf(b, DayType.WEEKDAY);
+        CrowdTime weekend = crowdTimeOf(b, DayType.WEEKEND);
+
+        // 2025-05-17 is Saturday
+        BakeryAiSearch search =
+                BakeryAiSearch.builder().open(true).visitDate(LocalDate.of(2025, 5, 17)).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L)))
+                .thenReturn(List.of(weekday, weekend));
+
+        var responses = bakeryService.findAllForAi(search);
+
+        assertThat(responses.get(0).getCrowdTimes()).hasSize(1);
+        assertThat(responses.get(0).getCrowdTimes().get(0).getDayType()).isEqualTo("WEEKEND");
+    }
+
+    @Test
+    void findAllForAi_shows_weekday_hours_only_when_weekday_open() {
+        Bakery b = bakeryWithId(1L);
+        BusinessHours bh =
+                BusinessHours.builder()
+                        .weekdayOpen(LocalTime.of(9, 0))
+                        .weekdayClose(LocalTime.of(18, 0))
+                        .weekendOpen(LocalTime.of(10, 0))
+                        .weekendClose(LocalTime.of(17, 0))
+                        .build();
+        ReflectionTestUtils.setField(b, "businessHours", bh);
+
+        // 2025-05-19 is Monday
+        BakeryAiSearch search =
+                BakeryAiSearch.builder().open(true).visitDate(LocalDate.of(2025, 5, 19)).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+
+        var r = bakeryService.findAllForAi(search).get(0);
+
+        assertThat(r.getWeekdayOpen()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(r.getWeekdayClose()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(r.getWeekendOpen()).isNull();
+        assertThat(r.getWeekendClose()).isNull();
+    }
+
+    @Test
+    void findAllForAi_shows_weekend_hours_only_when_weekend_open() {
+        Bakery b = bakeryWithId(1L);
+        BusinessHours bh =
+                BusinessHours.builder()
+                        .weekdayOpen(LocalTime.of(9, 0))
+                        .weekdayClose(LocalTime.of(18, 0))
+                        .weekendOpen(LocalTime.of(10, 0))
+                        .weekendClose(LocalTime.of(17, 0))
+                        .build();
+        ReflectionTestUtils.setField(b, "businessHours", bh);
+
+        // 2025-05-17 is Saturday
+        BakeryAiSearch search =
+                BakeryAiSearch.builder().open(true).visitDate(LocalDate.of(2025, 5, 17)).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+
+        var r = bakeryService.findAllForAi(search).get(0);
+
+        assertThat(r.getWeekendOpen()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(r.getWeekendClose()).isEqualTo(LocalTime.of(17, 0));
+        assertThat(r.getWeekdayOpen()).isNull();
+        assertThat(r.getWeekdayClose()).isNull();
+    }
+
+    @Test
+    void findAllForAi_shows_all_hours_when_open_false() {
+        Bakery b = bakeryWithId(1L);
+        BusinessHours bh =
+                BusinessHours.builder()
+                        .weekdayOpen(LocalTime.of(9, 0))
+                        .weekdayClose(LocalTime.of(18, 0))
+                        .weekendOpen(LocalTime.of(10, 0))
+                        .weekendClose(LocalTime.of(17, 0))
+                        .build();
+        ReflectionTestUtils.setField(b, "businessHours", bh);
+
+        BakeryAiSearch search = BakeryAiSearch.builder().open(false).build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of(b));
+        when(breadRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of(1L))).thenReturn(List.of());
+
+        var r = bakeryService.findAllForAi(search).get(0);
+
+        assertThat(r.getWeekdayOpen()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(r.getWeekdayClose()).isEqualTo(LocalTime.of(18, 0));
+        assertThat(r.getWeekendOpen()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(r.getWeekendClose()).isEqualTo(LocalTime.of(17, 0));
+    }
+
+    @Test
+    void findAllForAi_returns_empty_when_no_bakeries() {
+        BakeryAiSearch search = BakeryAiSearch.builder().build();
+        when(bakeryRepository.searchForAi(any(BakeryAiSearch.class))).thenReturn(List.of());
+        when(breadRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
+        when(crowdTimeRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
+
+        var responses = bakeryService.findAllForAi(search);
+
+        assertThat(responses).isEmpty();
     }
 
     @Test
@@ -847,5 +991,17 @@ class BakeryServiceTest {
         ReflectionTestUtils.setField(request, "content", content);
         ReflectionTestUtils.setField(request, "rating", rating);
         return request;
+    }
+
+    private static CrowdTime crowdTimeOf(Bakery bakery, DayType dayType) {
+        return CrowdTime.builder()
+                .dayType(dayType)
+                .crowdLevel(CrowdLevel.LOW)
+                .peakStart(null)
+                .peakEnd(null)
+                .expectedWaitMin(null)
+                .sourceType("test")
+                .bakery(bakery)
+                .build();
     }
 }


### PR DESCRIPTION
## Task
- `GET /bakeries/ai` 필터 10종 추가 (키워드, 지역구, 영업중, 날짜·시각, 음료판매, 매장취식, 빵집유형, 이용유형, 분위기)
- `open=true` 시 혼잡도·영업시간을 해당 요일(평일/주말)만 반환, null 필드 응답 제외
- `GET /bakeries/ai/{id}` 신규 추가
- `BakeryAiResponse`에 `estimatedStayMinutes` 필드 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #181 
