### PR TITLE
feat: AI 코스 결과를 Redis 임시 저장 후 사용자 요청 시 DB에 저장하도록 변경

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -134,13 +134,18 @@ public class CourseController {
 
     @Operation(
             summary = "AI 코스 저장",
-            description = "미리보기 확인 후 코스를 내 목록에 저장합니다. 저장 후 Redis 임시 데이터는 삭제됩니다.")
+            description =
+                    "미리보기 확인 후 코스를 내 목록에 저장합니다. 저장 후 Redis 임시 데이터는 삭제됩니다."
+                            + " bakeryOrder 미전달 시 AI 추천 순서 그대로 저장됩니다.")
     @PostMapping("/ai/{jobId}/save")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("isAuthenticated()")
     public ApiResponse<Long> saveAiCourse(
-            @PathVariable String jobId, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ApiResponse.ok(courseService.saveAiCourse(jobId, userDetails.getId()));
+            @PathVariable String jobId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody(required = false) ReorderBakeriesRequest reorderRequest) {
+        List<Long> bakeryOrder = reorderRequest != null ? reorderRequest.getBakeryOrder() : null;
+        return ApiResponse.ok(courseService.saveAiCourse(jobId, userDetails.getId(), bakeryOrder));
     }
 
     @Operation(summary = "AI 코스 삭제 (본인 코스만 가능)")

--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -3,6 +3,7 @@ package com.breadbread.course.controller;
 import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.bakery.entity.BreadType;
 import com.breadbread.course.dto.*;
+import com.breadbread.course.dto.ai.AiCoursePreviewResponse;
 import com.breadbread.course.dto.ai.AiCourseRequest;
 import com.breadbread.course.dto.ai.AiJobStatusResponse;
 import com.breadbread.course.service.CourseService;
