### PR TITLE
feat: 예약 스케줄러 및 예약 불가능 시간 조회 API 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
@@ -5,6 +5,7 @@ import com.breadbread.global.dto.ApiResponse;
 import com.breadbread.reservation.dto.CreateReservationRequest;
 import com.breadbread.reservation.dto.ReservationDetailResponse;
 import com.breadbread.reservation.dto.ReservationSummaryResponse;
+import com.breadbread.reservation.dto.UnavailableTimesResponse;
 import com.breadbread.reservation.dto.UpdateReservationRequest;
 import com.breadbread.reservation.entity.ReservationStatus;
 import com.breadbread.reservation.service.ReservationService;
@@ -12,8 +13,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -42,6 +45,19 @@ public class ReservationController {
     public ApiResponse<ReservationDetailResponse> getReservation(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.ok(reservationService.getReservation(userDetails.getId(), id));
+    }
+
+    @Operation(
+            summary = "예약 불가능한 시간 조회",
+            description = "해당 날짜에 본인이 이미 예약한 시간 목록을 반환합니다. (HH:mm 형식)")
+    @GetMapping("/unavailable-times")
+    public ApiResponse<UnavailableTimesResponse> getUnavailableTimes(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2025-07-01")
+                    @RequestParam
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate date) {
+        return ApiResponse.ok(reservationService.getUnavailableTimes(userDetails.getId(), date));
     }
 
     @Operation(summary = "예약 생성")

--- a/apps/be/src/main/java/com/breadbread/reservation/dto/UnavailableTimesResponse.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/dto/UnavailableTimesResponse.java
@@ -1,0 +1,11 @@
+package com.breadbread.reservation.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UnavailableTimesResponse {
+    private List<String> unavailableTimes;
+}

--- a/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
@@ -30,12 +30,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             Collection<ReservationStatus> statuses,
             Long id);
 
-    Optional<Reservation> findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-            Long userId,
-            LocalDate departureDate,
-            LocalTime departureTime,
-            ReservationStatus status);
-
     @Query(
             "SELECT DISTINCT r FROM Reservation r "
                     + "JOIN FETCH r.course c "
@@ -53,4 +47,19 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                     + "WHERE r.departureDate = :date AND r.status = :status")
     List<Reservation> findTodayConfirmedWithCourse(
             @Param("date") LocalDate date, @Param("status") ReservationStatus status);
+
+    @Query(
+            "SELECT r FROM Reservation r "
+                    + "JOIN FETCH r.user "
+                    + "WHERE r.departureDate < :today AND r.status = :status")
+    List<Reservation> findExpiredPending(
+            @Param("today") LocalDate today, @Param("status") ReservationStatus status);
+
+    @Query(
+            "SELECT DISTINCT r.departureTime FROM Reservation r "
+                    + "WHERE r.user.id = :userId AND r.departureDate = :date AND r.status IN :statuses")
+    List<LocalTime> findBookedTimesByUserAndDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("statuses") Collection<ReservationStatus> statuses);
 }

