### PR TITLE
feat: 투어 시작·완료에 따른 예약 상태 연동 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -19,6 +19,7 @@ import com.breadbread.course.service.ai.AiCourseAsyncService;
 import com.breadbread.course.service.ai.AiCourseRedisService;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.tour.service.TourRedisService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
@@ -52,6 +53,7 @@ public class CourseService {
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
     private final CourseDrivingRouteSaver courseDrivingRouteSaver;
     private final BakeryImageUrlResolver bakeryImageUrlResolver;
+    private final TourRedisService tourRedisService;
 
     @Transactional(readOnly = true)
     public CourseListResponse search(CourseSearch courseSearch, Pageable pageable, Long userId) {
@@ -631,6 +633,35 @@ public class CourseService {
         if (!new HashSet<>(activeBakeryOrder).equals(currentBakeryIds)) {
             throw new CustomException(ErrorCode.BAKERY_ORDER_COUNT_MISMATCH);
         }
+
+        // 투어 진행 중이면 이미 방문한 빵집 순서는 변경 불가
+        tourRedisService
+                .getTourState(userId)
+                .filter(
+                        state ->
+                                state.getCourseId().equals(courseId)
+                                        && state.getStatus()
+                                                == com.breadbread.tour.redis.TourStatus.IN_PROGRESS)
+                .ifPresent(
+                        state -> {
+                            int visitedCount = state.getCurrentVisitOrder();
+                            if (visitedCount == 0) return;
+
+                            List<Long> visitedOrder =
+                                    courseBakeries.stream()
+                                            .filter(cb -> cb.getVisitOrder() <= visitedCount)
+                                            .sorted(
+                                                    Comparator.comparingInt(
+                                                            CourseBakery::getVisitOrder))
+                                            .map(cb -> cb.getBakery().getId())
+                                            .toList();
+
+                            for (int i = 0; i < visitedOrder.size(); i++) {
+                                if (!activeBakeryOrder.get(i).equals(visitedOrder.get(i))) {
+                                    throw new CustomException(ErrorCode.TOUR_INVALID_VISIT_ORDER);
+                                }
+                            }
+                        });
 
         // visitOrder 업데이트
         Map<Long, CourseBakery> bakeryMap =

--- a/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
+++ b/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
@@ -16,6 +16,7 @@ import com.breadbread.payment.entity.PaymentStatus;
 import com.breadbread.payment.entity.PgProvider;
 import com.breadbread.payment.repository.PaymentRepository;
 import com.breadbread.reservation.entity.Reservation;
+import com.breadbread.reservation.entity.ReservationStatus;
 import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -227,7 +228,9 @@ public class PaymentService {
                             String.valueOf(payment.getReservation().getId())));
         } catch (CustomException e) {
             if (e.getErrorCode() == ErrorCode.PAYMENT_ALREADY_DONE
-                    || e.getErrorCode() == ErrorCode.RESERVATION_ALREADY_CONFIRMED) {
+                    || e.getErrorCode() == ErrorCode.RESERVATION_ALREADY_CONFIRMED
+                    || e.getErrorCode() == ErrorCode.RESERVATION_CONFIRM_FAILED) {
+                // 이미 CONFIRMED 이상 상태(IN_PROGRESS 등)인 경우 멱등 처리
                 return;
             }
             throw e;
@@ -268,8 +271,8 @@ public class PaymentService {
         try {
             payment.markCancelled();
             Reservation reservation = payment.getReservation();
-            if (reservation.getStatus()
-                    == com.breadbread.reservation.entity.ReservationStatus.CONFIRMED) {
+            if (reservation.getStatus() == ReservationStatus.PENDING
+                    || reservation.getStatus() == ReservationStatus.CONFIRMED) {
                 reservation.cancel();
             }
             log.info("[포트원 웹훅] 결제 취소 처리: paymentId={}", paymentId);

--- a/apps/be/src/main/java/com/breadbread/reservation/entity/Reservation.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/entity/Reservation.java
@@ -85,7 +85,8 @@ public class Reservation extends BaseEntity {
 
     public void update(UpdateReservationRequest request) {
         if (this.status == ReservationStatus.CANCELLED
-                || this.status == ReservationStatus.COMPLETED) {
+                || this.status == ReservationStatus.COMPLETED
+                || this.status == ReservationStatus.IN_PROGRESS) {
             throw new CustomException(ErrorCode.RESERVATION_NOT_MODIFIABLE);
         }
         if (request.getDepartureDate() != null) this.departureDate = request.getDepartureDate();
@@ -96,11 +97,27 @@ public class Reservation extends BaseEntity {
         if (request.getHeadCount() != null) this.headCount = request.getHeadCount();
     }
 
+    public void startTour() {
+        if (this.status != ReservationStatus.CONFIRMED) {
+            throw new CustomException(ErrorCode.RESERVATION_NOT_MODIFIABLE);
+        }
+        this.status = ReservationStatus.IN_PROGRESS;
+    }
+
+    public void complete() {
+        if (this.status != ReservationStatus.IN_PROGRESS) {
+            throw new CustomException(ErrorCode.RESERVATION_NOT_MODIFIABLE);
+        }
+        this.status = ReservationStatus.COMPLETED;
+    }
+
+    /** 사용자 요청 취소 — IN_PROGRESS·COMPLETED 상태에서는 불가 */
     public void cancel() {
         if (this.status == ReservationStatus.CANCELLED) {
             throw new CustomException(ErrorCode.RESERVATION_ALREADY_CANCELLED);
         }
-        if (this.status == ReservationStatus.COMPLETED) {
+        if (this.status == ReservationStatus.COMPLETED
+                || this.status == ReservationStatus.IN_PROGRESS) {
             throw new CustomException(ErrorCode.RESERVATION_CANCEL_FAILED);
         }
         this.status = ReservationStatus.CANCELLED;

--- a/apps/be/src/main/java/com/breadbread/reservation/entity/ReservationStatus.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/entity/ReservationStatus.java
@@ -3,6 +3,7 @@ package com.breadbread.reservation.entity;
 public enum ReservationStatus {
     PENDING,
     CONFIRMED,
+    IN_PROGRESS,
     COMPLETED,
     CANCELLED,
 }

--- a/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
@@ -51,9 +51,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query(
             "SELECT r FROM Reservation r "
                     + "JOIN FETCH r.user "
-                    + "WHERE r.departureDate < :today AND r.status = :status")
-    List<Reservation> findExpiredPending(
-            @Param("today") LocalDate today, @Param("status") ReservationStatus status);
+                    + "WHERE r.departureDate < :today AND r.status IN :statuses")
+    List<Reservation> findExpiredByStatuses(
+            @Param("today") LocalDate today,
+            @Param("statuses") Collection<ReservationStatus> statuses);
+
+    Optional<Reservation> findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+            Long userId, Long courseId, LocalDate departureDate, ReservationStatus status);
 
     @Query(
             "SELECT DISTINCT r.departureTime FROM Reservation r "

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationDailyService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationDailyService.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -53,7 +54,8 @@ public class ReservationDailyService {
     public void cancelExpiredPending() {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         List<Reservation> expired =
-                reservationRepository.findExpiredPending(today, ReservationStatus.PENDING);
+                reservationRepository.findExpiredByStatuses(
+                        today, Set.of(ReservationStatus.PENDING));
         if (expired.isEmpty()) return;
 
         log.info("[만료 예약 취소] 대상 수: {}", expired.size());

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationRealTimeService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationRealTimeService.java
@@ -104,7 +104,7 @@ public class ReservationRealTimeService {
     }
 
     private void startTourAtDeparture(Reservation reservation, long minutesUntil) {
-        if (minutesUntil < -2 || minutesUntil > 2) return;
+        if (minutesUntil < -5 || minutesUntil > 5) return;
 
         Long userId = reservation.getUser().getId();
         Long reservationId = reservation.getId();

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
@@ -44,7 +44,10 @@ public class ReservationService {
     private final BakeryImageUrlResolver bakeryImageUrlResolver;
 
     static final Set<ReservationStatus> ACTIVE_STATUSES =
-            Set.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED);
+            Set.of(
+                    ReservationStatus.PENDING,
+                    ReservationStatus.CONFIRMED,
+                    ReservationStatus.IN_PROGRESS);
 
     @Transactional(readOnly = true)
     public List<ReservationSummaryResponse> getMyReservations(

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourRedisService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourRedisService.java
@@ -65,7 +65,6 @@ public class TourRedisService {
 
         if (isCompleted) {
             stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, String.valueOf(userId));
-            log.info("[투어] 완료: userId={}, courseId={}", userId, current.getCourseId());
         }
         return updated;
     }
@@ -104,7 +103,6 @@ public class TourRedisService {
 
         save(userId, completed, Duration.ofHours(1));
         stringRedisTemplate.opsForSet().remove(ACTIVE_SET_KEY, String.valueOf(userId));
-        log.info("[투어] 수동 완료: userId={}, courseId={}", userId, current.getCourseId());
         return completed;
     }
 

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
@@ -5,12 +5,19 @@ import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.reservation.entity.Reservation;
+import com.breadbread.reservation.entity.ReservationStatus;
+import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.tour.dto.TourCurrentResponse;
 import com.breadbread.tour.dto.TourStartResponse;
 import com.breadbread.tour.dto.TourVisitResponse;
 import com.breadbread.tour.redis.TourStateCache;
 import com.breadbread.tour.redis.TourStatus;
+import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,8 +31,10 @@ public class TourService {
     private final TourRedisService tourRedisService;
     private final CourseRepository courseRepository;
     private final CourseBakeryRepository courseBakeryRepository;
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public TourStartResponse startTour(Long userId, UserRole role, Long courseId) {
         if (tourRedisService.hasActiveTour(userId)) {
             throw new CustomException(ErrorCode.TOUR_ALREADY_STARTED);
@@ -49,11 +58,19 @@ public class TourService {
             throw new CustomException(ErrorCode.COURSE_BAKERY_REQUIRED);
         }
 
+        // Redis 먼저 성공해야 예약 상태 전환 (실패 시 DB 롤백으로 상태 보존)
         TourStateCache state = tourRedisService.startTour(userId, course.getId(), totalBakeryCount);
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        reservationRepository
+                .findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        userId, courseId, today, ReservationStatus.CONFIRMED)
+                .ifPresent(Reservation::startTour);
 
         return TourStartResponse.from(state);
     }
 
+    @Transactional
     public TourVisitResponse visitBakery(Long userId, Long courseId, int visitOrder) {
         TourStateCache state =
                 tourRedisService
@@ -75,6 +92,10 @@ public class TourService {
 
         TourStateCache updated = tourRedisService.updateVisitOrder(userId, visitOrder);
 
+        if (updated.getStatus() == TourStatus.COMPLETED) {
+            completeReservationIfExists(userId, courseId);
+        }
+
         log.info(
                 "[투어] 빵집 방문: userId={}, courseId={}, visitOrder={}, remaining={}, status={}",
                 userId,
@@ -93,6 +114,7 @@ public class TourService {
         return TourCurrentResponse.from(state);
     }
 
+    @Transactional
     public TourCurrentResponse completeTour(Long userId, Long courseId) {
         TourStateCache state =
                 tourRedisService
@@ -107,6 +129,36 @@ public class TourService {
             throw new CustomException(ErrorCode.TOUR_ALREADY_COMPLETED);
         }
 
-        return TourCurrentResponse.from(tourRedisService.completeTour(userId));
+        TourCurrentResponse response =
+                TourCurrentResponse.from(tourRedisService.completeTour(userId));
+
+        completeReservationIfExists(userId, courseId);
+
+        return response;
+    }
+
+    private void completeReservationIfExists(Long userId, Long courseId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        reservationRepository
+                .findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        userId, courseId, today, ReservationStatus.IN_PROGRESS)
+                .ifPresent(
+                        reservation -> {
+                            reservation.complete();
+                            User user =
+                                    userRepository
+                                            .findById(userId)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new CustomException(
+                                                                    ErrorCode.USER_NOT_FOUND));
+                            user.incrementUsage();
+                            log.info(
+                                    "[투어 완료] userId={}, courseId={}, usageCount={}, grade={}",
+                                    userId,
+                                    courseId,
+                                    user.getUsageCount(),
+                                    user.getGrade());
+                        });
     }
 }

--- a/apps/be/src/main/java/com/breadbread/user/entity/User.java
+++ b/apps/be/src/main/java/com/breadbread/user/entity/User.java
@@ -77,6 +77,14 @@ public class User extends BaseEntity {
         this.privacyAgreed = privacyAgreed;
     }
 
+    public void incrementUsage() {
+        this.usageCount++;
+        UserGrade nextGrade = this.grade.next();
+        if (nextGrade != null && this.usageCount >= nextGrade.getRequiredCount()) {
+            this.grade = nextGrade;
+        }
+    }
+
     public void updateProfile(UpdateProfileRequest req) {
         if (req.getNickname() != null) this.nickname = req.getNickname();
         if (req.getEmail() != null) this.email = req.getEmail();

--- a/apps/be/src/main/resources/db/migration/V7__add_reservation_status_in_progress.sql
+++ b/apps/be/src/main/resources/db/migration/V7__add_reservation_status_in_progress.sql
@@ -1,0 +1,6 @@
+ALTER TABLE reservation
+    DROP CONSTRAINT IF EXISTS reservation_status_check;
+
+ALTER TABLE reservation
+    ADD CONSTRAINT reservation_status_check
+        CHECK (status IN ('PENDING', 'CONFIRMED', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'));

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -87,6 +87,7 @@ class CourseServiceTest {
     @Mock private DrivingRouteClient drivingRouteClient;
     @Mock private CourseDrivingRouteSaver courseDrivingRouteSaver;
     @Mock private BakeryImageUrlResolver bakeryImageUrlResolver;
+    @Mock private com.breadbread.tour.service.TourRedisService tourRedisService;
 
     @InjectMocks private CourseService courseService;
 

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationDailyServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationDailyServiceTest.java
@@ -17,6 +17,7 @@ import com.breadbread.reservation.entity.ReservationStatus;
 import com.breadbread.reservation.repository.ReservationRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -61,8 +62,8 @@ class ReservationDailyServiceTest {
 
     @Test
     void cancelExpiredPending_만료예약없으면_취소처리없음() {
-        when(reservationRepository.findExpiredPending(
-                        any(LocalDate.class), eq(ReservationStatus.PENDING)))
+        when(reservationRepository.findExpiredByStatuses(
+                        any(LocalDate.class), eq(Set.of(ReservationStatus.PENDING))))
                 .thenReturn(List.of());
 
         reservationDailyService.cancelExpiredPending();
@@ -74,8 +75,8 @@ class ReservationDailyServiceTest {
     void cancelExpiredPending_만료PENDING_cancel호출() {
         Reservation reservation = mock(Reservation.class);
         lenient().when(reservation.getId()).thenReturn(1L);
-        when(reservationRepository.findExpiredPending(
-                        any(LocalDate.class), eq(ReservationStatus.PENDING)))
+        when(reservationRepository.findExpiredByStatuses(
+                        any(LocalDate.class), eq(Set.of(ReservationStatus.PENDING))))
                 .thenReturn(List.of(reservation));
 
         reservationDailyService.cancelExpiredPending();

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
@@ -424,6 +424,40 @@ class ReservationServiceTest {
     }
 
     @Test
+    void updateReservation_throws_whenReservationIsInProgress() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        ReflectionTestUtils.setField(reservation, "status", ReservationStatus.IN_PROGRESS);
+        UpdateReservationRequest request = new UpdateReservationRequest();
+        ReflectionTestUtils.setField(request, "headCount", 4);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+        when(reservationRepository
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                                10L,
+                                reservation.getDepartureDate(),
+                                reservation.getDepartureTime(),
+                                ReservationService.ACTIVE_STATUSES,
+                                1L))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> reservationService.updateReservation(10L, 1L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_NOT_MODIFIABLE);
+    }
+
+    @Test
+    void cancelReservation_throws_whenReservationIsInProgress() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        ReflectionTestUtils.setField(reservation, "status", ReservationStatus.IN_PROGRESS);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.cancelReservation(10L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_CANCEL_FAILED);
+    }
+
+    @Test
     void cancelReservation_throws_whenReservationMissing() {
         when(reservationRepository.findById(1L)).thenReturn(Optional.empty());
 

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
@@ -2,6 +2,8 @@ package com.breadbread.tour.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,6 +15,9 @@ import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.reservation.entity.Reservation;
+import com.breadbread.reservation.entity.ReservationStatus;
+import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.tour.dto.TourCurrentResponse;
 import com.breadbread.tour.dto.TourStartResponse;
 import com.breadbread.tour.dto.TourVisitResponse;
@@ -20,6 +25,8 @@ import com.breadbread.tour.redis.TourStateCache;
 import com.breadbread.tour.redis.TourStatus;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.repository.UserRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -38,6 +45,8 @@ class TourServiceTest {
     @Mock private TourRedisService tourRedisService;
     @Mock private CourseRepository courseRepository;
     @Mock private CourseBakeryRepository courseBakeryRepository;
+    @Mock private ReservationRepository reservationRepository;
+    @Mock private UserRepository userRepository;
 
     // ── startTour ──────────────────────────────────────────────────────────────
 
@@ -101,6 +110,9 @@ class TourServiceTest {
                                 mock(CourseBakery.class),
                                 mock(CourseBakery.class)));
         when(tourRedisService.startTour(1L, 10L, 3)).thenReturn(state);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
+                .thenReturn(Optional.empty());
 
         TourStartResponse response = tourService.startTour(1L, UserRole.ROLE_USER, 10L);
 
@@ -117,6 +129,9 @@ class TourServiceTest {
         when(courseBakeryRepository.findAllByCourseId(10L))
                 .thenReturn(List.of(mock(CourseBakery.class), mock(CourseBakery.class)));
         when(tourRedisService.startTour(5L, 10L, 2)).thenReturn(state);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(5L), eq(10L), any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
+                .thenReturn(Optional.empty());
 
         TourStartResponse response = tourService.startTour(5L, UserRole.ROLE_ADMIN, 10L);
 
@@ -214,12 +229,34 @@ class TourServiceTest {
         when(tourRedisService.getTourState(1L))
                 .thenReturn(Optional.of(tourState(1L, 10L, 3, 2, TourStatus.IN_PROGRESS)));
         when(tourRedisService.updateVisitOrder(1L, 3)).thenReturn(updated);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.IN_PROGRESS)))
+                .thenReturn(Optional.empty());
 
         TourVisitResponse response = tourService.visitBakery(1L, 10L, 3);
 
         assertThat(response.getCurrentVisitOrder()).isEqualTo(3);
         assertThat(response.getRemainingCount()).isEqualTo(0);
         assertThat(response.getStatus()).isEqualTo(TourStatus.COMPLETED);
+    }
+
+    @Test
+    void visitBakery_completes_reservation_and_increments_usage_when_last_bakery() {
+        TourStateCache updated = tourState(1L, 10L, 3, 3, TourStatus.COMPLETED);
+        Reservation reservation = mock(Reservation.class);
+        User user = mock(User.class);
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 2, TourStatus.IN_PROGRESS)));
+        when(tourRedisService.updateVisitOrder(1L, 3)).thenReturn(updated);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.IN_PROGRESS)))
+                .thenReturn(Optional.of(reservation));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        tourService.visitBakery(1L, 10L, 3);
+
+        verify(reservation).complete();
+        verify(user).incrementUsage();
     }
 
     // ── getCurrentTour ─────────────────────────────────────────────────────────
@@ -288,12 +325,35 @@ class TourServiceTest {
         when(tourRedisService.getTourState(1L))
                 .thenReturn(Optional.of(tourState(1L, 10L, 3, 1, TourStatus.IN_PROGRESS)));
         when(tourRedisService.completeTour(1L)).thenReturn(afterComplete);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.IN_PROGRESS)))
+                .thenReturn(Optional.empty());
 
         TourCurrentResponse response = tourService.completeTour(1L, 10L);
 
         assertThat(response.getStatus()).isEqualTo(TourStatus.COMPLETED);
         assertThat(response.getRemainingCount()).isEqualTo(0);
         assertThat(response.getCurrentVisitOrder()).isEqualTo(3);
+    }
+
+    @Test
+    void
+            completeTour_completes_reservation_and_increments_usage_when_in_progress_reservation_exists() {
+        TourStateCache afterComplete = tourState(1L, 10L, 3, 3, TourStatus.COMPLETED);
+        Reservation reservation = mock(Reservation.class);
+        User user = mock(User.class);
+        when(tourRedisService.getTourState(1L))
+                .thenReturn(Optional.of(tourState(1L, 10L, 3, 3, TourStatus.IN_PROGRESS)));
+        when(tourRedisService.completeTour(1L)).thenReturn(afterComplete);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.IN_PROGRESS)))
+                .thenReturn(Optional.of(reservation));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        tourService.completeTour(1L, 10L);
+
+        verify(reservation).complete();
+        verify(user).incrementUsage();
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────
@@ -336,9 +396,5 @@ class TourServiceTest {
         when(course.getUser()).thenReturn(null);
         when(course.getId()).thenReturn(courseId);
         return course;
-    }
-
-    private static <T> T any() {
-        return org.mockito.ArgumentMatchers.any();
     }
 }


### PR DESCRIPTION
## Task
- 투어 시작·완료에 따른 예약 상태 연동 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #209 
