### PR TITLE
feat: 예약 소프트 삭제 도입 및 동시성·중복 실행 방어

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.8.0'
+
+    // ShedLock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.9.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.9.0'
 }
 
 tasks.named('test') {

--- a/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
+++ b/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
@@ -1,6 +1,5 @@
 package com.breadbread;
 
-import java.util.TimeZone;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
+++ b/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
@@ -1,5 +1,7 @@
 package com.breadbread;
 
+import java.util.TimeZone;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -8,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
 public class BreadbreadApplication {
 
     public static void main(String[] args) {

--- a/apps/be/src/main/java/com/breadbread/global/config/ShedLockConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/ShedLockConfig.java
@@ -1,0 +1,16 @@
+package com.breadbread.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -85,6 +85,8 @@ public enum ErrorCode {
     RESERVATION_NOT_MODIFIABLE(HttpStatus.CONFLICT, "E0506", "현재 상태에서는 예약을 변경할 수 없습니다."),
     RESERVATION_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "E0507", "이미 확정된 예약입니다."),
     RESERVATION_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "E0508", "예약 확정이 불가능합니다."),
+    RESERVATION_DELETE_FAILED(HttpStatus.BAD_REQUEST, "E0509", "결제 전 또는 취소된 예약만 삭제할 수 있습니다."),
+    RESERVATION_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "E0510", "이미 삭제된 예약입니다."),
 
     // 결제 E06xx
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E0601", "존재하지 않는 결제 내역입니다."),

--- a/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
+++ b/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
@@ -58,6 +58,9 @@ public class PaymentService {
         if (!reservation.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
+        if (!reservation.isActive()) {
+            throw new CustomException(ErrorCode.RESERVATION_ALREADY_DELETED);
+        }
         String paymentId = UUID.randomUUID().toString();
 
         Payment payment =

--- a/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
@@ -86,4 +86,12 @@ public class ReservationController {
         reservationService.cancelReservation(userDetails.getId(), id);
         return ApiResponse.ok();
     }
+
+    @Operation(summary = "예약 삭제", description = "결제 전(PENDING) 또는 취소된(CANCELLED) 예약만 삭제할 수 있습니다. 삭제된 예약은 목록에서 보이지 않습니다.")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteReservation(
+            @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        reservationService.deleteReservation(userDetails.getId(), id);
+    }
 }

--- a/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/controller/ReservationController.java
@@ -87,7 +87,9 @@ public class ReservationController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "예약 삭제", description = "결제 전(PENDING) 또는 취소된(CANCELLED) 예약만 삭제할 수 있습니다. 삭제된 예약은 목록에서 보이지 않습니다.")
+    @Operation(
+            summary = "예약 삭제",
+            description = "결제 전(PENDING) 또는 취소된(CANCELLED) 예약만 삭제할 수 있습니다. 삭제된 예약은 목록에서 보이지 않습니다.")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteReservation(

--- a/apps/be/src/main/java/com/breadbread/reservation/entity/Reservation.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/entity/Reservation.java
@@ -45,6 +45,8 @@ public class Reservation extends BaseEntity {
 
     private LocalDateTime confirmedAt;
 
+    private boolean active = true;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -122,6 +124,18 @@ public class Reservation extends BaseEntity {
         }
         this.status = ReservationStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
+    }
+
+    /** 소프트 삭제 — PENDING·CANCELLED 상태에서만 허용 */
+    public void deactivate() {
+        if (!this.active) {
+            throw new CustomException(ErrorCode.RESERVATION_ALREADY_DELETED);
+        }
+        if (this.status != ReservationStatus.CANCELLED
+                && this.status != ReservationStatus.PENDING) {
+            throw new CustomException(ErrorCode.RESERVATION_DELETE_FAILED);
+        }
+        this.active = false;
     }
 
     public void confirm() {

--- a/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
@@ -12,18 +12,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    List<Reservation> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
-    List<Reservation> findAllByUserIdAndStatusOrderByCreatedAtDesc(
-            Long userId, ReservationStatus status);
+    List<Reservation> findAllByUserIdAndActiveOrderByCreatedAtDesc(Long userId, boolean active);
 
-    boolean existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
+    List<Reservation> findAllByUserIdAndStatusAndActiveOrderByCreatedAtDesc(
+            Long userId, ReservationStatus status, boolean active);
+
+    boolean existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndActiveTrue(
             Long userId,
             LocalDate departureDate,
             LocalTime departureTime,
             Collection<ReservationStatus> statuses);
 
-    boolean existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+    boolean existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
             Long userId,
             LocalDate departureDate,
             LocalTime departureTime,
@@ -35,7 +36,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                     + "JOIN FETCH r.course c "
                     + "JOIN FETCH c.courseBakeries cb "
                     + "JOIN FETCH cb.bakery "
-                    + "WHERE r.id = :id")
+                    + "WHERE r.id = :id AND r.active = true")
     Optional<Reservation> findWithCourseById(@Param("id") Long id);
 
     @Query(
@@ -44,14 +45,14 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                     + "JOIN FETCH r.course c "
                     + "JOIN FETCH c.courseBakeries cb "
                     + "JOIN FETCH cb.bakery "
-                    + "WHERE r.departureDate = :date AND r.status = :status")
+                    + "WHERE r.departureDate = :date AND r.status = :status AND r.active = true")
     List<Reservation> findTodayConfirmedWithCourse(
             @Param("date") LocalDate date, @Param("status") ReservationStatus status);
 
     @Query(
             "SELECT r FROM Reservation r "
                     + "JOIN FETCH r.user "
-                    + "WHERE r.departureDate < :today AND r.status IN :statuses")
+                    + "WHERE r.departureDate < :today AND r.status IN :statuses AND r.active = true")
     List<Reservation> findExpiredByStatuses(
             @Param("today") LocalDate today,
             @Param("statuses") Collection<ReservationStatus> statuses);