--- a/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationDailyScheduler.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationDailyScheduler.java
@@ -1,0 +1,19 @@
+package com.breadbread.reservation.scheduler;
+
+import com.breadbread.reservation.service.ReservationDailyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationDailyScheduler {
+
+    private final ReservationDailyService reservationDailyService;
+
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    public void run() {
+        reservationDailyService.cancelExpiredPending();
+        reservationDailyService.notifyTodayConfirmed();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationDailyService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationDailyService.java
@@ -1,0 +1,66 @@
+package com.breadbread.reservation.service;
+
+import com.breadbread.notification.service.FcmService;
+import com.breadbread.reservation.entity.Reservation;
+import com.breadbread.reservation.entity.ReservationStatus;
+import com.breadbread.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationDailyService {
+
+    private final ReservationRepository reservationRepository;
+    private final FcmService fcmService;
+
+    @Transactional
+    public void notifyTodayConfirmed() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        List<Reservation> reservations =
+                reservationRepository.findTodayConfirmedWithCourse(
+                        today, ReservationStatus.CONFIRMED);
+        if (reservations.isEmpty()) return;
+
+        log.info("[오늘 투어 알림] CONFIRMED 예약 수: {}", reservations.size());
+
+        for (Reservation reservation : reservations) {
+            Long userId = reservation.getUser().getId();
+            Long reservationId = reservation.getId();
+            String courseName = reservation.getCourseNameSnapshot();
+
+            fcmService.sendToUser(
+                    userId,
+                    "오늘의 빵집 투어",
+                    courseName + " 코스 출발일입니다! 즐거운 빵집 투어 되세요!",
+                    Map.of(
+                            "type", "TODAY_TOUR",
+                            "courseId", String.valueOf(reservation.getCourse().getId()),
+                            "reservationId", String.valueOf(reservationId)));
+
+            log.info("[오늘 투어 알림] 발송: userId={}, reservationId={}", userId, reservationId);
+        }
+    }
+
+    @Transactional
+    public void cancelExpiredPending() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        List<Reservation> expired =
+                reservationRepository.findExpiredPending(today, ReservationStatus.PENDING);
+        if (expired.isEmpty()) return;
+
+        log.info("[만료 예약 취소] 대상 수: {}", expired.size());
+
+        for (Reservation reservation : expired) {
+            reservation.cancel();
+            log.info("[만료 예약 취소] reservationId={}", reservation.getId());
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
@@ -25,7 +25,6 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,11 +43,8 @@ public class ReservationService {
     private final PaymentRepository paymentRepository;
     private final BakeryImageUrlResolver bakeryImageUrlResolver;
 
-    private static final Set<ReservationStatus> ACTIVE_STATUSES =
+    static final Set<ReservationStatus> ACTIVE_STATUSES =
             Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED);
-
-    private static final Set<ReservationStatus> CONFIRMED_ONLY =
-            Set.of(ReservationStatus.CONFIRMED);
 
     @Transactional(readOnly = true)
     public List<ReservationSummaryResponse> getMyReservations(
@@ -87,31 +83,10 @@ public class ReservationService {
         validateDepartureDateTime(request.getDepartureDate(), request.getDepartureTime());
         validateDepartureLocation(request.getDeparture(), request.getLat(), request.getLng());
 
-        // 확정된 예약은 같은 출발 일시에 중복 불가 (코스 무관)
+        // 같은 출발 일시에 PENDING·CONFIRMED 예약 모두 중복 불가
         if (reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
-                userId, request.getDepartureDate(), request.getDepartureTime(), CONFIRMED_ONLY)) {
+                userId, request.getDepartureDate(), request.getDepartureTime(), ACTIVE_STATUSES)) {
             throw new CustomException(ErrorCode.ALREADY_RESERVED);
-        }
-
-        // 결제 전 PENDING만 있는 경우: 결제 창을 닫고 다시 누르면 동일 요청이 반복되므로 기존 예약 ID 재사용
-        Optional<Reservation> pendingSameSlot =
-                reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                userId,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING);
-        if (pendingSameSlot.isPresent()) {
-            Reservation pending = pendingSameSlot.get();
-            if (!pending.getCourse().getId().equals(request.getCourseId())) {
-                throw new CustomException(ErrorCode.ALREADY_RESERVED);
-            }
-            if (paymentRepository.existsByReservationIdAndStatus(
-                    pending.getId(), PaymentStatus.PAID)) {
-                throw new CustomException(ErrorCode.ALREADY_RESERVED);
-            }
-            log.info("예약 재사용(동일 일시·코스, 미결제): reservationId={}, userId={}", pending.getId(), userId);
-            return pending.getId();
         }
 
         Course course =
@@ -230,6 +205,18 @@ public class ReservationService {
         if (departureDateTime.isBefore(LocalDateTime.now())) {
             throw new CustomException(ErrorCode.INVALID_RESERVATION_TIME);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public UnavailableTimesResponse getUnavailableTimes(Long userId, LocalDate date) {
+        List<String> unavailableTimes =
+                reservationRepository
+                        .findBookedTimesByUserAndDate(userId, date, ACTIVE_STATUSES)
+                        .stream()
+                        .sorted()
+                        .map(t -> t.format(java.time.format.DateTimeFormatter.ofPattern("HH:mm")))
+                        .toList();
+        return new UnavailableTimesResponse(unavailableTimes);
     }
 
     private void validateDepartureLocation(String departure, Double lat, Double lng) {

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationDailyServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationDailyServiceTest.java
@@ -1,0 +1,97 @@
+package com.breadbread.reservation.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.notification.service.FcmService;
+import com.breadbread.reservation.entity.Reservation;
+import com.breadbread.reservation.entity.ReservationStatus;
+import com.breadbread.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationDailyServiceTest {
+
+    @Mock private ReservationRepository reservationRepository;
+    @Mock private FcmService fcmService;
+
+    @InjectMocks private ReservationDailyService reservationDailyService;
+
+    // ───────────────── notifyTodayConfirmed ─────────────────
+
+    @Test
+    void notifyTodayConfirmed_예약없으면_FCM미전송() {
+        when(reservationRepository.findTodayConfirmedWithCourse(
+                        any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
+                .thenReturn(List.of());
+
+        reservationDailyService.notifyTodayConfirmed();
+
+        verify(fcmService, never()).sendToUser(anyLong(), any(), any(), any());
+    }
+
+    @Test
+    void notifyTodayConfirmed_CONFIRMED예약있으면_FCM전송() {
+        Reservation reservation = stubConfirmedReservation(1L, 10L, "서울 빵집 투어");
+        when(reservationRepository.findTodayConfirmedWithCourse(
+                        any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
+                .thenReturn(List.of(reservation));
+
+        reservationDailyService.notifyTodayConfirmed();
+
+        verify(fcmService).sendToUser(eq(1L), eq("오늘의 빵집 투어"), anyString(), anyMap());
+    }
+
+    // ───────────────── cancelExpiredPending ─────────────────
+
+    @Test
+    void cancelExpiredPending_만료예약없으면_취소처리없음() {
+        when(reservationRepository.findExpiredPending(
+                        any(LocalDate.class), eq(ReservationStatus.PENDING)))
+                .thenReturn(List.of());
+
+        reservationDailyService.cancelExpiredPending();
+
+        verify(reservationRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelExpiredPending_만료PENDING_cancel호출() {
+        Reservation reservation = mock(Reservation.class);
+        lenient().when(reservation.getId()).thenReturn(1L);
+        when(reservationRepository.findExpiredPending(
+                        any(LocalDate.class), eq(ReservationStatus.PENDING)))
+                .thenReturn(List.of(reservation));
+
+        reservationDailyService.cancelExpiredPending();
+
+        verify(reservation).cancel();
+    }
+
+    // ───────────────────────── helpers ──────────────────────
+
+    private static Reservation stubConfirmedReservation(
+            Long reservationId, Long courseId, String courseName) {
+        Reservation reservation = mock(Reservation.class, Answers.RETURNS_DEEP_STUBS);
+        lenient().when(reservation.getId()).thenReturn(reservationId);
+        lenient().when(reservation.getUser().getId()).thenReturn(1L);
+        lenient().when(reservation.getCourse().getId()).thenReturn(courseId);
+        lenient().when(reservation.getCourseNameSnapshot()).thenReturn(courseName);
+        return reservation;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +38,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -156,79 +154,13 @@ class ReservationServiceTest {
     }
 
     @Test
-    void createReservation_throws_whenConfirmedReservationAlreadyExists() {
+    void createReservation_throws_whenActiveReservationAlreadyExists() {
         CreateReservationRequest request = createReservationRequest(3L);
         when(reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
                         eq(10L),
                         eq(request.getDepartureDate()),
                         eq(request.getDepartureTime()),
-                        eq(Set.of(ReservationStatus.CONFIRMED))))
-                .thenReturn(true);
-
-        assertThatThrownBy(() -> reservationService.createReservation(10L, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.ALREADY_RESERVED);
-    }
-
-    @Test
-    void createReservation_reuses_pending_when_same_slot_and_course() {
-        CreateReservationRequest request = createReservationRequest(3L);
-        User owner = user(10L);
-        Course course = manualCourse(3L, "course");
-        Reservation pending = reservation(5L, owner, course);
-
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.of(pending));
-        when(paymentRepository.existsByReservationIdAndStatus(5L, PaymentStatus.PAID))
-                .thenReturn(false);
-
-        Long result = reservationService.createReservation(10L, request);
-
-        assertThat(result).isEqualTo(5L);
-        verify(reservationRepository, never()).save(any(Reservation.class));
-    }
-
-    @Test
-    void createReservation_throws_whenPendingReservationExistsForDifferentCourse() {
-        CreateReservationRequest request = createReservationRequest(3L);
-        Reservation pending = reservation(5L, user(10L), manualCourse(99L, "other-course"));
-
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.of(pending));
-
-        assertThatThrownBy(() -> reservationService.createReservation(10L, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.ALREADY_RESERVED);
-    }
-
-    @Test
-    void createReservation_throws_whenPendingReservationAlreadyHasPaidPayment() {
-        CreateReservationRequest request = createReservationRequest(3L);
-        Reservation pending = reservation(5L, user(10L), manualCourse(3L, "same-course"));
-
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.of(pending));
-        when(paymentRepository.existsByReservationIdAndStatus(5L, PaymentStatus.PAID))
+                        eq(ReservationService.ACTIVE_STATUSES)))
                 .thenReturn(true);
 
         assertThatThrownBy(() -> reservationService.createReservation(10L, request))
@@ -241,14 +173,7 @@ class ReservationServiceTest {
     void createReservation_throws_whenCourseMissing() {
         CreateReservationRequest request = createReservationRequest(3L);
 
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.empty());
+        stubNoActiveConflict(request);
         when(courseRepository.findByIdAndActiveTrue(3L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> reservationService.createReservation(10L, request))
@@ -262,14 +187,7 @@ class ReservationServiceTest {
         CreateReservationRequest request = createReservationRequest(3L);
         Course course = manualCourse(3L, "course");
 
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.empty());
+        stubNoActiveConflict(request);
         when(courseRepository.findByIdAndActiveTrue(3L)).thenReturn(Optional.of(course));
         when(userRepository.findById(10L)).thenReturn(Optional.empty());
 
@@ -285,14 +203,7 @@ class ReservationServiceTest {
         User owner = user(10L);
         Course course = manualCourse(3L, "course");
 
-        stubNoConfirmedConflict(request);
-        when(reservationRepository
-                        .findFirstByUserIdAndDepartureDateAndDepartureTimeAndStatusOrderByIdDesc(
-                                10L,
-                                request.getDepartureDate(),
-                                request.getDepartureTime(),
-                                ReservationStatus.PENDING))
-                .thenReturn(Optional.empty());
+        stubNoActiveConflict(request);
         when(courseRepository.findByIdAndActiveTrue(3L)).thenReturn(Optional.of(course));
         when(userRepository.findById(10L)).thenReturn(Optional.of(owner));
         when(reservationRepository.save(any(Reservation.class)))
@@ -354,6 +265,28 @@ class ReservationServiceTest {
     }
 
     @Test
+    void getUnavailableTimes_예약없으면_빈리스트_반환() {
+        when(reservationRepository.findBookedTimesByUserAndDate(
+                        eq(10L), eq(NEXT_DATE), eq(ReservationService.ACTIVE_STATUSES)))
+                .thenReturn(List.of());
+
+        var result = reservationService.getUnavailableTimes(10L, NEXT_DATE);
+
+        assertThat(result.getUnavailableTimes()).isEmpty();
+    }
+
+    @Test
+    void getUnavailableTimes_PENDING과CONFIRMED_모두포함하여_정렬된_HHmm_반환() {
+        when(reservationRepository.findBookedTimesByUserAndDate(
+                        eq(10L), eq(NEXT_DATE), eq(ReservationService.ACTIVE_STATUSES)))
+                .thenReturn(List.of(LocalTime.of(13, 30), LocalTime.of(9, 0)));
+
+        var result = reservationService.getUnavailableTimes(10L, NEXT_DATE);
+
+        assertThat(result.getUnavailableTimes()).containsExactly("09:00", "13:30");
+    }
+
+    @Test
     void updateReservation_throws_whenReservationMissing() {
         when(reservationRepository.findById(1L)).thenReturn(Optional.empty());
 
@@ -407,7 +340,7 @@ class ReservationServiceTest {
                                 10L,
                                 UPDATED_DATE,
                                 UPDATED_TIME,
-                                Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED),
+                                ReservationService.ACTIVE_STATUSES,
                                 1L))
                 .thenReturn(true);
 
@@ -434,7 +367,7 @@ class ReservationServiceTest {
                                 10L,
                                 UPDATED_DATE,
                                 UPDATED_HALF_HOUR_TIME,
-                                Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED),
+                                ReservationService.ACTIVE_STATUSES,
                                 1L))
                 .thenReturn(false);
 
@@ -458,7 +391,7 @@ class ReservationServiceTest {
                                 10L,
                                 reservation.getDepartureDate(),
                                 reservation.getDepartureTime(),
-                                Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED),
+                                ReservationService.ACTIVE_STATUSES,
                                 1L))
                 .thenReturn(false);
 
@@ -480,7 +413,7 @@ class ReservationServiceTest {
                                 10L,
                                 reservation.getDepartureDate(),
                                 reservation.getDepartureTime(),
-                                Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED),
+                                ReservationService.ACTIVE_STATUSES,
                                 1L))
                 .thenReturn(false);
 
@@ -546,12 +479,14 @@ class ReservationServiceTest {
                 .isEqualTo(ErrorCode.RESERVATION_CANCEL_FAILED);
     }
 
-    private void stubNoConfirmedConflict(CreateReservationRequest request) {
+    // ───────────────────────────── helpers ─────────────────────────────
+
+    private void stubNoActiveConflict(CreateReservationRequest request) {
         when(reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
                         eq(10L),
                         eq(request.getDepartureDate()),
                         eq(request.getDepartureTime()),
-                        eq(Set.of(ReservationStatus.CONFIRMED))))
+                        eq(ReservationService.ACTIVE_STATUSES)))
                 .thenReturn(false);
     }
 


### PR DESCRIPTION
## Task
- 예약 당일 오전 알림 전송 스케줄러 추가
- 출발일이 지난 PENDING 예약 자동 취소 처리
- 예약 불가능 시간 조회 API 추가
- 예약 생성 시 기존 PENDING/CONFIRMED 예약과 중복 차단

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #203 