### PR TITLE
feat: 투어 도메인 추가

### DIFF
--- a/apps/be/lombok.config
+++ b/apps/be/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -111,7 +111,13 @@ public enum ErrorCode {
     ALREADY_POST_LIKED(HttpStatus.CONFLICT, "E0803", "이미 좋아요한 게시글입니다."),
     NOT_POST_LIKED(HttpStatus.BAD_REQUEST, "E0804", "좋아요하지 않은 게시글입니다."),
     POST_AUTHOR_ONLY(HttpStatus.FORBIDDEN, "E0805", "게시글 작성자만 수행할 수 있습니다."),
-    COMMENT_AUTHOR_ONLY(HttpStatus.FORBIDDEN, "E0806", "댓글 작성자만 수행할 수 있습니다.");
+    COMMENT_AUTHOR_ONLY(HttpStatus.FORBIDDEN, "E0806", "댓글 작성자만 수행할 수 있습니다."),
+
+    // 투어 E09xx
+    TOUR_NOT_FOUND(HttpStatus.NOT_FOUND, "E0901", "진행 중인 투어가 없습니다."),
+    TOUR_ALREADY_STARTED(HttpStatus.CONFLICT, "E0902", "이미 시작된 투어가 있습니다."),
+    TOUR_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "E0903", "이미 완료된 투어입니다."),
+    TOUR_INVALID_VISIT_ORDER(HttpStatus.BAD_REQUEST, "E0904", "유효하지 않은 방문 순서입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/be/src/main/java/com/breadbread/tour/controller/TourController.java
+++ b/apps/be/src/main/java/com/breadbread/tour/controller/TourController.java
@@ -1,0 +1,59 @@
+package com.breadbread.tour.controller;
+
+import com.breadbread.auth.dto.CustomUserDetails;
+import com.breadbread.global.dto.ApiResponse;
+import com.breadbread.tour.dto.TourCurrentResponse;
+import com.breadbread.tour.dto.TourStartResponse;
+import com.breadbread.tour.dto.TourVisitResponse;
+import com.breadbread.tour.service.TourService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "투어")
+@RestController
+@RequestMapping("/tours")
+@RequiredArgsConstructor
+public class TourController {
+
+    private final TourService tourService;
+
+    @Operation(summary = "투어 시작", description = "코스 투어를 시작합니다. 이미 진행 중인 투어가 있으면 409를 반환합니다.")
+    @PostMapping("/{courseId}/start")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<TourStartResponse> startTour(
+            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long courseId) {
+        return ApiResponse.ok(
+                tourService.startTour(userDetails.getId(), userDetails.getRole(), courseId));
+    }
+
+    @Operation(summary = "빵집 방문 체크", description = "n번째 빵집 방문을 기록합니다. 마지막 빵집 방문 시 투어가 자동 완료됩니다.")
+    @PatchMapping("/{courseId}/visit/{order}")
+    public ApiResponse<TourVisitResponse> visitBakery(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long courseId,
+            @PathVariable int order) {
+        return ApiResponse.ok(tourService.visitBakery(userDetails.getId(), courseId, order));
+    }
+
+    @Operation(
+            summary = "현재 투어 조회",
+            description =
+                    "투어 상태를 조회합니다. 앱 재접속 시 상태 복구용으로 사용합니다."
+                            + " status 필드가 IN_PROGRESS(진행 중) 또는 COMPLETED(완료 후 1시간 이내) 모두 반환될 수 있습니다.")
+    @GetMapping("/current")
+    public ApiResponse<TourCurrentResponse> getCurrentTour(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(tourService.getCurrentTour(userDetails.getId()));
+    }
+
+    @Operation(summary = "투어 완료 처리", description = "마지막 빵집 방문 외에 명시적으로 투어를 완료합니다.")
+    @PostMapping("/{courseId}/complete")
+    public ApiResponse<TourCurrentResponse> completeTour(
+            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long courseId) {
+        return ApiResponse.ok(tourService.completeTour(userDetails.getId(), courseId));
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/dto/TourCurrentResponse.java
+++ b/apps/be/src/main/java/com/breadbread/tour/dto/TourCurrentResponse.java
@@ -1,0 +1,27 @@
+package com.breadbread.tour.dto;
+
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TourCurrentResponse {
+
+    private Long courseId;
+    private int currentVisitOrder;
+    private int remainingCount;
+    private TourStatus status;
+    private String startedAt;
+
+    public static TourCurrentResponse from(TourStateCache state) {
+        return TourCurrentResponse.builder()
+                .courseId(state.getCourseId())
+                .currentVisitOrder(state.getCurrentVisitOrder())
+                .remainingCount(state.getTotalBakeryCount() - state.getCurrentVisitOrder())
+                .status(state.getStatus())
+                .startedAt(state.getStartedAt())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/dto/TourStartResponse.java
+++ b/apps/be/src/main/java/com/breadbread/tour/dto/TourStartResponse.java
@@ -1,0 +1,23 @@
+package com.breadbread.tour.dto;
+
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TourStartResponse {
+
+    private Long courseId;
+    private int totalBakeryCount;
+    private TourStatus status;
+
+    public static TourStartResponse from(TourStateCache state) {
+        return TourStartResponse.builder()
+                .courseId(state.getCourseId())
+                .totalBakeryCount(state.getTotalBakeryCount())
+                .status(state.getStatus())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/dto/TourVisitResponse.java
+++ b/apps/be/src/main/java/com/breadbread/tour/dto/TourVisitResponse.java
@@ -1,0 +1,25 @@
+package com.breadbread.tour.dto;
+
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TourVisitResponse {
+
+    private Long courseId;
+    private int currentVisitOrder;
+    private int remainingCount;
+    private TourStatus status;
+
+    public static TourVisitResponse from(TourStateCache state) {
+        return TourVisitResponse.builder()
+                .courseId(state.getCourseId())
+                .currentVisitOrder(state.getCurrentVisitOrder())
+                .remainingCount(state.getTotalBakeryCount() - state.getCurrentVisitOrder())
+                .status(state.getStatus())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/redis/TourStateCache.java
+++ b/apps/be/src/main/java/com/breadbread/tour/redis/TourStateCache.java
@@ -1,0 +1,20 @@
+package com.breadbread.tour.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TourStateCache {
+
+    private Long userId;
+    private Long courseId;
+    private int totalBakeryCount;
+    private int currentVisitOrder; // 완료한 방문 수
+    private TourStatus status;
+    private String startedAt; // ISO-8601 문자열
+}

--- a/apps/be/src/main/java/com/breadbread/tour/redis/TourStatus.java
+++ b/apps/be/src/main/java/com/breadbread/tour/redis/TourStatus.java
@@ -1,0 +1,6 @@
+package com.breadbread.tour.redis;
+
+public enum TourStatus {
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourRedisService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourRedisService.java
@@ -1,0 +1,153 @@
+package com.breadbread.tour.service;
+
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TourRedisService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String TOUR_PREFIX = "tour:";
+    private static final String ACTIVE_SET_KEY = "tour:active";
+    private static final Duration TOUR_TTL = Duration.ofHours(24);
+
+    public TourStateCache startTour(Long userId, Long courseId, int totalBakeryCount) {
+        TourStateCache state =
+                TourStateCache.builder()
+                        .userId(userId)
+                        .courseId(courseId)
+                        .totalBakeryCount(totalBakeryCount)
+                        .currentVisitOrder(0)
+                        .status(TourStatus.IN_PROGRESS)
+                        .startedAt(LocalDateTime.now().toString())
+                        .build();
+        save(userId, state, TOUR_TTL);
+        stringRedisTemplate.opsForSet().add(ACTIVE_SET_KEY, String.valueOf(userId));
+        log.info("[투어] 시작: userId={}, courseId={}", userId, courseId);
+        return state;
+    }
+
+    public TourStateCache updateVisitOrder(Long userId, int visitedOrder) {
+        TourStateCache current =
+                getTourState(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOUR_NOT_FOUND));
+
+        boolean isCompleted = visitedOrder >= current.getTotalBakeryCount();
+        TourStateCache updated =
+                TourStateCache.builder()
+                        .userId(userId)
+                        .courseId(current.getCourseId())
+                        .totalBakeryCount(current.getTotalBakeryCount())
+                        .currentVisitOrder(visitedOrder)
+                        .status(isCompleted ? TourStatus.COMPLETED : TourStatus.IN_PROGRESS)
+                        .startedAt(current.getStartedAt())
+                        .build();
+
+        Duration ttl = isCompleted ? Duration.ofHours(1) : TOUR_TTL;
+        save(userId, updated, ttl);
+
+        if (isCompleted) {
+            stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, String.valueOf(userId));
+            log.info("[투어] 완료: userId={}, courseId={}", userId, current.getCourseId());
+        }
+        return updated;
+    }
+
+    public Optional<TourStateCache> getTourState(Long userId) {
+        String json = stringRedisTemplate.opsForValue().get(TOUR_PREFIX + userId);
+        if (json == null) return Optional.empty();
+        try {
+            return Optional.of(objectMapper.readValue(json, TourStateCache.class));
+        } catch (JsonProcessingException e) {
+            log.error("[투어] Redis 역직렬화 실패: userId={}", userId, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public boolean hasActiveTour(Long userId) {
+        return getTourState(userId)
+                .map(state -> state.getStatus() == TourStatus.IN_PROGRESS)
+                .orElse(false);
+    }
+
+    public TourStateCache completeTour(Long userId) {
+        TourStateCache current =
+                getTourState(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOUR_NOT_FOUND));
+
+        TourStateCache completed =
+                TourStateCache.builder()
+                        .userId(userId)
+                        .courseId(current.getCourseId())
+                        .totalBakeryCount(current.getTotalBakeryCount())
+                        .currentVisitOrder(current.getTotalBakeryCount()) // remainingCount = 0 보장
+                        .status(TourStatus.COMPLETED)
+                        .startedAt(current.getStartedAt())
+                        .build();
+
+        save(userId, completed, Duration.ofHours(1));
+        stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, String.valueOf(userId));
+        log.info("[투어] 수동 완료: userId={}, courseId={}", userId, current.getCourseId());
+        return completed;
+    }
+
+    public List<Long> getAllActiveUserIds() {
+        Set<String> members = stringRedisTemplate.opsForSet().members(ACTIVE_SET_KEY);
+        if (members == null) return List.of();
+
+        List<Long> activeIds = new java.util.ArrayList<>();
+        for (String s : members) {
+            Long userId;
+            try {
+                userId = Long.parseLong(s);
+            } catch (NumberFormatException e) {
+                stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, s);
+                continue;
+            }
+
+            Optional<TourStateCache> state = getTourState(userId);
+            if (state.isEmpty()) {
+                // TTL 만료 등으로 상태 키가 사라진 stale 항목 정리
+                stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, s);
+                log.warn("[투어] getAllActiveUserIds — stale 항목 제거: userId={}", userId);
+                continue;
+            }
+            if (state.get().getStatus() == TourStatus.IN_PROGRESS) {
+                activeIds.add(userId);
+            } else {
+                // COMPLETED인데 set에 남아 있는 경우 정리
+                stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, s);
+                log.warn("[투어] getAllActiveUserIds — COMPLETED 잔류 항목 제거: userId={}", userId);
+            }
+        }
+        return activeIds;
+    }
+
+    private void save(Long userId, TourStateCache state, Duration ttl) {
+        try {
+            stringRedisTemplate
+                    .opsForValue()
+                    .set(TOUR_PREFIX + userId, objectMapper.writeValueAsString(state), ttl);
+        } catch (JsonProcessingException e) {
+            log.error("[투어] Redis 직렬화 실패: userId={}", userId, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
@@ -1,0 +1,112 @@
+package com.breadbread.tour.service;
+
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.repository.CourseBakeryRepository;
+import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.tour.dto.TourCurrentResponse;
+import com.breadbread.tour.dto.TourStartResponse;
+import com.breadbread.tour.dto.TourVisitResponse;
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import com.breadbread.user.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TourService {
+
+    private final TourRedisService tourRedisService;
+    private final CourseRepository courseRepository;
+    private final CourseBakeryRepository courseBakeryRepository;
+
+    @Transactional(readOnly = true)
+    public TourStartResponse startTour(Long userId, UserRole role, Long courseId) {
+        if (tourRedisService.hasActiveTour(userId)) {
+            throw new CustomException(ErrorCode.TOUR_ALREADY_STARTED);
+        }
+
+        Course course =
+                courseRepository
+                        .findByIdAndActiveTrue(courseId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+
+        // 비공개 코스는 본인 또는 ADMIN만 투어 시작 가능 (CourseService와 동일한 규칙)
+        if (!course.isShared()
+                && role != UserRole.ROLE_ADMIN
+                && (course.getUser() == null || !course.getUser().getId().equals(userId))) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        int totalBakeryCount = courseBakeryRepository.findAllByCourseId(courseId).size();
+
+        if (totalBakeryCount == 0) {
+            throw new CustomException(ErrorCode.COURSE_BAKERY_REQUIRED);
+        }
+
+        TourStateCache state = tourRedisService.startTour(userId, course.getId(), totalBakeryCount);
+
+        return TourStartResponse.from(state);
+    }
+
+    public TourVisitResponse visitBakery(Long userId, Long courseId, int visitOrder) {
+        TourStateCache state =
+                tourRedisService
+                        .getTourState(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOUR_NOT_FOUND));
+
+        if (!state.getCourseId().equals(courseId)) {
+            throw new CustomException(ErrorCode.TOUR_NOT_FOUND);
+        }
+
+        if (state.getStatus() == TourStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.TOUR_ALREADY_COMPLETED);
+        }
+
+        // 다음 순서(currentVisitOrder + 1)만 허용 — 건너뛰기·되돌아가기 불가
+        if (visitOrder != state.getCurrentVisitOrder() + 1) {
+            throw new CustomException(ErrorCode.TOUR_INVALID_VISIT_ORDER);
+        }
+
+        TourStateCache updated = tourRedisService.updateVisitOrder(userId, visitOrder);
+
+        log.info(
+                "[투어] 빵집 방문: userId={}, courseId={}, visitOrder={}, remaining={}, status={}",
+                userId,
+                courseId,
+                visitOrder,
+                updated.getTotalBakeryCount() - updated.getCurrentVisitOrder(),
+                updated.getStatus());
+        return TourVisitResponse.from(updated);
+    }
+
+    public TourCurrentResponse getCurrentTour(Long userId) {
+        TourStateCache state =
+                tourRedisService
+                        .getTourState(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOUR_NOT_FOUND));
+        return TourCurrentResponse.from(state);
+    }
+
+    public TourCurrentResponse completeTour(Long userId, Long courseId) {
+        TourStateCache state =
+                tourRedisService
+                        .getTourState(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOUR_NOT_FOUND));
+
+        if (!state.getCourseId().equals(courseId)) {
+            throw new CustomException(ErrorCode.TOUR_NOT_FOUND);
+        }
+
+        if (state.getStatus() == TourStatus.COMPLETED) {
+            throw new CustomException(ErrorCode.TOUR_ALREADY_COMPLETED);
+        }
+
+        return TourCurrentResponse.from(tourRedisService.completeTour(userId));
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourRedisServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourRedisServiceTest.java
@@ -1,0 +1,206 @@
+package com.breadbread.tour.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TourRedisServiceTest {
+
+    @Mock private StringRedisTemplate stringRedisTemplate;
+    @Mock private ValueOperations<String, String> valueOps;
+    @Mock private SetOperations<String, String> setOps;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private TourRedisService tourRedisService;
+
+    @BeforeEach
+    void setUp() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+        when(stringRedisTemplate.opsForSet()).thenReturn(setOps);
+        tourRedisService = new TourRedisService(stringRedisTemplate, objectMapper);
+    }
+
+    // ── startTour ──────────────────────────────────────────────────────────────
+
+    @Test
+    void startTour_saves_IN_PROGRESS_state_with_24h_ttl_and_adds_to_active_set() {
+        TourStateCache result = tourRedisService.startTour(1L, 10L, 3);
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOps).set(keyCaptor.capture(), jsonCaptor.capture(), eq(Duration.ofHours(24)));
+        assertThat(keyCaptor.getValue()).isEqualTo("tour:1");
+        assertThat(jsonCaptor.getValue())
+                .contains("\"status\":\"IN_PROGRESS\"")
+                .contains("\"courseId\":10")
+                .contains("\"totalBakeryCount\":3")
+                .contains("\"currentVisitOrder\":0");
+        verify(setOps).add("tour:active", "1");
+        // 반환된 상태가 Redis 재조회 없이 직접 사용 가능한지 확인
+        assertThat(result.getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+        assertThat(result.getCourseId()).isEqualTo(10L);
+        assertThat(result.getCurrentVisitOrder()).isEqualTo(0);
+    }
+
+    // ── updateVisitOrder ───────────────────────────────────────────────────────
+
+    @Test
+    void updateVisitOrder_keeps_IN_PROGRESS_and_24h_ttl_when_not_last_bakery() throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 1, TourStatus.IN_PROGRESS));
+
+        TourStateCache updated = tourRedisService.updateVisitOrder(1L, 2);
+
+        assertThat(updated.getCurrentVisitOrder()).isEqualTo(2);
+        assertThat(updated.getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+        verify(valueOps).set(eq("tour:1"), any(), eq(Duration.ofHours(24)));
+        verify(setOps, never()).remove(any(), any());
+    }
+
+    @Test
+    void updateVisitOrder_sets_COMPLETED_with_1h_ttl_and_removes_from_active_set_when_last_bakery()
+            throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 2, TourStatus.IN_PROGRESS));
+
+        TourStateCache updated = tourRedisService.updateVisitOrder(1L, 3);
+
+        assertThat(updated.getStatus()).isEqualTo(TourStatus.COMPLETED);
+        assertThat(updated.getCurrentVisitOrder()).isEqualTo(3);
+        verify(valueOps).set(eq("tour:1"), any(), eq(Duration.ofHours(1)));
+        verify(setOps).remove("tour:active", "1");
+    }
+
+    // ── getTourState ───────────────────────────────────────────────────────────
+
+    @Test
+    void getTourState_returns_deserialized_state_when_key_exists() throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 1, TourStatus.IN_PROGRESS));
+
+        Optional<TourStateCache> result = tourRedisService.getTourState(1L);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getCourseId()).isEqualTo(10L);
+        assertThat(result.get().getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+        assertThat(result.get().getCurrentVisitOrder()).isEqualTo(1);
+    }
+
+    @Test
+    void getTourState_returns_empty_when_key_missing() {
+        when(valueOps.get("tour:1")).thenReturn(null);
+
+        assertThat(tourRedisService.getTourState(1L)).isEmpty();
+    }
+
+    // ── hasActiveTour ──────────────────────────────────────────────────────────
+
+    @Test
+    void hasActiveTour_returns_true_when_IN_PROGRESS() throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 1, TourStatus.IN_PROGRESS));
+
+        assertThat(tourRedisService.hasActiveTour(1L)).isTrue();
+    }
+
+    @Test
+    void hasActiveTour_returns_false_when_COMPLETED() throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 3, TourStatus.COMPLETED));
+
+        assertThat(tourRedisService.hasActiveTour(1L)).isFalse();
+    }
+
+    @Test
+    void hasActiveTour_returns_false_when_no_state() {
+        when(valueOps.get("tour:1")).thenReturn(null);
+
+        assertThat(tourRedisService.hasActiveTour(1L)).isFalse();
+    }
+
+    // ── completeTour ───────────────────────────────────────────────────────────
+
+    @Test
+    void completeTour_sets_currentVisitOrder_to_total_and_saves_COMPLETED_with_1h_ttl()
+            throws Exception {
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 1, TourStatus.IN_PROGRESS));
+
+        TourStateCache result = tourRedisService.completeTour(1L);
+
+        ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOps).set(eq("tour:1"), jsonCaptor.capture(), eq(Duration.ofHours(1)));
+        assertThat(jsonCaptor.getValue())
+                .contains("\"status\":\"COMPLETED\"")
+                .contains("\"currentVisitOrder\":3"); // totalBakeryCount = 3
+        verify(setOps).remove("tour:active", "1");
+        assertThat(result.getStatus()).isEqualTo(TourStatus.COMPLETED);
+        assertThat(result.getCurrentVisitOrder()).isEqualTo(3);
+        assertThat(result.getTotalBakeryCount() - result.getCurrentVisitOrder()).isZero();
+    }
+
+    // ── getAllActiveUserIds ─────────────────────────────────────────────────────
+
+    @Test
+    void getAllActiveUserIds_returns_only_IN_PROGRESS_users() throws Exception {
+        when(setOps.members("tour:active")).thenReturn(Set.of("1", "2"));
+        when(valueOps.get("tour:1")).thenReturn(json(1L, 10L, 3, 1, TourStatus.IN_PROGRESS));
+        when(valueOps.get("tour:2")).thenReturn(json(2L, 10L, 3, 3, TourStatus.COMPLETED));
+
+        List<Long> result = tourRedisService.getAllActiveUserIds();
+
+        assertThat(result).containsExactly(1L);
+        verify(setOps).remove("tour:active", "2"); // COMPLETED 항목 정리
+    }
+
+    @Test
+    void getAllActiveUserIds_cleans_up_stale_entries_whose_state_key_expired() throws Exception {
+        when(setOps.members("tour:active")).thenReturn(Set.of("1"));
+        when(valueOps.get("tour:1")).thenReturn(null); // TTL 만료
+
+        List<Long> result = tourRedisService.getAllActiveUserIds();
+
+        assertThat(result).isEmpty();
+        verify(setOps).remove("tour:active", "1");
+    }
+
+    @Test
+    void getAllActiveUserIds_returns_empty_when_active_set_is_null() {
+        when(setOps.members("tour:active")).thenReturn(null);
+
+        assertThat(tourRedisService.getAllActiveUserIds()).isEmpty();
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private String json(Long userId, Long courseId, int total, int current, TourStatus status)
+            throws Exception {
+        return objectMapper.writeValueAsString(
+                TourStateCache.builder()
+                        .userId(userId)
+                        .courseId(courseId)
+                        .totalBakeryCount(total)
+                        .currentVisitOrder(current)
+                        .status(status)
+                        .startedAt("2026-01-01T10:00:00")
+                        .build());
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
@@ -1,0 +1,344 @@
+package com.breadbread.tour.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.repository.CourseBakeryRepository;
+import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.tour.dto.TourCurrentResponse;
+import com.breadbread.tour.dto.TourStartResponse;
+import com.breadbread.tour.dto.TourVisitResponse;
+import com.breadbread.tour.redis.TourStateCache;
+import com.breadbread.tour.redis.TourStatus;
+import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserRole;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TourServiceTest {
+
+    @InjectMocks private TourService tourService;
+    @Mock private TourRedisService tourRedisService;
+    @Mock private CourseRepository courseRepository;
+    @Mock private CourseBakeryRepository courseBakeryRepository;
+
+    // ── startTour ──────────────────────────────────────────────────────────────
+
+    @Test
+    void startTour_throws_TOUR_ALREADY_STARTED_when_active_tour_exists() {
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_ALREADY_STARTED);
+
+        verify(courseRepository, never()).findByIdAndActiveTrue(any());
+    }
+
+    @Test
+    void startTour_throws_COURSE_NOT_FOUND_when_course_missing_or_inactive() {
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
+    }
+
+    @Test
+    void startTour_throws_FORBIDDEN_when_private_course_and_not_owner() {
+        Course course = privateCourse(10L, 99L);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void startTour_throws_FORBIDDEN_when_private_course_and_owner_is_null() {
+        Course course = privateCourseNullOwner(10L);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void startTour_succeeds_when_private_course_and_is_owner() {
+        Course course = privateCourse(10L, 1L); // userId == ownerId
+        TourStateCache state = tourState(1L, 10L, 3, 0, TourStatus.IN_PROGRESS);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(10L))
+                .thenReturn(
+                        List.of(
+                                mock(CourseBakery.class),
+                                mock(CourseBakery.class),
+                                mock(CourseBakery.class)));
+        when(tourRedisService.startTour(1L, 10L, 3)).thenReturn(state);
+
+        TourStartResponse response = tourService.startTour(1L, UserRole.ROLE_USER, 10L);
+
+        assertThat(response.getCourseId()).isEqualTo(10L);
+        assertThat(response.getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void startTour_succeeds_when_private_course_and_is_admin() {
+        Course course = privateCourse(10L, 99L); // 다른 유저 소유지만 ADMIN
+        TourStateCache state = tourState(5L, 10L, 2, 0, TourStatus.IN_PROGRESS);
+        when(tourRedisService.hasActiveTour(5L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(10L))
+                .thenReturn(List.of(mock(CourseBakery.class), mock(CourseBakery.class)));
+        when(tourRedisService.startTour(5L, 10L, 2)).thenReturn(state);
+
+        TourStartResponse response = tourService.startTour(5L, UserRole.ROLE_ADMIN, 10L);
+
+        assertThat(response.getCourseId()).isEqualTo(10L);
+    }
+
+    @Test
+    void startTour_throws_COURSE_BAKERY_REQUIRED_when_course_has_no_bakeries() {
+        Course course = sharedCourse(10L);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(10L)).thenReturn(List.of());
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.COURSE_BAKERY_REQUIRED);
+    }
+
+    // ── visitBakery ────────────────────────────────────────────────────────────
+
+    @Test
+    void visitBakery_throws_TOUR_NOT_FOUND_when_no_state() {
+        when(tourRedisService.getTourState(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tourService.visitBakery(1L, 10L, 1))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_NOT_FOUND);
+    }
+
+    @Test
+    void visitBakery_throws_TOUR_NOT_FOUND_when_courseId_mismatch() {
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS)));
+
+        assertThatThrownBy(() -> tourService.visitBakery(1L, 99L, 2))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_NOT_FOUND);
+    }
+
+    @Test
+    void visitBakery_throws_TOUR_ALREADY_COMPLETED_when_status_is_completed() {
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 3, TourStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> tourService.visitBakery(1L, 10L, 4))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_ALREADY_COMPLETED);
+    }
+
+    @Test
+    void visitBakery_throws_TOUR_INVALID_VISIT_ORDER_when_skipping_order() {
+        // currentVisitOrder=0 → 다음 순서는 1이어야 함, 2로 건너뛰기 시도
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 0, TourStatus.IN_PROGRESS)));
+
+        assertThatThrownBy(() -> tourService.visitBakery(1L, 10L, 2))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_INVALID_VISIT_ORDER);
+    }
+
+    @Test
+    void visitBakery_throws_TOUR_INVALID_VISIT_ORDER_when_going_backward() {
+        // currentVisitOrder=2 → 다음 순서는 3이어야 함, 1로 되돌아가기 시도
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 2, TourStatus.IN_PROGRESS)));
+
+        assertThatThrownBy(() -> tourService.visitBakery(1L, 10L, 1))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_INVALID_VISIT_ORDER);
+    }
+
+    @Test
+    void visitBakery_returns_IN_PROGRESS_response_when_not_last_bakery() {
+        TourStateCache updated = tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS);
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 0, TourStatus.IN_PROGRESS)));
+        when(tourRedisService.updateVisitOrder(1L, 1)).thenReturn(updated);
+
+        TourVisitResponse response = tourService.visitBakery(1L, 10L, 1);
+
+        assertThat(response.getCurrentVisitOrder()).isEqualTo(1);
+        assertThat(response.getRemainingCount()).isEqualTo(2);
+        assertThat(response.getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void visitBakery_returns_COMPLETED_response_when_last_bakery() {
+        TourStateCache updated = tourState(1L, 10L, 3, 3, TourStatus.COMPLETED);
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 2, TourStatus.IN_PROGRESS)));
+        when(tourRedisService.updateVisitOrder(1L, 3)).thenReturn(updated);
+
+        TourVisitResponse response = tourService.visitBakery(1L, 10L, 3);
+
+        assertThat(response.getCurrentVisitOrder()).isEqualTo(3);
+        assertThat(response.getRemainingCount()).isEqualTo(0);
+        assertThat(response.getStatus()).isEqualTo(TourStatus.COMPLETED);
+    }
+
+    // ── getCurrentTour ─────────────────────────────────────────────────────────
+
+    @Test
+    void getCurrentTour_throws_TOUR_NOT_FOUND_when_no_state() {
+        when(tourRedisService.getTourState(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tourService.getCurrentTour(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_NOT_FOUND);
+    }
+
+    @Test
+    void getCurrentTour_returns_response_with_correct_remaining_count() {
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS)));
+
+        TourCurrentResponse response = tourService.getCurrentTour(1L);
+
+        assertThat(response.getCourseId()).isEqualTo(10L);
+        assertThat(response.getCurrentVisitOrder()).isEqualTo(1);
+        assertThat(response.getRemainingCount()).isEqualTo(2);
+        assertThat(response.getStatus()).isEqualTo(TourStatus.IN_PROGRESS);
+    }
+
+    // ── completeTour ───────────────────────────────────────────────────────────
+
+    @Test
+    void completeTour_throws_TOUR_NOT_FOUND_when_no_state() {
+        when(tourRedisService.getTourState(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tourService.completeTour(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_NOT_FOUND);
+    }
+
+    @Test
+    void completeTour_throws_TOUR_NOT_FOUND_when_courseId_mismatch() {
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS)));
+
+        assertThatThrownBy(() -> tourService.completeTour(1L, 99L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_NOT_FOUND);
+    }
+
+    @Test
+    void completeTour_throws_TOUR_ALREADY_COMPLETED_when_already_done() {
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 3, TourStatus.COMPLETED)));
+
+        assertThatThrownBy(() -> tourService.completeTour(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_ALREADY_COMPLETED);
+    }
+
+    @Test
+    void completeTour_sets_remainingCount_zero_regardless_of_current_visit_order() {
+        // 1번만 방문한 상태에서 강제 완료 → currentVisitOrder=total=3, remainingCount=0
+        TourStateCache afterComplete = tourState(1L, 10L, 3, 3, TourStatus.COMPLETED);
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS)));
+        when(tourRedisService.completeTour(1L)).thenReturn(afterComplete);
+
+        TourCurrentResponse response = tourService.completeTour(1L, 10L);
+
+        assertThat(response.getStatus()).isEqualTo(TourStatus.COMPLETED);
+        assertThat(response.getRemainingCount()).isEqualTo(0);
+        assertThat(response.getCurrentVisitOrder()).isEqualTo(3);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static TourStateCache tourState(
+            Long userId, Long courseId, int total, int current, TourStatus status) {
+        return TourStateCache.builder()
+                .userId(userId)
+                .courseId(courseId)
+                .totalBakeryCount(total)
+                .currentVisitOrder(current)
+                .status(status)
+                .startedAt("2026-01-01T10:00:00")
+                .build();
+    }
+
+    /** shared=true인 코스 목(공개 코스 — 소유자 체크 불필요) */
+    private static Course sharedCourse(long courseId) {
+        Course course = mock(Course.class);
+        when(course.isShared()).thenReturn(true);
+        when(course.getId()).thenReturn(courseId);
+        return course;
+    }
+
+    /** shared=false인 코스 목(비공개 코스 — 소유자 ownerId) */
+    private static Course privateCourse(long courseId, long ownerId) {
+        User owner = mock(User.class);
+        when(owner.getId()).thenReturn(ownerId);
+        Course course = mock(Course.class);
+        when(course.isShared()).thenReturn(false);
+        when(course.getUser()).thenReturn(owner);
+        when(course.getId()).thenReturn(courseId);
+        return course;
+    }
+
+    /** shared=false이고 user == null인 코스 목(데이터 이상 케이스) */
+    private static Course privateCourseNullOwner(long courseId) {
+        Course course = mock(Course.class);
+        when(course.isShared()).thenReturn(false);
+        when(course.getUser()).thenReturn(null);
+        when(course.getId()).thenReturn(courseId);
+        return course;
+    }
+
+    private static <T> T any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+}


### PR DESCRIPTION
## Task
- 코스 기반 투어 시작/방문/현재 상태/완료 API 추가
- Redis 기반 실시간 방문 상태 추적 추가
- 비공개 코스 접근 제어 및 stale active set 정리

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #183 