@@ -112,12 +113,34 @@ public class CourseController {
 
     @Operation(
             summary = "AI 코스 추천 상태 조회",
-            description = "status: PENDING | COMPLETED | FAILED. COMPLETED 시 courseId로 코스를 조회하세요.")
+            description =
+                    "status: PENDING | COMPLETED | FAILED. COMPLETED 시 GET /courses/ai/{jobId}/preview로 결과를 확인한 뒤 POST /courses/ai/{jobId}/save로 저장하세요.")
     @GetMapping("/ai/status/{jobId}")
     @PreAuthorize("isAuthenticated()")
     public ApiResponse<AiJobStatusResponse> getAiJobStatus(
             @PathVariable String jobId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.ok(courseService.getAiJobStatus(jobId, userDetails.getId()));
+    }
+
+    @Operation(
+            summary = "AI 코스 추천 결과 미리보기",
+            description = "추천 완료 후 저장 전에 결과를 확인합니다. 24시간 내에 저장하지 않으면 결과가 만료됩니다.")
+    @GetMapping("/ai/{jobId}/preview")
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponse<AiCoursePreviewResponse> getAiPreview(
+            @PathVariable String jobId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(courseService.getAiPreview(jobId, userDetails.getId()));
+    }
+
+    @Operation(
+            summary = "AI 코스 저장",
+            description = "미리보기 확인 후 코스를 내 목록에 저장합니다. 저장 후 Redis 임시 데이터는 삭제됩니다.")
+    @PostMapping("/ai/{jobId}/save")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponse<Long> saveAiCourse(
+            @PathVariable String jobId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(courseService.saveAiCourse(jobId, userDetails.getId()));
     }
 
     @Operation(summary = "AI 코스 삭제 (본인 코스만 가능)")

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewBakeryResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewBakeryResponse.java
@@ -1,0 +1,33 @@
+package com.breadbread.course.dto.ai;
+
+import com.breadbread.bakery.entity.Bakery;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCoursePreviewBakeryResponse {
+    private Long id;
+    private int order;
+    private String name;
+    private String recommendedBread;
+    private String reason;
+    private String address;
+    private double latitude;
+    private double longitude;
+    private Double rating;
+
+    public static AiCoursePreviewBakeryResponse of(RecommendedBakeryResponse ai, Bakery bakery) {
+        return AiCoursePreviewBakeryResponse.builder()
+                .id(ai.getId())
+                .order(ai.getOrder())
+                .name(bakery.getName())
+                .recommendedBread(ai.getRecommendedBread())
+                .reason(ai.getReason())
+                .address(bakery.getAddress())
+                .latitude(bakery.getLatitude())
+                .longitude(bakery.getLongitude())
+                .rating(bakery.getRating())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewResponse.java
@@ -1,0 +1,35 @@
+package com.breadbread.course.dto.ai;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiCoursePreviewResponse {
+    private String name;
+    private int bakeryCount;
+    private String estimatedTime;
+    private Long estimatedCost;
+    private String theme;
+    private String summary;
+    private String recommendReason;
+    private List<RecommendedBakeryResponse> bakeries;
+
+    public static AiCoursePreviewResponse from(AiCourseWebhookResponse response) {
+        return AiCoursePreviewResponse.builder()
+                .name(response.getName())
+                .bakeryCount(response.getBakeries() != null ? response.getBakeries().size() : 0)
+                .estimatedTime(response.getEstimatedTime())
+                .estimatedCost(response.getEstimatedCost())
+                .theme(response.getTheme())
+                .summary(response.getSummary())
+                .recommendReason(response.getRecommendReason())
+                .bakeries(response.getBakeries())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCoursePreviewResponse.java
@@ -18,18 +18,20 @@ public class AiCoursePreviewResponse {
     private String theme;
     private String summary;
     private String recommendReason;
-    private List<RecommendedBakeryResponse> bakeries;
+    private List<AiCoursePreviewBakeryResponse> bakeries;
 
-    public static AiCoursePreviewResponse from(AiCourseWebhookResponse response) {
+    public static AiCoursePreviewResponse of(
+            AiCourseWebhookResponse response,
+            List<AiCoursePreviewBakeryResponse> enrichedBakeries) {
         return AiCoursePreviewResponse.builder()
                 .name(response.getName())
-                .bakeryCount(response.getBakeries() != null ? response.getBakeries().size() : 0)
+                .bakeryCount(enrichedBakeries.size())
                 .estimatedTime(response.getEstimatedTime())
                 .estimatedCost(response.getEstimatedCost())
                 .theme(response.getTheme())
                 .summary(response.getSummary())
                 .recommendReason(response.getRecommendReason())
-                .bakeries(response.getBakeries())
+                .bakeries(enrichedBakeries)
                 .build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCourseResultCache.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCourseResultCache.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(exclude = "response")
+@ToString(exclude = {"request", "response"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AiCourseResultCache {
     private Long userId;

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCourseResultCache.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiCourseResultCache.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString(exclude = "response")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AiCourseResultCache {
     private Long userId;

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiJobCache.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiJobCache.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AiJobCache {
     private AiJobStatus status;
-    private Long courseId;
     private String errorMessage;
     private Long userId;
 }

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/AiJobStatusResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/AiJobStatusResponse.java
@@ -9,6 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AiJobStatusResponse {
     private AiJobStatus status;
-    private Long courseId;
     private String errorMessage;
 }

--- a/apps/be/src/main/java/com/breadbread/course/repository/RouteRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/RouteRepository.java
@@ -29,6 +29,10 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     List<Route> findByUserId(Long userId);
 
     @Query(
-            "SELECT r FROM Route r JOIN FETCH r.course c WHERE r.user.id = :userId AND c.active = true")
+            "SELECT DISTINCT r FROM Route r "
+                    + "JOIN FETCH r.course c "
+                    + "LEFT JOIN FETCH c.courseBakeries cb "
+                    + "LEFT JOIN FETCH cb.bakery "
+                    + "WHERE r.user.id = :userId AND c.active = true")
     List<Route> findActiveByUserId(@Param("userId") Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -7,6 +7,7 @@ import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.bakery.service.BakeryImageUrlResolver;
 import com.breadbread.course.client.DrivingRouteClient;
 import com.breadbread.course.dto.*;
+import com.breadbread.course.dto.ai.AiCoursePreviewBakeryResponse;
 import com.breadbread.course.dto.ai.AiCoursePreviewResponse;
 import com.breadbread.course.dto.ai.AiCourseRequest;
 import com.breadbread.course.dto.ai.AiCourseResultCache;
@@ -365,16 +366,42 @@ public class CourseService {
                 .orElseThrow(() -> new CustomException(ErrorCode.AI_JOB_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public AiCoursePreviewResponse getAiPreview(String jobId, Long userId) {
         AiCourseResultCache cache =
                 aiCourseResultRedisService
                         .getResult(jobId, userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.AI_RESULT_NOT_FOUND));
-        return AiCoursePreviewResponse.from(cache.getResponse());
+
+        var webhookResponse = cache.getResponse();
+        List<RecommendedBakeryResponse> aiBakeries = webhookResponse.getBakeries();
+
+        // 추천 빵집 ID 목록
+        List<Long> bakeryIds = aiBakeries.stream().map(RecommendedBakeryResponse::getId).toList();
+
+        // DB에서 빵집 정보 일괄 조회 (주소·좌표·평점)
+        Map<Long, Bakery> bakeryMap =
+                bakeryRepository.findAllByIdInAndActiveTrue(bakeryIds).stream()
+                        .collect(Collectors.toMap(Bakery::getId, b -> b));
+
+        // 저장과 동일 기준: DB에 없거나 비활성화된 추천 빵집이 있으면 예외
+        // (프리뷰에서 일부 빵집만 보이다 저장이 실패하는 불일치 방지)
+        if (bakeryMap.size() != bakeryIds.size()) {
+            throw new CustomException(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
+        }
+
+        // AI 순서 기준 정렬 후 DB 정보 병합
+        List<AiCoursePreviewBakeryResponse> enrichedBakeries =
+                aiBakeries.stream()
+                        .sorted(Comparator.comparingInt(RecommendedBakeryResponse::getOrder))
+                        .map(ai -> AiCoursePreviewBakeryResponse.of(ai, bakeryMap.get(ai.getId())))
+                        .toList();
+
+        return AiCoursePreviewResponse.of(webhookResponse, enrichedBakeries);
     }
 
     @Transactional
-    public Long saveAiCourse(String jobId, Long userId) {
+    public Long saveAiCourse(String jobId, Long userId, List<Long> bakeryOrder) {
         // 동시 저장 요청 차단 — SET NX EX 락
         if (!aiCourseResultRedisService.tryAcquireSaveLock(jobId)) {
             throw new CustomException(ErrorCode.AI_COURSE_SAVE_IN_PROGRESS);
@@ -437,20 +464,43 @@ public class CourseService {
 
             Course saved = courseRepository.save(course);
 
-            response.getBakeries().stream()
-                    .sorted(Comparator.comparingInt(RecommendedBakeryResponse::getOrder))
-                    .forEach(
-                            item -> {
-                                CourseBakery cb =
-                                        CourseBakery.builder()
-                                                .bakery(bakeryMap.get(item.getId()))
-                                                .course(saved)
-                                                .visitOrder(item.getOrder())
-                                                .recommendedBread(item.getRecommendedBread())
-                                                .reason(item.getReason())
-                                                .build();
-                                saved.addCourseBakery(cb);
-                            });
+            // 사용자 지정 순서가 있으면 유효성 검사 후 적용, 없으면 AI 추천 순서 사용
+            List<Long> effectiveOrder;
+            if (bakeryOrder != null && !bakeryOrder.isEmpty()) {
+                boolean validOrder =
+                        bakeryOrder.size() == recommendedIds.size()
+                                && new HashSet<>(bakeryOrder).equals(new HashSet<>(recommendedIds));
+                if (!validOrder) {
+                    throw new CustomException(ErrorCode.BAKERY_ORDER_COUNT_MISMATCH);
+                }
+                effectiveOrder = bakeryOrder;
+            } else {
+                effectiveOrder =
+                        response.getBakeries().stream()
+                                .sorted(
+                                        Comparator.comparingInt(
+                                                RecommendedBakeryResponse::getOrder))
+                                .map(RecommendedBakeryResponse::getId)
+                                .toList();
+            }
+
+            Map<Long, RecommendedBakeryResponse> aiMetaMap =
+                    response.getBakeries().stream()
+                            .collect(Collectors.toMap(RecommendedBakeryResponse::getId, r -> r));
+
+            for (int i = 0; i < effectiveOrder.size(); i++) {
+                Long bakeryId = effectiveOrder.get(i);
+                RecommendedBakeryResponse meta = aiMetaMap.get(bakeryId);
+                CourseBakery cb =
+                        CourseBakery.builder()
+                                .bakery(bakeryMap.get(bakeryId))
+                                .course(saved)
+                                .visitOrder(i + 1)
+                                .recommendedBread(meta.getRecommendedBread())
+                                .reason(meta.getReason())
+                                .build();
+                saved.addCourseBakery(cb);
+            }
 
             // 커밋 성공 후 Redis 결과 + 락 정리
             // 트랜잭션 동기화가 활성 상태(정상 프로덕션)이면 afterCommit에 등록,

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -7,8 +7,11 @@ import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.bakery.service.BakeryImageUrlResolver;
 import com.breadbread.course.client.DrivingRouteClient;
 import com.breadbread.course.dto.*;
+import com.breadbread.course.dto.ai.AiCoursePreviewResponse;
 import com.breadbread.course.dto.ai.AiCourseRequest;
+import com.breadbread.course.dto.ai.AiCourseResultCache;
 import com.breadbread.course.dto.ai.AiJobStatusResponse;
+import com.breadbread.course.dto.ai.RecommendedBakeryResponse;
 import com.breadbread.course.entity.*;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
@@ -17,11 +20,14 @@ import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.course.repository.RouteRepository;
 import com.breadbread.course.service.ai.AiCourseAsyncService;
 import com.breadbread.course.service.ai.AiCourseRedisService;
+import com.breadbread.course.service.ai.AiCourseResultRedisService;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.tour.service.TourRedisService;
 import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserPreference;
 import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
 import java.util.*;
 import java.util.concurrent.CompletionException;
@@ -34,6 +40,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -49,6 +57,8 @@ public class CourseService {
     private final RouteRepository routeRepository;
     private final AiCourseAsyncService aiCourseAsyncService;
     private final AiCourseRedisService aiCourseRedisService;
+    private final AiCourseResultRedisService aiCourseResultRedisService;
+    private final UserPreferenceRepository userPreferenceRepository;
     private final DrivingRouteClient drivingRouteClient;
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
     private final CourseDrivingRouteSaver courseDrivingRouteSaver;
@@ -353,6 +363,130 @@ public class CourseService {
         return aiCourseRedisService
                 .findByJobId(jobId, requesterId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AI_JOB_NOT_FOUND));
+    }
+
+    public AiCoursePreviewResponse getAiPreview(String jobId, Long userId) {
+        AiCourseResultCache cache =
+                aiCourseResultRedisService
+                        .getResult(jobId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.AI_RESULT_NOT_FOUND));
+        return AiCoursePreviewResponse.from(cache.getResponse());
+    }
+
+    @Transactional
+    public Long saveAiCourse(String jobId, Long userId) {
+        // 동시 저장 요청 차단 — SET NX EX 락
+        if (!aiCourseResultRedisService.tryAcquireSaveLock(jobId)) {
+            throw new CustomException(ErrorCode.AI_COURSE_SAVE_IN_PROGRESS);
+        }
+        try {
+            // 삭제는 커밋 후 수행 — DB 저장 실패 시 결과가 유실되지 않도록 보호
+            AiCourseResultCache cache =
+                    aiCourseResultRedisService
+                            .getResult(jobId, userId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.AI_RESULT_NOT_FOUND));
+
+            var request = cache.getRequest();
+            var response = cache.getResponse();
+
+            User user =
+                    userRepository
+                            .findById(userId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+            UserPreference userPreference =
+                    userPreferenceRepository
+                            .findByUserId(userId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.PREFERENCE_NOT_FOUND));
+
+            List<Long> recommendedIds =
+                    response.getBakeries().stream().map(RecommendedBakeryResponse::getId).toList();
+            Map<Long, Bakery> bakeryMap =
+                    bakeryRepository.findAllByIdInAndActiveTrue(recommendedIds).stream()
+                            .collect(Collectors.toMap(Bakery::getId, b -> b));
+
+            if (bakeryMap.size() != recommendedIds.size()) {
+                throw new CustomException(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
+            }
+
+            AiCourseInfo aiCourseInfo =
+                    AiCourseInfo.builder()
+                            .travelType(request.getTravelType())
+                            .budgetRange(request.getBudgetRange())
+                            .minimizeRoute(request.isMinimizeRoute())
+                            .latitude(request.getLatitude())
+                            .longitude(request.getLongitude())
+                            .waitingPreference(request.isWaitingPreference())
+                            .drinkPreference(request.isDrinkPreference())
+                            .bakeryCount(request.getBakeryCount())
+                            .flexibilityLevel(request.getFlexibilityLevel())
+                            .recommendReason(response.getRecommendReason())
+                            .build();
+
+            Course course =
+                    Course.createAi(
+                            response.getName(),
+                            user,
+                            userPreference,
+                            aiCourseInfo,
+                            new HashSet<>(request.getBreadTypes()));
+            course.updateAiResult(
+                    response.getEstimatedCost(),
+                    response.getEstimatedTime(),
+                    response.getTheme(),
+                    response.getSummary());
+
+            Course saved = courseRepository.save(course);
+
+            response.getBakeries().stream()
+                    .sorted(Comparator.comparingInt(RecommendedBakeryResponse::getOrder))
+                    .forEach(
+                            item -> {
+                                CourseBakery cb =
+                                        CourseBakery.builder()
+                                                .bakery(bakeryMap.get(item.getId()))
+                                                .course(saved)
+                                                .visitOrder(item.getOrder())
+                                                .recommendedBread(item.getRecommendedBread())
+                                                .reason(item.getReason())
+                                                .build();
+                                saved.addCourseBakery(cb);
+                            });
+
+            // 커밋 성공 후 Redis 결과 + 락 정리
+            // 트랜잭션 동기화가 활성 상태(정상 프로덕션)이면 afterCommit에 등록,
+            // 비활성(단위 테스트 등)이면 즉시 정리
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.registerSynchronization(
+                        new TransactionSynchronization() {
+                            @Override
+                            public void afterCommit() {
+                                aiCourseResultRedisService.deleteResult(jobId);
+                                aiCourseResultRedisService.releaseSaveLock(jobId);
+                                aiCourseRedisService.deleteJob(jobId);
+                                log.info(
+                                        "[AI 코스 저장] Redis 정리 완료: jobId={}, courseId={}",
+                                        jobId,
+                                        saved.getId());
+                            }
+                        });
+            } else {
+                aiCourseResultRedisService.deleteResult(jobId);
+                aiCourseResultRedisService.releaseSaveLock(jobId);
+                aiCourseRedisService.deleteJob(jobId);
+            }
+
+            log.info(
+                    "[AI 코스 저장] 완료: jobId={}, courseId={}, userId={}",
+                    jobId,
+                    saved.getId(),
+                    userId);
+            return saved.getId();
+
+        } catch (Exception e) {
+            // DB 저장 실패 시 락 즉시 해제 — 재시도 허용
+            aiCourseResultRedisService.releaseSaveLock(jobId);
+            throw e;
+        }
     }
 
     @Transactional

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseAsyncService.java
@@ -11,19 +11,17 @@ import com.breadbread.course.client.AiWebhookClient;
 import com.breadbread.course.dto.ai.AiCourseRequest;
 import com.breadbread.course.dto.ai.AiCourseWebhookRequest;
 import com.breadbread.course.dto.ai.AiCourseWebhookResponse;
-import com.breadbread.course.dto.ai.RecommendedBakeryResponse;
-import com.breadbread.course.entity.*;
-import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.util.GeoDistance;
 import com.breadbread.notification.service.FcmService;
 import com.breadbread.user.dto.PreferenceResponse;
-import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserPreference;
 import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -45,8 +43,8 @@ public class AiCourseAsyncService {
     private final BreadRepository breadRepository;
     private final CrowdTimeRepository crowdTimeRepository;
     private final AiWebhookClient aiWebhookClient;
-    private final CourseRepository courseRepository;
     private final AiCourseRedisService aiCourseRedisService;
+    private final AiCourseResultRedisService aiCourseResultRedisService;
     private final TransactionTemplate transactionTemplate;
     private final FcmService fcmService;
 
@@ -91,7 +89,6 @@ public class AiCourseAsyncService {
                                                         Collectors.groupingBy(
                                                                 ct -> ct.getBakery().getId()));
 
-                                // BakeryAiResponse.from() 내부의 모든 lazy 필드 접근이 트랜잭션 안에서 일어남
                                 List<BakeryAiResponse> bakeryAiResponses =
                                         candidateBakeries.stream()
                                                 .map(
@@ -128,105 +125,23 @@ public class AiCourseAsyncService {
                 return CompletableFuture.completedFuture(null);
             }
 
-            // 3. 쓰기 트랜잭션: DB 저장 — 실패 시 롤백 후 예외 전파
-            Long courseId =
-                    transactionTemplate.execute(
-                            status -> {
-                                User user =
-                                        userRepository
-                                                .findById(userId)
-                                                .orElseThrow(
-                                                        () ->
-                                                                new CustomException(
-                                                                        ErrorCode.USER_NOT_FOUND));
-                                UserPreference userPreference =
-                                        userPreferenceRepository
-                                                .findByUserId(userId)
-                                                .orElseThrow(
-                                                        () ->
-                                                                new CustomException(
-                                                                        ErrorCode
-                                                                                .PREFERENCE_NOT_FOUND));
+            // 3. AI 응답을 Redis에 임시 저장 (TTL 24시간)
+            aiCourseResultRedisService.saveResult(jobId, userId, request, response);
 
-                                List<Long> recommendedIds =
-                                        response.getBakeries().stream()
-                                                .map(RecommendedBakeryResponse::getId)
-                                                .toList();
-                                Map<Long, Bakery> bakeryMap =
-                                        bakeryRepository
-                                                .findAllByIdInAndActiveTrue(recommendedIds)
-                                                .stream()
-                                                .collect(Collectors.toMap(Bakery::getId, b -> b));
+            // 4. Redis 상태 COMPLETED로 업데이트
+            aiCourseRedisService.saveCompleted(jobId);
+            log.info("[AI 코스 생성] 완료 (Redis 임시 저장): jobId={}", jobId);
 
-                                if (bakeryMap.size() != recommendedIds.size()) {
-                                    log.error("[AI 코스 생성] DB에 없는 빵집 ID 포함 jobId={}", jobId);
-                                    throw new CustomException(
-                                            ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
-                                }
-
-                                AiCourseInfo aiCourseInfo =
-                                        AiCourseInfo.builder()
-                                                .travelType(request.getTravelType())
-                                                .budgetRange(request.getBudgetRange())
-                                                .minimizeRoute(request.isMinimizeRoute())
-                                                .latitude(request.getLatitude())
-                                                .longitude(request.getLongitude())
-                                                .waitingPreference(request.isWaitingPreference())
-                                                .drinkPreference(request.isDrinkPreference())
-                                                .bakeryCount(request.getBakeryCount())
-                                                .flexibilityLevel(request.getFlexibilityLevel())
-                                                .recommendReason(response.getRecommendReason())
-                                                .build();
-
-                                Course course =
-                                        Course.createAi(
-                                                response.getName(),
-                                                user,
-                                                userPreference,
-                                                aiCourseInfo,
-                                                new HashSet<>(request.getBreadTypes()));
-                                course.updateAiResult(
-                                        response.getEstimatedCost(),
-                                        response.getEstimatedTime(),
-                                        response.getTheme(),
-                                        response.getSummary());
-
-                                Course saved = courseRepository.save(course);
-
-                                response.getBakeries().stream()
-                                        .sorted(
-                                                Comparator.comparingInt(
-                                                        RecommendedBakeryResponse::getOrder))
-                                        .forEach(
-                                                item -> {
-                                                    CourseBakery cb =
-                                                            CourseBakery.builder()
-                                                                    .bakery(
-                                                                            bakeryMap.get(
-                                                                                    item.getId()))
-                                                                    .course(saved)
-                                                                    .visitOrder(item.getOrder())
-                                                                    .recommendedBread(
-                                                                            item
-                                                                                    .getRecommendedBread())
-                                                                    .reason(item.getReason())
-                                                                    .build();
-                                                    saved.addCourseBakery(cb);
-                                                });
-
-                                return saved.getId();
-                            });
-
-            // 4. Redis 업데이트 (트랜잭션 밖)
-            aiCourseRedisService.saveCompleted(jobId, courseId);
-            log.info("[AI 코스 생성] 완료: jobId={}, courseId={}", jobId, courseId);
-
-            // 5. FCM 알림 (트랜잭션 밖, 비동기)
-            fcmService.sendToUser(
-                    userId,
-                    "코스 생성 완료 ✨",
-                    response.getName() + " 코스가 완성됐습니다",
-                    Map.of("type", "AI_COURSE", "courseId", String.valueOf(courseId)));
+            // 5. FCM 알림 (실패해도 AI 작업 결과에 영향 없음)
+            try {
+                fcmService.sendToUser(
+                        userId,
+                        "AI 코스 추천 완료 ✨",
+                        response.getName() + " 코스 추천이 완료됐습니다. 확인하고 저장해보세요!",
+                        Map.of("type", "AI_COURSE_READY", "jobId", jobId));
+            } catch (Exception fcmEx) {
+                log.warn("[AI 코스 생성] FCM 알림 실패 (작업은 정상 완료): jobId={}", jobId, fcmEx);
+            }
 
         } catch (CustomException e) {
             log.error("[AI 코스 생성] 실패 jobId={}", jobId, e);
@@ -243,7 +158,6 @@ public class AiCourseAsyncService {
             List<Bakery> bakeries, AiCourseRequest request) {
         double departureLat = request.getLatitude();
         double departureLng = request.getLongitude();
-
         List<Bakery> sorted =
                 bakeries.stream()
                         .filter(
@@ -260,7 +174,6 @@ public class AiCourseAsyncService {
                                                         bakery.getLongitude())))
                         .limit(AI_BAKERY_CANDIDATE_LIMIT)
                         .toList();
-
         return sorted.isEmpty() ? bakeries : sorted;
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRedisService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRedisService.java
@@ -30,13 +30,12 @@ public class AiCourseRedisService {
         save(jobId, AiJobCache.builder().status(AiJobStatus.PENDING).userId(userId).build());
     }
 
-    public void saveCompleted(String jobId, Long courseId) {
+    public void saveCompleted(String jobId) {
         AiJobCache current = findCacheByJobId(jobId).orElse(null);
         save(
                 jobId,
                 AiJobCache.builder()
                         .status(AiJobStatus.COMPLETED)
-                        .courseId(courseId)
                         .userId(current != null ? current.getUserId() : null)
                         .build());
     }
@@ -61,10 +60,12 @@ public class AiCourseRedisService {
                                 throw new CustomException(ErrorCode.FORBIDDEN);
                             }
                             return new AiJobStatusResponse(
-                                    cache.getStatus(),
-                                    cache.getCourseId(),
-                                    cache.getErrorMessage());
+                                    cache.getStatus(), cache.getErrorMessage());
                         });
+    }
+
+    public void deleteJob(String jobId) {
+        stringRedisTemplate.delete(JOB_PREFIX + jobId);
     }
 
     private Optional<AiJobCache> findCacheByJobId(String jobId) {

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseResultRedisService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseResultRedisService.java
@@ -1,0 +1,82 @@
+package com.breadbread.course.service.ai;
+
+import com.breadbread.course.dto.ai.AiCourseRequest;
+import com.breadbread.course.dto.ai.AiCourseResultCache;
+import com.breadbread.course.dto.ai.AiCourseWebhookResponse;
+import com.breadbread.global.config.AiProperties;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiCourseResultRedisService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final AiProperties aiProperties;
+
+    private static final String RESULT_PREFIX = "ai:result:";
+
+    public void saveResult(
+            String jobId, Long userId, AiCourseRequest request, AiCourseWebhookResponse response) {
+        AiCourseResultCache cache =
+                AiCourseResultCache.builder()
+                        .userId(userId)
+                        .request(request)
+                        .response(response)
+                        .build();
+        try {
+            stringRedisTemplate
+                    .opsForValue()
+                    .set(
+                            RESULT_PREFIX + jobId,
+                            objectMapper.writeValueAsString(cache),
+                            Duration.ofHours(aiProperties.getJobTtlHours()));
+        } catch (JsonProcessingException e) {
+            log.error("AI 결과 Redis 직렬화 실패 jobId={}", jobId, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public Optional<AiCourseResultCache> getResult(String jobId, Long requesterId) {
+        String json = stringRedisTemplate.opsForValue().get(RESULT_PREFIX + jobId);
+        if (json == null) return Optional.empty();
+        try {
+            AiCourseResultCache cache = objectMapper.readValue(json, AiCourseResultCache.class);
+            if (!cache.getUserId().equals(requesterId)) {
+                throw new CustomException(ErrorCode.FORBIDDEN);
+            }
+            return Optional.of(cache);
+        } catch (JsonProcessingException e) {
+            log.error("AI 결과 Redis 역직렬화 실패 jobId={}", jobId, e);
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void deleteResult(String jobId) {
+        stringRedisTemplate.delete(RESULT_PREFIX + jobId);
+    }
+
+    /** 저장 진행 중 락을 SET NX EX로 획득한다. 이미 다른 요청이 저장 중이면 false를 반환해 중복 저장을 방지한다. */
+    public boolean tryAcquireSaveLock(String jobId) {
+        Boolean acquired =
+                stringRedisTemplate
+                        .opsForValue()
+                        .setIfAbsent(RESULT_PREFIX + jobId + ":saving", "1", Duration.ofMinutes(5));
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    /** 저장 락을 해제한다. DB 실패 시 즉시 해제해 재시도를 허용한다. */
+    public void releaseSaveLock(String jobId) {
+        stringRedisTemplate.delete(RESULT_PREFIX + jobId + ":saving");
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
     ROUTE_TOO_MANY_WAYPOINTS(
             HttpStatus.UNPROCESSABLE_ENTITY, "E0422", "경로에 포함할 수 있는 최대 빵집 수를 초과했습니다."),
     AI_INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "E0423", "유효하지 않은 API 키입니다."),
+    AI_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "E0424", "AI 추천 결과가 만료되었거나 존재하지 않습니다."),
+    AI_COURSE_SAVE_IN_PROGRESS(
+            HttpStatus.CONFLICT, "E0425", "AI 코스 저장이 이미 진행 중입니다. 잠시 후 다시 시도해주세요."),
 
     // 예약 E05xx
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "E0501", "존재하지 않는 예약입니다."),

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -127,7 +127,7 @@ ai:
   chat-webhook-url: ${AI_CHAT_WEBHOOK_URL}
   congestion-webhook-url: ${AI_CONGESTION_WEBHOOK_URL}
   webhook-timeout-seconds: ${AI_WEBHOOK_TIMEOUT_SECONDS:90}
-  job-ttl-hours: ${AI_JOB_TTL_HOURS:1}
+  job-ttl-hours: ${AI_JOB_TTL_HOURS:24}
   api-key: ${AI_API_KEY}
 
 portone:

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -28,9 +28,13 @@ import com.breadbread.course.dto.ReorderBakeriesResponse;
 import com.breadbread.course.dto.RouteResponse;
 import com.breadbread.course.dto.RouteResult;
 import com.breadbread.course.dto.UpdateCourseRequest;
+import com.breadbread.course.dto.ai.AiCoursePreviewResponse;
 import com.breadbread.course.dto.ai.AiCourseRequest;
+import com.breadbread.course.dto.ai.AiCourseResultCache;
+import com.breadbread.course.dto.ai.AiCourseWebhookResponse;
 import com.breadbread.course.dto.ai.AiJobStatus;
 import com.breadbread.course.dto.ai.AiJobStatusResponse;
+import com.breadbread.course.dto.ai.RecommendedBakeryResponse;
 import com.breadbread.course.entity.AiCourseInfo;
 import com.breadbread.course.entity.BudgetRange;
 import com.breadbread.course.entity.Course;
@@ -48,10 +52,14 @@ import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.course.repository.RouteRepository;
 import com.breadbread.course.service.ai.AiCourseAsyncService;
 import com.breadbread.course.service.ai.AiCourseRedisService;
+import com.breadbread.course.service.ai.AiCourseResultRedisService;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserPreference;
 import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.entity.WaitingTolerance;
+import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,6 +92,8 @@ class CourseServiceTest {
     @Mock private CourseDrivingRouteRepository courseDrivingRouteRepository;
     @Mock private AiCourseAsyncService aiCourseAsyncService;
     @Mock private AiCourseRedisService aiCourseRedisService;
+    @Mock private AiCourseResultRedisService aiCourseResultRedisService;
+    @Mock private UserPreferenceRepository userPreferenceRepository;
     @Mock private DrivingRouteClient drivingRouteClient;
     @Mock private CourseDrivingRouteSaver courseDrivingRouteSaver;
     @Mock private BakeryImageUrlResolver bakeryImageUrlResolver;
@@ -407,7 +417,7 @@ class CourseServiceTest {
 
     @Test
     void getAiJobStatus_returns_cached_when_job_exists() {
-        AiJobStatusResponse expected = new AiJobStatusResponse(AiJobStatus.COMPLETED, 9L, null);
+        AiJobStatusResponse expected = new AiJobStatusResponse(AiJobStatus.COMPLETED, null);
         when(aiCourseRedisService.findByJobId("job-2", 1L)).thenReturn(Optional.of(expected));
 
         assertThat(courseService.getAiJobStatus("job-2", 1L)).isSameAs(expected);
@@ -1034,6 +1044,122 @@ class CourseServiceTest {
 
     // ── updateManual 추가 케이스 ─────────────────────────────────────────
 
+    // ── getAiPreview ─────────────────────────────────────────────────────
+
+    @Test
+    void getAiPreview_throws_whenResultNotFound() {
+        when(aiCourseResultRedisService.getResult("job-1", 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> courseService.getAiPreview("job-1", 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    void getAiPreview_returns_preview_whenResultExists() {
+        AiCourseWebhookResponse webhookResponse = webhookResponse(10L);
+        AiCourseResultCache cache =
+                AiCourseResultCache.builder()
+                        .userId(1L)
+                        .request(aiRequest())
+                        .response(webhookResponse)
+                        .build();
+        when(aiCourseResultRedisService.getResult("job-2", 1L)).thenReturn(Optional.of(cache));
+
+        AiCoursePreviewResponse preview = courseService.getAiPreview("job-2", 1L);
+
+        assertThat(preview.getName()).isEqualTo("ai-course-name");
+        assertThat(preview.getBakeryCount()).isEqualTo(1);
+        assertThat(preview.getBakeries()).hasSize(1);
+    }
+
+    // ── saveAiCourse ─────────────────────────────────────────────────────
+
+    @Test
+    void saveAiCourse_throws_whenLockAlreadyHeld() {
+        // 동시 요청 — 두 번째 요청은 락 획득 실패 → 409
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-dup")).thenReturn(false);
+
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-dup", 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_COURSE_SAVE_IN_PROGRESS);
+    }
+
+    @Test
+    void saveAiCourse_throws_whenResultNotFound() {
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-gone")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-gone", 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-gone", 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    void saveAiCourse_throws_whenRequesterIsNotOwner() {
+        // 비소유자(userId=99)가 호출하면 AiCourseResultRedisService에서 FORBIDDEN을 던진다.
+        // Redis 키는 삭제되지 않아 원소유자(userId=1)의 결과가 보존된다.
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-other")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-other", 99L))
+                .thenThrow(new CustomException(ErrorCode.FORBIDDEN));
+
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-other", 99L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void saveAiCourse_throws_whenRecommendedBakeryMissing() {
+        AiCourseResultCache cache = resultCache(1L, 10L);
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-3")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-3", 1L)).thenReturn(Optional.of(cache));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(userPreferenceRepository.findByUserId(1L))
+                .thenReturn(Optional.of(preference(user(1L))));
+        // 추천 빵집 ID가 DB에 없음 → DB 저장 실패, Redis 결과는 보존됨
+        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(10L))).thenReturn(List.of());
+
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-3", 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
+
+        verify(aiCourseResultRedisService, never()).deleteResult(any());
+    }
+
+    @Test
+    void saveAiCourse_saves_and_returns_courseId() {
+        Bakery bakery = bakery(10L, "맛집");
+        AiCourseResultCache cache = resultCache(1L, 10L);
+
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-4")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-4", 1L)).thenReturn(Optional.of(cache));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(userPreferenceRepository.findByUserId(1L))
+                .thenReturn(Optional.of(preference(user(1L))));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(10L))).thenReturn(List.of(bakery));
+        when(courseRepository.save(any(Course.class)))
+                .thenAnswer(
+                        inv -> {
+                            Course c = inv.getArgument(0);
+                            ReflectionTestUtils.setField(c, "id", 99L);
+                            return c;
+                        });
+
+        Long courseId = courseService.saveAiCourse("job-4", 1L);
+
+        assertThat(courseId).isEqualTo(99L);
+        verify(courseRepository).save(any(Course.class));
+        // 단위 테스트는 트랜잭션 동기화 비활성 → afterCommit 없이 즉시 정리됨
+        verify(aiCourseResultRedisService).deleteResult("job-4");
+        verify(aiCourseResultRedisService).releaseSaveLock("job-4");
+        verify(aiCourseRedisService).deleteJob("job-4");
+    }
+
     @Test
     void updateManual_doesNotInvalidateCache_whenBakeriesNotChanged() {
         Course course = manualCourse(1L, "이름");
@@ -1148,6 +1274,57 @@ class CourseServiceTest {
                         .build();
         ReflectionTestUtils.setField(b, "id", id);
         return b;
+    }
+
+    private static AiCourseRequest aiRequest() {
+        AiCourseRequest req = new AiCourseRequest();
+        ReflectionTestUtils.setField(req, "travelType", TravelType.ALONE);
+        ReflectionTestUtils.setField(req, "budgetRange", BudgetRange.ANY);
+        ReflectionTestUtils.setField(req, "minimizeRoute", false);
+        ReflectionTestUtils.setField(req, "breadTypes", List.of(BreadType.BREAD));
+        ReflectionTestUtils.setField(req, "latitude", 36.0);
+        ReflectionTestUtils.setField(req, "longitude", 127.0);
+        ReflectionTestUtils.setField(req, "waitingPreference", false);
+        ReflectionTestUtils.setField(req, "drinkPreference", false);
+        ReflectionTestUtils.setField(req, "bakeryCount", 2);
+        ReflectionTestUtils.setField(req, "flexibilityLevel", FlexibilityLevel.ACTIVE);
+        return req;
+    }
+
+    private static AiCourseWebhookResponse webhookResponse(long bakeryId) {
+        RecommendedBakeryResponse rb = new RecommendedBakeryResponse();
+        ReflectionTestUtils.setField(rb, "id", bakeryId);
+        ReflectionTestUtils.setField(rb, "order", 1);
+        ReflectionTestUtils.setField(rb, "recommendedBread", "소금빵");
+        ReflectionTestUtils.setField(rb, "reason", "맛있음");
+
+        AiCourseWebhookResponse res = new AiCourseWebhookResponse();
+        ReflectionTestUtils.setField(res, "name", "ai-course-name");
+        ReflectionTestUtils.setField(res, "theme", "테마");
+        ReflectionTestUtils.setField(res, "estimatedCost", 8000L);
+        ReflectionTestUtils.setField(res, "estimatedTime", "2h");
+        ReflectionTestUtils.setField(res, "summary", "요약");
+        ReflectionTestUtils.setField(res, "recommendReason", "추천");
+        ReflectionTestUtils.setField(res, "bakeries", List.of(rb));
+        return res;
+    }
+
+    private static AiCourseResultCache resultCache(long userId, long bakeryId) {
+        return AiCourseResultCache.builder()
+                .userId(userId)
+                .request(aiRequest())
+                .response(webhookResponse(bakeryId))
+                .build();
+    }
+
+    private static UserPreference preference(User user) {
+        return UserPreference.builder()
+                .bakeryTypes(List.of(com.breadbread.bakery.entity.BakeryType.CLASSIC))
+                .bakeryPersonalities(List.of())
+                .bakeryUseTypes(List.of())
+                .waitingTolerance(WaitingTolerance.NO_WAIT)
+                .user(user)
+                .build();
     }
 
     private static ReorderBakeriesRequest reorderRequest(List<Long> bakeryOrder) {

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -1046,42 +1046,58 @@ class CourseServiceTest {
 
     // ── getAiPreview ─────────────────────────────────────────────────────
 
+    // ── getAiPreview ──────────────────────────────────────────────────────
+
     @Test
     void getAiPreview_throws_whenResultNotFound() {
-        when(aiCourseResultRedisService.getResult("job-1", 1L)).thenReturn(Optional.empty());
+        when(aiCourseResultRedisService.getResult("job-p1", 1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseService.getAiPreview("job-1", 1L))
+        assertThatThrownBy(() -> courseService.getAiPreview("job-p1", 1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_RESULT_NOT_FOUND);
     }
 
     @Test
-    void getAiPreview_returns_preview_whenResultExists() {
-        AiCourseWebhookResponse webhookResponse = webhookResponse(10L);
-        AiCourseResultCache cache =
-                AiCourseResultCache.builder()
-                        .userId(1L)
-                        .request(aiRequest())
-                        .response(webhookResponse)
-                        .build();
-        when(aiCourseResultRedisService.getResult("job-2", 1L)).thenReturn(Optional.of(cache));
+    void getAiPreview_throws_whenRecommendedBakeryMissing() {
+        // 프리뷰와 저장의 불일치 방지 — 추천 빵집이 DB에 없으면 프리뷰도 예외
+        AiCourseResultCache cache = resultCache(1L, 10L);
+        when(aiCourseResultRedisService.getResult("job-p2", 1L)).thenReturn(Optional.of(cache));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList())).thenReturn(List.of());
 
-        AiCoursePreviewResponse preview = courseService.getAiPreview("job-2", 1L);
+        assertThatThrownBy(() -> courseService.getAiPreview("job-p2", 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
+    }
+
+    @Test
+    void getAiPreview_returns_enriched_preview() {
+        Bakery bakery = bakery(10L, "맛집");
+        AiCourseResultCache cache = resultCache(1L, 10L);
+        when(aiCourseResultRedisService.getResult("job-p3", 1L)).thenReturn(Optional.of(cache));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList())).thenReturn(List.of(bakery));
+
+        AiCoursePreviewResponse preview = courseService.getAiPreview("job-p3", 1L);
 
         assertThat(preview.getName()).isEqualTo("ai-course-name");
         assertThat(preview.getBakeryCount()).isEqualTo(1);
         assertThat(preview.getBakeries()).hasSize(1);
+
+        var b = preview.getBakeries().get(0);
+        assertThat(b.getId()).isEqualTo(10L);
+        assertThat(b.getName()).isEqualTo("맛집"); // DB 이름 사용
+        assertThat(b.getAddress()).isEqualTo("addr");
+        assertThat(b.getRating()).isEqualTo(4.0);
     }
 
-    // ── saveAiCourse ─────────────────────────────────────────────────────
+    // ── saveAiCourse ──────────────────────────────────────────────────────
 
     @Test
     void saveAiCourse_throws_whenLockAlreadyHeld() {
-        // 동시 요청 — 두 번째 요청은 락 획득 실패 → 409
-        when(aiCourseResultRedisService.tryAcquireSaveLock("job-dup")).thenReturn(false);
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s1")).thenReturn(false);
 
-        assertThatThrownBy(() -> courseService.saveAiCourse("job-dup", 1L))
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-s1", 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_COURSE_SAVE_IN_PROGRESS);
@@ -1089,10 +1105,10 @@ class CourseServiceTest {
 
     @Test
     void saveAiCourse_throws_whenResultNotFound() {
-        when(aiCourseResultRedisService.tryAcquireSaveLock("job-gone")).thenReturn(true);
-        when(aiCourseResultRedisService.getResult("job-gone", 1L)).thenReturn(Optional.empty());
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s2")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s2", 1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseService.saveAiCourse("job-gone", 1L))
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-s2", 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_RESULT_NOT_FOUND);
@@ -1100,13 +1116,12 @@ class CourseServiceTest {
 
     @Test
     void saveAiCourse_throws_whenRequesterIsNotOwner() {
-        // 비소유자(userId=99)가 호출하면 AiCourseResultRedisService에서 FORBIDDEN을 던진다.
-        // Redis 키는 삭제되지 않아 원소유자(userId=1)의 결과가 보존된다.
-        when(aiCourseResultRedisService.tryAcquireSaveLock("job-other")).thenReturn(true);
-        when(aiCourseResultRedisService.getResult("job-other", 99L))
+        // 비소유자 호출 시 FORBIDDEN — Redis 키 보존
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s3")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s3", 99L))
                 .thenThrow(new CustomException(ErrorCode.FORBIDDEN));
 
-        assertThatThrownBy(() -> courseService.saveAiCourse("job-other", 99L))
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-s3", 99L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN);
@@ -1114,16 +1129,16 @@ class CourseServiceTest {
 
     @Test
     void saveAiCourse_throws_whenRecommendedBakeryMissing() {
+        // 추천 빵집이 DB에 없으면 예외 — Redis 결과는 삭제되지 않음
         AiCourseResultCache cache = resultCache(1L, 10L);
-        when(aiCourseResultRedisService.tryAcquireSaveLock("job-3")).thenReturn(true);
-        when(aiCourseResultRedisService.getResult("job-3", 1L)).thenReturn(Optional.of(cache));
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s4")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s4", 1L)).thenReturn(Optional.of(cache));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
         when(userPreferenceRepository.findByUserId(1L))
                 .thenReturn(Optional.of(preference(user(1L))));
-        // 추천 빵집 ID가 DB에 없음 → DB 저장 실패, Redis 결과는 보존됨
-        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(10L))).thenReturn(List.of());
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList())).thenReturn(List.of());
 
-        assertThatThrownBy(() -> courseService.saveAiCourse("job-3", 1L))
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-s4", 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND);
@@ -1136,12 +1151,12 @@ class CourseServiceTest {
         Bakery bakery = bakery(10L, "맛집");
         AiCourseResultCache cache = resultCache(1L, 10L);
 
-        when(aiCourseResultRedisService.tryAcquireSaveLock("job-4")).thenReturn(true);
-        when(aiCourseResultRedisService.getResult("job-4", 1L)).thenReturn(Optional.of(cache));
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s5")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s5", 1L)).thenReturn(Optional.of(cache));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
         when(userPreferenceRepository.findByUserId(1L))
                 .thenReturn(Optional.of(preference(user(1L))));
-        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(10L))).thenReturn(List.of(bakery));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList())).thenReturn(List.of(bakery));
         when(courseRepository.save(any(Course.class)))
                 .thenAnswer(
                         inv -> {
@@ -1150,14 +1165,67 @@ class CourseServiceTest {
                             return c;
                         });
 
-        Long courseId = courseService.saveAiCourse("job-4", 1L);
+        Long courseId = courseService.saveAiCourse("job-s5", 1L, null);
 
         assertThat(courseId).isEqualTo(99L);
         verify(courseRepository).save(any(Course.class));
         // 단위 테스트는 트랜잭션 동기화 비활성 → afterCommit 없이 즉시 정리됨
-        verify(aiCourseResultRedisService).deleteResult("job-4");
-        verify(aiCourseResultRedisService).releaseSaveLock("job-4");
-        verify(aiCourseRedisService).deleteJob("job-4");
+        verify(aiCourseResultRedisService).deleteResult("job-s5");
+        verify(aiCourseResultRedisService).releaseSaveLock("job-s5");
+        verify(aiCourseRedisService).deleteJob("job-s5");
+    }
+
+    @Test
+    void saveAiCourse_applies_custom_bakeryOrder_whenProvided() {
+        // bakery 10→1번, 20→2번 추천 — 사용자가 [20, 10]으로 역순 지정
+        Bakery b10 = bakery(10L, "빵집10");
+        Bakery b20 = bakery(20L, "빵집20");
+        AiCourseResultCache cache = resultCache2(1L, 10L, 20L);
+
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s6")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s6", 1L)).thenReturn(Optional.of(cache));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(userPreferenceRepository.findByUserId(1L))
+                .thenReturn(Optional.of(preference(user(1L))));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList())).thenReturn(List.of(b10, b20));
+
+        ArgumentCaptor<Course> captor = ArgumentCaptor.forClass(Course.class);
+        when(courseRepository.save(captor.capture()))
+                .thenAnswer(
+                        inv -> {
+                            Course c = inv.getArgument(0);
+                            ReflectionTestUtils.setField(c, "id", 100L);
+                            return c;
+                        });
+
+        Long courseId = courseService.saveAiCourse("job-s6", 1L, List.of(20L, 10L));
+
+        assertThat(courseId).isEqualTo(100L);
+        List<CourseBakery> cbs =
+                captor.getValue().getCourseBakeries().stream()
+                        .sorted(java.util.Comparator.comparingInt(CourseBakery::getVisitOrder))
+                        .toList();
+        assertThat(cbs.get(0).getBakery().getId()).isEqualTo(20L); // visitOrder=1
+        assertThat(cbs.get(1).getBakery().getId()).isEqualTo(10L); // visitOrder=2
+    }
+
+    @Test
+    void saveAiCourse_throws_whenBakeryOrderMismatch() {
+        // 추천 빵집은 10, 20인데 잘못된 ID(99)가 포함 → 400
+        AiCourseResultCache cache = resultCache2(1L, 10L, 20L);
+
+        when(aiCourseResultRedisService.tryAcquireSaveLock("job-s7")).thenReturn(true);
+        when(aiCourseResultRedisService.getResult("job-s7", 1L)).thenReturn(Optional.of(cache));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+        when(userPreferenceRepository.findByUserId(1L))
+                .thenReturn(Optional.of(preference(user(1L))));
+        when(bakeryRepository.findAllByIdInAndActiveTrue(anyList()))
+                .thenReturn(List.of(bakery(10L, "빵집10"), bakery(20L, "빵집20")));
+
+        assertThatThrownBy(() -> courseService.saveAiCourse("job-s7", 1L, List.of(10L, 99L)))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_ORDER_COUNT_MISMATCH);
     }
 
     @Test
@@ -1314,6 +1382,36 @@ class CourseServiceTest {
                 .userId(userId)
                 .request(aiRequest())
                 .response(webhookResponse(bakeryId))
+                .build();
+    }
+
+    /** 빵집 2개짜리 결과 캐시 (순서 지정 테스트용) */
+    private static AiCourseResultCache resultCache2(long userId, long bakeryId1, long bakeryId2) {
+        RecommendedBakeryResponse rb1 = new RecommendedBakeryResponse();
+        ReflectionTestUtils.setField(rb1, "id", bakeryId1);
+        ReflectionTestUtils.setField(rb1, "order", 1);
+        ReflectionTestUtils.setField(rb1, "recommendedBread", "크루아상");
+        ReflectionTestUtils.setField(rb1, "reason", "이유1");
+
+        RecommendedBakeryResponse rb2 = new RecommendedBakeryResponse();
+        ReflectionTestUtils.setField(rb2, "id", bakeryId2);
+        ReflectionTestUtils.setField(rb2, "order", 2);
+        ReflectionTestUtils.setField(rb2, "recommendedBread", "소금빵");
+        ReflectionTestUtils.setField(rb2, "reason", "이유2");
+
+        AiCourseWebhookResponse res = new AiCourseWebhookResponse();
+        ReflectionTestUtils.setField(res, "name", "ai-course-name");
+        ReflectionTestUtils.setField(res, "theme", "테마");
+        ReflectionTestUtils.setField(res, "estimatedCost", 15000L);
+        ReflectionTestUtils.setField(res, "estimatedTime", "2h");
+        ReflectionTestUtils.setField(res, "summary", "요약");
+        ReflectionTestUtils.setField(res, "recommendReason", "추천");
+        ReflectionTestUtils.setField(res, "bakeries", List.of(rb1, rb2));
+
+        return AiCourseResultCache.builder()
+                .userId(userId)
+                .request(aiRequest())
+                .response(res)
                 .build();
     }
 

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseAsyncServiceTest.java
@@ -1,8 +1,9 @@
 package com.breadbread.course.service.ai;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -17,10 +18,8 @@ import com.breadbread.course.dto.ai.AiCourseRequest;
 import com.breadbread.course.dto.ai.AiCourseWebhookResponse;
 import com.breadbread.course.dto.ai.RecommendedBakeryResponse;
 import com.breadbread.course.entity.BudgetRange;
-import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.FlexibilityLevel;
 import com.breadbread.course.entity.TravelType;
-import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.notification.service.FcmService;
 import com.breadbread.user.entity.User;
@@ -30,11 +29,11 @@ import com.breadbread.user.entity.WaitingTolerance;
 import com.breadbread.user.repository.UserPreferenceRepository;
 import com.breadbread.user.repository.UserRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -52,8 +51,8 @@ class AiCourseAsyncServiceTest {
     @Mock private BreadRepository breadRepository;
     @Mock private CrowdTimeRepository crowdTimeRepository;
     @Mock private AiWebhookClient aiWebhookClient;
-    @Mock private CourseRepository courseRepository;
     @Mock private AiCourseRedisService aiCourseRedisService;
+    @Mock private AiCourseResultRedisService aiCourseResultRedisService;
     @Mock private TransactionTemplate transactionTemplate;
     @Mock private FcmService fcmService;
 
@@ -75,8 +74,8 @@ class AiCourseAsyncServiceTest {
                         breadRepository,
                         crowdTimeRepository,
                         aiWebhookClient,
-                        courseRepository,
                         aiCourseRedisService,
+                        aiCourseResultRedisService,
                         transactionTemplate,
                         fcmService);
     }
@@ -124,7 +123,7 @@ class AiCourseAsyncServiceTest {
         when(breadRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
         when(crowdTimeRepository.findAllByBakeryIdIn(List.of())).thenReturn(List.of());
         when(aiWebhookClient.requestCourse(eq("job-throw"), any()))
-                .thenThrow(new RuntimeException("portone down"));
+                .thenThrow(new RuntimeException("webhook down"));
 
         aiCourseAsyncService.processAiCourse("job-throw", 1L, aiRequest()).join();
 
@@ -133,58 +132,52 @@ class AiCourseAsyncServiceTest {
     }
 
     @Test
-    void processAiCourse_saveCompleted_whenWebhookSucceeds() {
+    void processAiCourse_savesResultToRedis_andSetsCompleted_whenWebhookSucceeds() {
         User user = user(1L);
-        UserPreference pref = preference(user);
         Bakery bakery = bakery(10L, "맛집");
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(userPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(pref));
+        when(userPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(preference(user)));
         when(bakeryRepository.findAllByActiveTrue()).thenReturn(List.of(bakery));
         when(breadRepository.findAllByBakeryIdIn(List.of(10L))).thenReturn(List.of());
         when(crowdTimeRepository.findAllByBakeryIdIn(List.of(10L))).thenReturn(List.of());
-
-        AiCourseWebhookResponse webhookResponse = validWebhookResponse(10L);
-        when(aiWebhookClient.requestCourse(eq("job-d"), any())).thenReturn(webhookResponse);
-        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(10L))).thenReturn(List.of(bakery));
-        when(courseRepository.save(any(Course.class)))
-                .thenAnswer(
-                        inv -> {
-                            Course c = inv.getArgument(0);
-                            ReflectionTestUtils.setField(c, "id", 777L);
-                            return c;
-                        });
+        when(aiWebhookClient.requestCourse(eq("job-d"), any()))
+                .thenReturn(validWebhookResponse(10L));
 
         aiCourseAsyncService.processAiCourse("job-d", 1L, aiRequest()).join();
 
-        verify(aiCourseRedisService).saveCompleted("job-d", 777L);
-        ArgumentCaptor<Course> courseCaptor = ArgumentCaptor.forClass(Course.class);
-        verify(courseRepository).save(courseCaptor.capture());
-        assertThat(courseCaptor.getValue().getName()).isEqualTo("ai-course-name");
+        // Redis 임시 저장 + 상태 COMPLETED 업데이트
+        verify(aiCourseResultRedisService).saveResult(eq("job-d"), eq(1L), any(), any());
+        verify(aiCourseRedisService).saveCompleted("job-d");
+        // RDB 저장은 CourseService.saveAiCourse()에서 처리 — 여기서는 하지 않음
+        verify(fcmService).sendToUser(eq(1L), any(), any(), any(Map.class));
     }
 
     @Test
-    void processAiCourse_saveFailed_whenRecommendedBakeryMissingInDb() {
+    void processAiCourse_saveCompleted_evenWhenFcmFails() {
         User user = user(1L);
-        UserPreference pref = preference(user);
         Bakery bakery = bakery(10L, "맛집");
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(userPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(pref));
+        when(userPreferenceRepository.findByUserId(1L)).thenReturn(Optional.of(preference(user)));
         when(bakeryRepository.findAllByActiveTrue()).thenReturn(List.of(bakery));
         when(breadRepository.findAllByBakeryIdIn(List.of(10L))).thenReturn(List.of());
         when(crowdTimeRepository.findAllByBakeryIdIn(List.of(10L))).thenReturn(List.of());
+        when(aiWebhookClient.requestCourse(eq("job-fcm"), any()))
+                .thenReturn(validWebhookResponse(10L));
+        doThrow(new RuntimeException("FCM 연결 실패"))
+                .when(fcmService)
+                .sendToUser(any(), any(), any(), any(Map.class));
 
-        AiCourseWebhookResponse webhookResponse = validWebhookResponse(99L);
-        when(aiWebhookClient.requestCourse(eq("job-e"), any())).thenReturn(webhookResponse);
-        when(bakeryRepository.findAllByIdInAndActiveTrue(List.of(99L))).thenReturn(List.of());
+        aiCourseAsyncService.processAiCourse("job-fcm", 1L, aiRequest()).join();
 
-        aiCourseAsyncService.processAiCourse("job-e", 1L, aiRequest()).join();
-
-        verify(aiCourseRedisService)
-                .saveFailed(
-                        eq("job-e"), eq(ErrorCode.AI_RECOMMENDED_BAKERY_NOT_FOUND.getMessage()));
+        // FCM 실패와 무관하게 작업은 COMPLETED
+        verify(aiCourseRedisService).saveCompleted("job-fcm");
+        // saveFailed가 호출되어선 안 됨
+        verify(aiCourseRedisService, never()).saveFailed(any(), any());
     }
+
+    // ── 헬퍼 ────────────────────────────────────────────────────────────────
 
     private static AiCourseWebhookResponse validWebhookResponse(long bakeryId) {
         RecommendedBakeryResponse rb = new RecommendedBakeryResponse();

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRedisServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRedisServiceTest.java
@@ -62,7 +62,6 @@ class AiCourseRedisServiceTest {
                 objectMapper.writeValueAsString(
                         com.breadbread.course.dto.ai.AiJobCache.builder()
                                 .status(AiJobStatus.COMPLETED)
-                                .courseId(100L)
                                 .userId(5L)
                                 .build());
         when(valueOps.get("ai:job:job-x")).thenReturn(json);
@@ -71,7 +70,6 @@ class AiCourseRedisServiceTest {
 
         assertThat(result).isPresent();
         assertThat(result.get().getStatus()).isEqualTo(AiJobStatus.COMPLETED);
-        assertThat(result.get().getCourseId()).isEqualTo(100L);
     }
 
     @Test
@@ -108,13 +106,13 @@ class AiCourseRedisServiceTest {
                                 .build());
         when(valueOps.get("ai:job:job-z")).thenReturn(existing);
 
-        aiCourseRedisService.saveCompleted("job-z", 200L);
+        aiCourseRedisService.saveCompleted("job-z");
 
         ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
         verify(valueOps).set(eq("ai:job:job-z"), jsonCaptor.capture(), any(Duration.class));
         assertThat(jsonCaptor.getValue())
                 .contains("\"status\":\"COMPLETED\"")
-                .contains("\"courseId\":200")
-                .contains("\"userId\":3");
+                .contains("\"userId\":3")
+                .doesNotContain("\"courseId\"");
     }
 }

--- a/apps/be/src/test/java/com/breadbread/tour/client/CongestionInstantCheckClientTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/client/CongestionInstantCheckClientTest.java
@@ -42,9 +42,6 @@ class CongestionInstantCheckClientTest {
 
     @Test
     void check_returnsResponse_whenSuccessful() throws Exception {
-        CongestionInstantCheckResponse.CongestionResult result =
-                new CongestionInstantCheckResponse.CongestionResult();
-
         String json =
                 objectMapper.writeValueAsString(
                         Map.of("success", true, "data", List.of(), "error", ""));


### PR DESCRIPTION
## Task
- AI 웹훅 응답을 즉시 DB에 저장하던 방식을 Redis TTL 24h 임시 저장으로 전환
- GET /courses/ai/{jobId}/preview로 결과 미리보기, POST /courses/ai/{jobId}/save로 DB 저장
- DB 저장 실패 시 Redis 결과 유실 방지 (afterCommit 이후 삭제)
- SET NX EX 분산 락으로 동시 중복 저장 차단 (ai:result:{jobId}:saving)
- 비소유자 호출 시 Redis 키 보존 (소유권 확인 후 삭제)
- 저장 완료 시 result / saving lock / job status 세 Redis 키 일괄 정리
- AiCoursePreviewResponse 추가 (bakeryCount, summary, recommendReason 포함)
- AiJobCache에서 미사용 courseId 필드 제거
- 관련 단위 테스트 추가 및 수정
- GET /courses/ai/{jobId}/preview 응답에 주소·좌표·평점 추가 (DB 조회)
- 빵집 이름을 AI 응답 대신 DB 기준으로 반환
- 프리뷰와 저장 불일치 방지: 추천 빵집 누락 시 프리뷰도 동일하게 예외 처리
- POST /courses/ai/{jobId}/save body에 bakeryOrder 선택적 추가
  - 미전달 시 AI 추천 순서 그대로 저장
  - 전달 시 유효성 검사 후 지정 순서로 visitOrder 부여

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #221 