@@ -61,7 +62,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query(
             "SELECT DISTINCT r.departureTime FROM Reservation r "
-                    + "WHERE r.user.id = :userId AND r.departureDate = :date AND r.status IN :statuses")
+                    + "WHERE r.user.id = :userId AND r.departureDate = :date "
+                    + "AND r.status IN :statuses AND r.active = true")
     List<LocalTime> findBookedTimesByUserAndDate(
             @Param("userId") Long userId,
             @Param("date") LocalDate date,

--- a/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationDailyScheduler.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationDailyScheduler.java
@@ -2,6 +2,7 @@ package com.breadbread.reservation.scheduler;
 
 import com.breadbread.reservation.service.ReservationDailyService;
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,10 @@ public class ReservationDailyScheduler {
     private final ReservationDailyService reservationDailyService;
 
     @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(
+            name = "reservationDailyScheduler",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M")
     public void run() {
         reservationDailyService.cancelExpiredPending();
         reservationDailyService.notifyTodayConfirmed();

--- a/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationRealTimeScheduler.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/scheduler/ReservationRealTimeScheduler.java
@@ -2,6 +2,7 @@ package com.breadbread.reservation.scheduler;
 
 import com.breadbread.reservation.service.ReservationRealTimeService;
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,12 +14,20 @@ public class ReservationRealTimeScheduler {
 
     /** 매시간 0분/30분 — 1시간 전 알림 + tourService.startTour 호출 */
     @Scheduled(cron = "0 0,30 * * * *", zone = "Asia/Seoul")
+    @SchedulerLock(
+            name = "reservationRealTimeScheduler_hourly",
+            lockAtMostFor = "PT25M",
+            lockAtLeastFor = "PT1M")
     public void runHourly() {
         reservationRealTimeService.processHourlyEvents();
     }
 
     /** 매시간 20분/50분 — 10분 전 알림 */
     @Scheduled(cron = "0 20,50 * * * *", zone = "Asia/Seoul")
+    @SchedulerLock(
+            name = "reservationRealTimeScheduler_tenMin",
+            lockAtMostFor = "PT15M",
+            lockAtLeastFor = "PT1M")
     public void runTenMin() {
         reservationRealTimeService.processTenMinEvents();
     }

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
@@ -54,9 +54,11 @@ public class ReservationService {
             Long userId, ReservationStatus status) {
         List<Reservation> reservations =
                 status != null
-                        ? reservationRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
-                                userId, status)
-                        : reservationRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+                        ? reservationRepository
+                                .findAllByUserIdAndStatusAndActiveOrderByCreatedAtDesc(
+                                        userId, status, true)
+                        : reservationRepository.findAllByUserIdAndActiveOrderByCreatedAtDesc(
+                                userId, true);
         return reservations.stream().map(ReservationSummaryResponse::from).toList();
     }
 
@@ -87,8 +89,12 @@ public class ReservationService {
         validateDepartureLocation(request.getDeparture(), request.getLat(), request.getLng());
 
         // 같은 출발 일시에 PENDING·CONFIRMED 예약 모두 중복 불가
-        if (reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
-                userId, request.getDepartureDate(), request.getDepartureTime(), ACTIVE_STATUSES)) {
+        if (reservationRepository
+                .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndActiveTrue(
+                        userId,
+                        request.getDepartureDate(),
+                        request.getDepartureTime(),
+                        ACTIVE_STATUSES)) {
             throw new CustomException(ErrorCode.ALREADY_RESERVED);
         }
 
@@ -144,8 +150,9 @@ public class ReservationService {
         validateDepartureLocation(request.getDeparture(), request.getLat(), request.getLng());
 
         // 같은 날짜·시간에 다른 활성 예약 중복 방지
-        if (reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
-                userId, newDate, newTime, ACTIVE_STATUSES, reservationId)) {
+        if (reservationRepository
+                .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
+                        userId, newDate, newTime, ACTIVE_STATUSES, reservationId)) {
             throw new CustomException(ErrorCode.ALREADY_RESERVED);
         }
 
@@ -162,6 +169,17 @@ public class ReservationService {
         validateOwner(reservation, userId);
         reservation.cancel();
         log.info("예약 취소: reservationId={}", reservationId);
+    }
+
+    @Transactional
+    public void deleteReservation(Long userId, Long reservationId) {
+        Reservation reservation =
+                reservationRepository
+                        .findById(reservationId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+        validateOwner(reservation, userId);
+        reservation.deactivate();
+        log.info("예약 삭제: reservationId={}", reservationId);
     }
 
     private void validateOwner(Reservation reservation, Long userId) {

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -119,13 +120,17 @@ public class ReservationService {
                         .user(user)
                         .build();
 
-        Long savedId = reservationRepository.save(reservation).getId();
-        log.info(
-                "예약 생성: reservationId={}, userId={}, courseId={}",
-                savedId,
-                userId,
-                request.getCourseId());
-        return savedId;
+        try {
+            Long savedId = reservationRepository.saveAndFlush(reservation).getId();
+            log.info(
+                    "예약 생성: reservationId={}, userId={}, courseId={}",
+                    savedId,
+                    userId,
+                    request.getCourseId());
+            return savedId;
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.ALREADY_RESERVED);
+        }
     }
 
     @Transactional

--- a/apps/be/src/main/resources/db/migration/V8__add_reservation_active_flag.sql
+++ b/apps/be/src/main/resources/db/migration/V8__add_reservation_active_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reservation
+    ADD COLUMN IF NOT EXISTS active boolean NOT NULL DEFAULT true;

--- a/apps/be/src/main/resources/db/migration/V9__add_reservation_unique_active_slot.sql
+++ b/apps/be/src/main/resources/db/migration/V9__add_reservation_unique_active_slot.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX ux_reservation_user_slot_active
+    ON reservation (user_id, departure_date, departure_time)
+    WHERE active = true AND status IN ('PENDING', 'CONFIRMED', 'IN_PROGRESS');

--- a/apps/be/src/test/java/com/breadbread/payment/service/PaymentServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/payment/service/PaymentServiceTest.java
@@ -113,6 +113,20 @@ class PaymentServiceTest {
     }
 
     @Test
+    void preparePayment_throws_whenReservationAlreadyDeleted() {
+        PreparePaymentRequest request = prepareRequest(1L);
+        Reservation reservation = reservation(1L, user(10L), manualCourse("코스"));
+        reservation.cancel();
+        ReflectionTestUtils.setField(reservation, "active", false);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> paymentService.preparePayment(10L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_ALREADY_DELETED);
+    }
+
+    @Test
     void preparePayment_saves_whenReservationOwned() {
         PreparePaymentRequest request = prepareRequest(1L);
         User owner = user(10L);

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
@@ -207,7 +207,7 @@ class ReservationServiceTest {
         stubNoActiveConflict(request);
         when(courseRepository.findByIdAndActiveTrue(3L)).thenReturn(Optional.of(course));
         when(userRepository.findById(10L)).thenReturn(Optional.of(owner));
-        when(reservationRepository.save(any(Reservation.class)))
+        when(reservationRepository.saveAndFlush(any(Reservation.class)))
                 .thenAnswer(
                         invocation -> {
                             Reservation saved = invocation.getArgument(0);
@@ -219,7 +219,7 @@ class ReservationServiceTest {
 
         assertThat(result).isEqualTo(77L);
         ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
-        verify(reservationRepository).save(captor.capture());
+        verify(reservationRepository).saveAndFlush(captor.capture());
         assertThat(captor.getValue().getDeparture()).isEqualTo("daejeon-station");
         assertThat(captor.getValue().getQuotedAmount()).isEqualTo(12000L);
     }

--- a/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/reservation/service/ReservationServiceTest.java
@@ -69,8 +69,8 @@ class ReservationServiceTest {
     @Test
     void getMyReservations_filtersByStatus_whenProvided() {
         Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
-        when(reservationRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(
-                        10L, ReservationStatus.PENDING))
+        when(reservationRepository.findAllByUserIdAndStatusAndActiveOrderByCreatedAtDesc(
+                        10L, ReservationStatus.PENDING, true))
                 .thenReturn(List.of(reservation));
 
         var result = reservationService.getMyReservations(10L, ReservationStatus.PENDING);
@@ -83,14 +83,14 @@ class ReservationServiceTest {
     @Test
     void getMyReservations_usesUnfilteredQuery_whenStatusIsNull() {
         Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
-        when(reservationRepository.findAllByUserIdOrderByCreatedAtDesc(10L))
+        when(reservationRepository.findAllByUserIdAndActiveOrderByCreatedAtDesc(10L, true))
                 .thenReturn(List.of(reservation));
 
         var result = reservationService.getMyReservations(10L, null);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(1L);
-        verify(reservationRepository).findAllByUserIdOrderByCreatedAtDesc(10L);
+        verify(reservationRepository).findAllByUserIdAndActiveOrderByCreatedAtDesc(10L, true);
     }
 
     @Test
@@ -156,11 +156,12 @@ class ReservationServiceTest {
     @Test
     void createReservation_throws_whenActiveReservationAlreadyExists() {
         CreateReservationRequest request = createReservationRequest(3L);
-        when(reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
-                        eq(10L),
-                        eq(request.getDepartureDate()),
-                        eq(request.getDepartureTime()),
-                        eq(ReservationService.ACTIVE_STATUSES)))
+        when(reservationRepository
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndActiveTrue(
+                                eq(10L),
+                                eq(request.getDepartureDate()),
+                                eq(request.getDepartureTime()),
+                                eq(ReservationService.ACTIVE_STATUSES)))
                 .thenReturn(true);
 
         assertThatThrownBy(() -> reservationService.createReservation(10L, request))
@@ -336,7 +337,7 @@ class ReservationServiceTest {
 
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository
-                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
                                 10L,
                                 UPDATED_DATE,
                                 UPDATED_TIME,
@@ -363,7 +364,7 @@ class ReservationServiceTest {
 
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository
-                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
                                 10L,
                                 UPDATED_DATE,
                                 UPDATED_HALF_HOUR_TIME,
@@ -387,7 +388,7 @@ class ReservationServiceTest {
         ReflectionTestUtils.setField(request, "headCount", 4);
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository
-                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
                                 10L,
                                 reservation.getDepartureDate(),
                                 reservation.getDepartureTime(),
@@ -409,7 +410,7 @@ class ReservationServiceTest {
         ReflectionTestUtils.setField(request, "headCount", 4);
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository
-                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
                                 10L,
                                 reservation.getDepartureDate(),
                                 reservation.getDepartureTime(),
@@ -431,7 +432,7 @@ class ReservationServiceTest {
         ReflectionTestUtils.setField(request, "headCount", 4);
         when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
         when(reservationRepository
-                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNot(
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndIdNotAndActiveTrue(
                                 10L,
                                 reservation.getDepartureDate(),
                                 reservation.getDepartureTime(),
@@ -513,14 +514,82 @@ class ReservationServiceTest {
                 .isEqualTo(ErrorCode.RESERVATION_CANCEL_FAILED);
     }
 
+    @Test
+    void deleteReservation_throws_whenReservationMissing() {
+        when(reservationRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reservationService.deleteReservation(10L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    @Test
+    void deleteReservation_throws_whenRequesterIsNotOwner() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.deleteReservation(99L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void deleteReservation_throws_whenReservationIsConfirmed() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        ReflectionTestUtils.setField(reservation, "status", ReservationStatus.CONFIRMED);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.deleteReservation(10L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_DELETE_FAILED);
+    }
+
+    @Test
+    void deleteReservation_deactivates_whenPendingReservation() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        reservationService.deleteReservation(10L, 1L);
+
+        assertThat(reservation.isActive()).isFalse();
+    }
+
+    @Test
+    void deleteReservation_throws_whenAlreadyDeleted() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        reservation.cancel();
+        ReflectionTestUtils.setField(reservation, "active", false);
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.deleteReservation(10L, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESERVATION_ALREADY_DELETED);
+    }
+
+    @Test
+    void deleteReservation_deactivates_whenCancelledReservation() {
+        Reservation reservation = reservation(1L, user(10L), manualCourse(3L, "course"));
+        reservation.cancel();
+        when(reservationRepository.findById(1L)).thenReturn(Optional.of(reservation));
+
+        reservationService.deleteReservation(10L, 1L);
+
+        assertThat(reservation.isActive()).isFalse();
+    }
+
     // ───────────────────────────── helpers ─────────────────────────────
 
     private void stubNoActiveConflict(CreateReservationRequest request) {
-        when(reservationRepository.existsByUserIdAndDepartureDateAndDepartureTimeAndStatusIn(
-                        eq(10L),
-                        eq(request.getDepartureDate()),
-                        eq(request.getDepartureTime()),
-                        eq(ReservationService.ACTIVE_STATUSES)))
+        when(reservationRepository
+                        .existsByUserIdAndDepartureDateAndDepartureTimeAndStatusInAndActiveTrue(
+                                eq(10L),
+                                eq(request.getDepartureDate()),
+                                eq(request.getDepartureTime()),
+                                eq(ReservationService.ACTIVE_STATUSES)))
                 .thenReturn(false);
     }
 


### PR DESCRIPTION
## Task
- CANCELLED·PENDING 예약 소프트 삭제 도입
- DB partial unique index로 동시 중복 예약 차단
- ShedLock(Redis)으로 멀티 인스턴스 스케줄러 중복 실행 방지

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [x] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #211 
