### PR TITLE
refactor: BakeryService SRP 분리, existsBy 중복 pre-check 제거

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryController.java
@@ -2,21 +2,18 @@ package com.breadbread.bakery.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.bakery.dto.*;
-import com.breadbread.bakery.entity.BakeryPersonality;
-import com.breadbread.bakery.entity.BakerySortType;
-import com.breadbread.bakery.entity.BakeryType;
-import com.breadbread.bakery.entity.BakeryUseType;
 import com.breadbread.bakery.entity.ReviewSortType;
 import com.breadbread.bakery.service.BakeryService;
+import com.breadbread.bakery.service.BreadService;
 import com.breadbread.bakery.service.GooglePlacesUpdateService;
+import com.breadbread.bakery.service.ReviewService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -31,6 +28,8 @@ import org.springframework.web.bind.annotation.*;
 public class BakeryController {
 
     private final BakeryService bakeryService;
+    private final BreadService breadService;
+    private final ReviewService reviewService;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
 
     @Operation(
@@ -53,30 +52,7 @@ public class BakeryController {
     })
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200")
     @GetMapping("/ai")
-    public ApiResponse<java.util.List<BakeryAiResponse>> findAllForAi(
-            @RequestParam(required = false) String keyword,
-            @RequestParam(defaultValue = "false") boolean open,
-            @RequestParam(required = false) LocalDate visitDate,
-            @RequestParam(required = false) LocalTime visitTime,
-            @RequestParam(required = false) String region,
-            @RequestParam(required = false) Boolean drinkAvailable,
-            @RequestParam(required = false) Boolean dineInAvailable,
-            @RequestParam(required = false) BakeryType bakeryType,
-            @RequestParam(required = false) java.util.List<BakeryUseType> bakeryUseTypes,
-            @RequestParam(required = false) java.util.List<BakeryPersonality> bakeryPersonalities) {
-        BakeryAiSearch search =
-                BakeryAiSearch.builder()
-                        .keyword(keyword)
-                        .open(open)
-                        .visitDate(visitDate)
-                        .visitTime(visitTime)
-                        .region(region)
-                        .drinkAvailable(drinkAvailable)
-                        .dineInAvailable(dineInAvailable)
-                        .bakeryType(bakeryType)
-                        .bakeryUseTypes(bakeryUseTypes)
-                        .bakeryPersonalities(bakeryPersonalities)
-                        .build();
+    public ApiResponse<List<BakeryAiResponse>> findAllForAi(@ModelAttribute BakeryAiSearch search) {
         return ApiResponse.ok(bakeryService.findAllForAi(search));
     }
 
@@ -95,22 +71,10 @@ public class BakeryController {
     @GetMapping
     public ApiResponse<BakeryListResponse> search(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) BakerySortType sort,
-            @RequestParam(defaultValue = "false") boolean open,
-            @RequestParam(required = false) String region,
-            @RequestParam(required = false) String dong,
+            @ModelAttribute BakerySearch search,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Long userId = userDetails != null ? userDetails.getId() : null;
-        BakerySearch search =
-                BakerySearch.builder()
-                        .keyword(keyword)
-                        .sort(sort)
-                        .open(open)
-                        .region(region)
-                        .dong(dong)
-                        .build();
         return ApiResponse.ok(bakeryService.search(search, PageRequest.of(page, size), userId));
     }
 
@@ -128,21 +92,9 @@ public class BakeryController {
     })
     @GetMapping("/summary")
     public ApiResponse<BakerySimpleListResponse> searchSimple(
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) BakerySortType sort,
-            @RequestParam(defaultValue = "false") boolean open,
-            @RequestParam(required = false) String region,
-            @RequestParam(required = false) String dong,
+            @ModelAttribute BakerySearch search,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        BakerySearch search =
-                BakerySearch.builder()
-                        .keyword(keyword)
-                        .sort(sort)
-                        .open(open)
-                        .region(region)
-                        .dong(dong)
-                        .build();
         return ApiResponse.ok(bakeryService.searchSimple(search, PageRequest.of(page, size)));
     }
 
@@ -198,7 +150,7 @@ public class BakeryController {
             @PathVariable Long bakeryId,
             @Valid @RequestBody CreateBreadRequest request) {
         Long id =
-                bakeryService.createBread(
+                breadService.createBread(
                         userDetails.getId(), userDetails.getRole(), bakeryId, request);
         return ApiResponse.ok(id);
     }
@@ -210,7 +162,7 @@ public class BakeryController {
             @PathVariable Long bakeryId,
             @PathVariable Long breadId,
             @Valid @RequestBody UpdateBreadRequest request) {
-        bakeryService.updateBread(
+        breadService.updateBread(
                 userDetails.getId(), userDetails.getRole(), bakeryId, breadId, request);
         return ApiResponse.ok();
     }
@@ -221,7 +173,7 @@ public class BakeryController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long bakeryId,
             @PathVariable Long breadId) {
-        bakeryService.deleteBread(userDetails.getId(), userDetails.getRole(), bakeryId, breadId);
+        breadService.deleteBread(userDetails.getId(), userDetails.getRole(), bakeryId, breadId);
         return ApiResponse.ok();
     }
 
@@ -258,7 +210,7 @@ public class BakeryController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Long userId = userDetails != null ? userDetails.getId() : null;
-        return ApiResponse.ok(bakeryService.getReviews(bakeryId, sort, page, size, userId));
+        return ApiResponse.ok(reviewService.getReviews(bakeryId, sort, page, size, userId));
     }
 
     @Operation(summary = "빵집 리뷰 등록")
@@ -268,7 +220,7 @@ public class BakeryController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long bakeryId,
             @Valid @RequestBody CreateReviewRequest request) {
-        return ApiResponse.ok(bakeryService.createReview(bakeryId, userDetails.getId(), request));
+        return ApiResponse.ok(reviewService.createReview(bakeryId, userDetails.getId(), request));
     }
 
     @Operation(summary = "빵집 리뷰 수정", description = "본인 작성 리뷰만 수정 가능")
@@ -278,7 +230,7 @@ public class BakeryController {
             @PathVariable Long bakeryId,
             @PathVariable Long reviewId,
             @Valid @RequestBody UpdateReviewRequest request) {
-        bakeryService.updateReview(bakeryId, reviewId, userDetails.getId(), request);
+        reviewService.updateReview(bakeryId, reviewId, userDetails.getId(), request);
         return ApiResponse.ok();
     }
 
@@ -288,7 +240,7 @@ public class BakeryController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long bakeryId,
             @PathVariable Long reviewId) {
-        bakeryService.deleteReview(bakeryId, reviewId, userDetails.getId(), userDetails.getRole());
+        reviewService.deleteReview(bakeryId, reviewId, userDetails.getId(), userDetails.getRole());
         return ApiResponse.ok();
     }
 

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiSearch.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakeryAiSearch.java
@@ -6,11 +6,17 @@ import com.breadbread.bakery.entity.BakeryUseType;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class BakeryAiSearch {
     private String keyword;
     private boolean open;

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/BakerySearch.java
@@ -1,11 +1,17 @@
 package com.breadbread.bakery.dto;
 
 import com.breadbread.bakery.entity.BakerySortType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class BakerySearch {
     private String keyword;
     private BakerySortType sort;

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
@@ -3,8 +3,11 @@ package com.breadbread.bakery.repository;
 import com.breadbread.bakery.entity.Bread;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BreadRepository extends JpaRepository<Bread, Long> {
     List<Bread> findAllByBakeryIdIn(Collection<Long> bakeryIds);
+
+    Optional<Bread> findByIdAndBakeryId(Long id, Long bakeryId);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImageService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImageService.java
@@ -1,0 +1,123 @@
+package com.breadbread.bakery.service;
+
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
+import com.breadbread.bakery.repository.BakeryImageRepository;
+import com.breadbread.global.service.GcsService;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BakeryImageService {
+
+    private final BakeryImageRepository bakeryImageRepository;
+    private final BakeryImageUrlResolver bakeryImageUrlResolver;
+    private final GcsService gcsService;
+
+    /** createBakery — 새 이미지 저장 */
+    @Transactional
+    public void saveImages(Bakery bakery, String[] urls) {
+        if (urls == null) return;
+        List<BakeryImage> images = new ArrayList<>();
+        for (int i = 0; i < urls.length; i++) {
+            images.add(
+                    BakeryImage.builder()
+                            .imageUrl(urls[i])
+                            .displayOrder(i + 1)
+                            .bakery(bakery)
+                            .build());
+        }
+        bakeryImageRepository.saveAll(images);
+    }
+
+    /** updateBakery — GCS 삭제 후 새 이미지로 교체 */
+    @Transactional
+    public void replaceImages(Bakery bakery, String[] urls) {
+        Set<String> nextUrls =
+                urls == null
+                        ? Collections.emptySet()
+                        : Arrays.stream(urls).filter(Objects::nonNull).collect(Collectors.toSet());
+        bakery.getImages().stream()
+                .map(BakeryImage::getImageUrl)
+                .filter(Objects::nonNull)
+                .filter(url -> !nextUrls.contains(url))
+                .forEach(gcsService::deleteQuietly);
+        bakeryImageRepository.deleteAllByBakery(bakery);
+        saveImages(bakery, urls);
+    }
+
+    /** deleteBakery — GCS + DB 이미지 전체 삭제 */
+    @Transactional
+    public void deleteAllImages(Bakery bakery) {
+        bakery.getImages()
+                .forEach(
+                        img -> {
+                            if (img.getImageUrl() != null) {
+                                gcsService.deleteQuietly(img.getImageUrl());
+                            }
+                        });
+        bakeryImageRepository.deleteAllByBakery(bakery);
+    }
+
+    /** search — 빵집별 이미지 프리뷰 URL(최대 4장) + 나머지 개수 배치 조회 */
+    @Transactional(readOnly = true)
+    public PreviewBatch resolvePreviewBatch(List<Long> bakeryIds) {
+        if (bakeryIds.isEmpty()) return PreviewBatch.empty();
+
+        Map<Long, List<BakeryImage>> grouped =
+                bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(bakeryIds).stream()
+                        .collect(Collectors.groupingBy(img -> img.getBakery().getId()));
+
+        Map<Long, List<String>> previewUrls = new HashMap<>();
+        Map<Long, Integer> remainingCounts = new HashMap<>();
+        for (Long id : bakeryIds) {
+            List<BakeryImage> ordered = grouped.getOrDefault(id, List.of());
+            remainingCounts.put(id, ordered.size() > 4 ? ordered.size() - 4 : 0);
+            previewUrls.put(
+                    id,
+                    ordered.stream()
+                            .limit(4)
+                            .map(bakeryImageUrlResolver::resolve)
+                            .filter(Objects::nonNull)
+                            .toList());
+        }
+        return new PreviewBatch(previewUrls, remainingCounts);
+    }
+
+    /** searchSimple — 빵집별 썸네일(첫 번째 이미지) URL 배치 조회 */
+    @Transactional(readOnly = true)
+    public Map<Long, String> resolveThumbnails(List<Long> bakeryIds) {
+        if (bakeryIds.isEmpty()) return Collections.emptyMap();
+
+        Map<Long, String> result = new HashMap<>();
+        bakeryImageRepository
+                .findAllByBakeryIdInAndDisplayOrder(bakeryIds, 1)
+                .forEach(
+                        img -> {
+                            String url = bakeryImageUrlResolver.resolve(img);
+                            if (url != null) result.put(img.getBakery().getId(), url);
+                        });
+        return result;
+    }
+
+    /** findOne — 이미지 URL 목록 (displayOrder 정렬) */
+    public List<String> resolveDetailUrls(List<BakeryImage> images) {
+        return images.stream()
+                .sorted(Comparator.comparingInt(BakeryImage::getDisplayOrder))
+                .map(bakeryImageUrlResolver::resolve)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public record PreviewBatch(
+            Map<Long, List<String>> previewUrls, Map<Long, Integer> remainingCounts) {
+
+        static PreviewBatch empty() {
+            return new PreviewBatch(Collections.emptyMap(), Collections.emptyMap());
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -3,11 +3,11 @@ package com.breadbread.bakery.service;
 import com.breadbread.bakery.dto.*;
 import com.breadbread.bakery.entity.*;
 import com.breadbread.bakery.repository.*;
+import com.breadbread.bakery.service.BakeryImageService.PreviewBatch;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
-import com.breadbread.global.service.GcsService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
@@ -20,9 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,11 +35,10 @@ public class BakeryService {
     private final BakeryImageRepository bakeryImageRepository;
     private final BakeryLikeRepository bakeryLikeRepository;
     private final ReviewRepository reviewRepository;
-    private final GcsService gcsService;
     private final CourseBakeryRepository courseBakeryRepository;
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
-    private final BakeryImageUrlResolver bakeryImageUrlResolver;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
+    private final BakeryImageService bakeryImageService;
 
     @Transactional(readOnly = true)
     public List<BakeryAiResponse> findAllForAi(BakeryAiSearch search) {
@@ -108,30 +105,9 @@ public class BakeryService {
         List<Bakery> bakeries = result.getContent();
 
         List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
-        Map<Long, List<String>> previewUrlsByBakery = new HashMap<>();
-        Map<Long, Integer> remainingPreviewByBakery = new HashMap<>();
-        if (!ids.isEmpty()) {
-            List<BakeryImage> allListImages =
-                    bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(ids);
-            Map<Long, List<BakeryImage>> imagesByBakery =
-                    allListImages.stream()
-                            .collect(Collectors.groupingBy(img -> img.getBakery().getId()));
-            for (Long bakeryId : ids) {
-                List<BakeryImage> ordered =
-                        imagesByBakery.getOrDefault(bakeryId, List.of()).stream()
-                                .sorted(Comparator.comparingInt(BakeryImage::getDisplayOrder))
-                                .toList();
-                int remaining = ordered.size() > 4 ? ordered.size() - 4 : 0;
-                List<String> firstFour =
-                        ordered.stream()
-                                .limit(4)
-                                .map(bakeryImageUrlResolver::resolve)
-                                .filter(url -> url != null)
-                                .toList();
-                previewUrlsByBakery.put(bakeryId, firstFour);
-                remainingPreviewByBakery.put(bakeryId, remaining);
-            }
-        }
+        PreviewBatch previewBatch = bakeryImageService.resolvePreviewBatch(ids);
+        Map<Long, List<String>> previewUrlsByBakery = previewBatch.previewUrls();
+        Map<Long, Integer> remainingPreviewByBakery = previewBatch.remainingCounts();
         Map<Long, Long> likeCountMap =
                 bakeryLikeRepository.countByBakeryIdIn(ids).stream()
                         .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
@@ -188,22 +164,7 @@ public class BakeryService {
         List<Bakery> bakeries = result.getContent();
         List<Long> ids = bakeries.stream().map(Bakery::getId).toList();
 
-        Map<Long, String> thumbnailByBakery = new HashMap<>();
-        if (!ids.isEmpty()) {
-            List<BakeryImage> allImages =
-                    bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(ids);
-            allImages.stream()
-                    .collect(Collectors.groupingBy(img -> img.getBakery().getId()))
-                    .forEach(
-                            (bakeryId, images) ->
-                                    images.stream()
-                                            .min(
-                                                    Comparator.comparingInt(
-                                                            BakeryImage::getDisplayOrder))
-                                            .map(bakeryImageUrlResolver::resolve)
-                                            .ifPresent(
-                                                    url -> thumbnailByBakery.put(bakeryId, url)));
-        }
+        Map<Long, String> thumbnailByBakery = bakeryImageService.resolveThumbnails(ids);
 
         Map<Long, Double> avgRatingMap =
                 ids.isEmpty()
@@ -258,12 +219,7 @@ public class BakeryService {
             }
         }
 
-        List<String> imageUrls =
-                images.stream()
-                        .sorted(Comparator.comparingInt(BakeryImage::getDisplayOrder))
-                        .map(bakeryImageUrlResolver::resolve)
-                        .filter(url -> url != null)
-                        .toList();
+        List<String> imageUrls = bakeryImageService.resolveDetailUrls(images);
 
         return BakeryDetailResponse.from(bakery, likeCount, liked, reviewCount, imageUrls, rating);
     }
@@ -311,19 +267,7 @@ public class BakeryService {
         Bakery saved = bakeryRepository.save(bakery);
         log.info("빵집 생성: bakeryId={}, userId={}", saved.getId(), userId);
 
-        if (request.getImageUrls() != null) {
-            List<BakeryImage> images = new ArrayList<>();
-            String[] urls = request.getImageUrls();
-            for (int i = 0; i < urls.length; i++) {
-                images.add(
-                        BakeryImage.builder()
-                                .imageUrl(urls[i])
-                                .displayOrder(i + 1)
-                                .bakery(saved)
-                                .build());
-            }
-            bakeryImageRepository.saveAll(images);
-        }
+        bakeryImageService.saveImages(saved, request.getImageUrls());
 
         return saved.getId();
     }
@@ -351,25 +295,7 @@ public class BakeryService {
         }
 
         if (request.getImageUrls() != null) {
-            bakery.getImages()
-                    .forEach(
-                            img -> {
-                                if (img.getImageUrl() != null) {
-                                    gcsService.deleteQuietly(img.getImageUrl());
-                                }
-                            });
-            bakeryImageRepository.deleteAllByBakery(bakery);
-            List<BakeryImage> images = new ArrayList<>();
-            String[] urls = request.getImageUrls();
-            for (int i = 0; i < urls.length; i++) {
-                images.add(
-                        BakeryImage.builder()
-                                .imageUrl(urls[i])
-                                .displayOrder(i + 1)
-                                .bakery(bakery)
-                                .build());
-            }
-            bakeryImageRepository.saveAll(images);
+            bakeryImageService.replaceImages(bakery, request.getImageUrls());
         }
     }
 
@@ -382,14 +308,7 @@ public class BakeryService {
 
         checkAuthority(bakery, userId, role);
         log.info("빵집 삭제: bakeryId={}, userId={}", bakeryId, userId);
-        bakery.getImages()
-                .forEach(
-                        img -> {
-                            if (img.getImageUrl() != null) {
-                                gcsService.deleteQuietly(img.getImageUrl());
-                            }
-                        });
-        bakeryImageRepository.deleteAllByBakery(bakery);
+        bakeryImageService.deleteAllImages(bakery);
         bakery.deactivate();
 
         List<Long> courseIds = courseBakeryRepository.findCourseIdsByBakeryId(bakeryId);
@@ -400,82 +319,11 @@ public class BakeryService {
     }
 
     @Transactional
-    public Long createBread(Long userId, UserRole role, Long bakeryId, CreateBreadRequest request) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        checkAuthority(bakery, userId, role);
-
-        Bread bread =
-                Bread.builder()
-                        .name(request.getName())
-                        .price(request.getPrice())
-                        .imageUrl(request.getImageUrl())
-                        .breadType(request.getBreadType())
-                        .signature(request.isSignature())
-                        .bakery(bakery)
-                        .build();
-
-        Long breadId = breadRepository.save(bread).getId();
-        log.info("빵 등록: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
-        return breadId;
-    }
-
-    @Transactional
-    public void updateBread(
-            Long userId, UserRole role, Long bakeryId, Long breadId, UpdateBreadRequest request) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        checkAuthority(bakery, userId, role);
-
-        Bread bread =
-                breadRepository
-                        .findById(breadId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
-
-        if (request.getImageUrl() != null && bread.getImageUrl() != null) {
-            gcsService.deleteQuietly(bread.getImageUrl());
-        }
-        bread.update(request);
-        log.info("빵 수정: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
-    }
-
-    @Transactional
-    public void deleteBread(Long userId, UserRole role, Long bakeryId, Long breadId) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        checkAuthority(bakery, userId, role);
-
-        Bread bread =
-                breadRepository
-                        .findById(breadId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
-
-        log.info("빵 삭제: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
-        if (bread.getImageUrl() != null) {
-            gcsService.deleteQuietly(bread.getImageUrl());
-        }
-        breadRepository.delete(bread);
-    }
-
-    @Transactional
     public void like(Long bakeryId, Long userId) {
         Bakery bakery =
                 bakeryRepository
                         .findByIdAndActiveTrue(bakeryId)
                         .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        if (bakeryLikeRepository.existsByBakeryIdAndUserId(bakeryId, userId)) {
-            throw new CustomException(ErrorCode.ALREADY_LIKED);
-        }
 
         User user =
                 userRepository
@@ -483,8 +331,14 @@ public class BakeryService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         try {
-            bakeryLikeRepository.save(BakeryLike.builder().bakery(bakery).user(user).build());
+            bakeryLikeRepository.saveAndFlush(
+                    BakeryLike.builder().bakery(bakery).user(user).build());
         } catch (DataIntegrityViolationException e) {
+            log.warn(
+                    "[빵집 좋아요 중복 또는 무결성 위반] bakeryId={}, userId={}, msg={}",
+                    bakeryId,
+                    userId,
+                    e.getMessage());
             throw new CustomException(ErrorCode.ALREADY_LIKED);
         }
     }
@@ -496,101 +350,6 @@ public class BakeryService {
                         .findByBakeryIdAndUserId(bakeryId, userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.NOT_LIKED));
         bakeryLikeRepository.delete(like);
-    }
-
-    @Transactional
-    public Long createReview(Long bakeryId, Long userId, CreateReviewRequest request) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        Review review =
-                Review.builder()
-                        .content(request.getContent())
-                        .rating(request.getRating())
-                        .imageUrls(request.getImageUrls())
-                        .bakery(bakery)
-                        .user(user)
-                        .build();
-        reviewRepository.save(review);
-        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
-        return review.getId();
-    }
-
-    @Transactional(readOnly = true)
-    public ReviewListResponse getReviews(
-            Long bakeryId, ReviewSortType sort, int page, int size, Long userId) {
-        if (!bakeryRepository.existsByIdAndActiveTrue(bakeryId)) {
-            throw new CustomException(ErrorCode.BAKERY_NOT_FOUND);
-        }
-        Sort sorting =
-                switch (sort) {
-                    case RATING_HIGH -> Sort.by("rating").descending();
-                    case RATING_LOW -> Sort.by("rating").ascending();
-                    default -> Sort.by("createdAt").descending();
-                };
-        Page<Review> result =
-                reviewRepository.findAllByBakeryIdAndActiveTrue(
-                        bakeryId, PageRequest.of(page, size, sorting));
-        return ReviewListResponse.builder()
-                .reviews(
-                        result.getContent().stream()
-                                .map(r -> ReviewResponse.from(r, userId))
-                                .toList())
-                .total((int) result.getTotalElements())
-                .page(page)
-                .size(size)
-                .hasNext(result.hasNext())
-                .build();
-    }
-
-    @Transactional
-    public void updateReview(
-            Long bakeryId, Long reviewId, Long userId, UpdateReviewRequest request) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        Review review =
-                reviewRepository
-                        .findByIdAndBakeryIdAndActiveTrue(reviewId, bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
-
-        if (!review.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        review.update(request);
-        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
-        log.info("리뷰 수정: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
-    }
-
-    @Transactional
-    public void deleteReview(Long bakeryId, Long reviewId, Long userId, UserRole role) {
-        Bakery bakery =
-                bakeryRepository
-                        .findByIdAndActiveTrue(bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
-
-        Review review =
-                reviewRepository
-                        .findByIdAndBakeryIdAndActiveTrue(reviewId, bakeryId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
-
-        if (role != UserRole.ROLE_ADMIN && !review.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        review.getImageUrls().forEach(gcsService::deleteQuietly);
-        review.deactivate();
-        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
-        log.info("리뷰 삭제: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
     }
 
     private void checkAuthority(Bakery bakery, Long userId, UserRole role) {

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BreadService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BreadService.java
@@ -1,0 +1,101 @@
+package com.breadbread.bakery.service;
+
+import com.breadbread.bakery.dto.CreateBreadRequest;
+import com.breadbread.bakery.dto.UpdateBreadRequest;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.Bread;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BreadRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.GcsService;
+import com.breadbread.user.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BreadService {
+
+    private final BakeryRepository bakeryRepository;
+    private final BreadRepository breadRepository;
+    private final GcsService gcsService;
+
+    @Transactional
+    public Long createBread(Long userId, UserRole role, Long bakeryId, CreateBreadRequest request) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        checkAuthority(bakery, userId, role);
+
+        Bread bread =
+                Bread.builder()
+                        .name(request.getName())
+                        .price(request.getPrice())
+                        .imageUrl(request.getImageUrl())
+                        .breadType(request.getBreadType())
+                        .signature(request.isSignature())
+                        .bakery(bakery)
+                        .build();
+
+        Long breadId = breadRepository.save(bread).getId();
+        log.info("빵 등록: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
+        return breadId;
+    }
+
+    @Transactional
+    public void updateBread(
+            Long userId, UserRole role, Long bakeryId, Long breadId, UpdateBreadRequest request) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        checkAuthority(bakery, userId, role);
+
+        Bread bread =
+                breadRepository
+                        .findByIdAndBakeryId(breadId, bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        if (request.getImageUrl() != null && bread.getImageUrl() != null) {
+            gcsService.deleteQuietly(bread.getImageUrl());
+        }
+        bread.update(request);
+        log.info("빵 수정: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
+    }
+
+    @Transactional
+    public void deleteBread(Long userId, UserRole role, Long bakeryId, Long breadId) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        checkAuthority(bakery, userId, role);
+
+        Bread bread =
+                breadRepository
+                        .findByIdAndBakeryId(breadId, bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        log.info("빵 삭제: breadId={}, bakeryId={}, userId={}", breadId, bakeryId, userId);
+        if (bread.getImageUrl() != null) {
+            gcsService.deleteQuietly(bread.getImageUrl());
+        }
+        breadRepository.delete(bread);
+    }
+
+    private void checkAuthority(Bakery bakery, Long userId, UserRole role) {
+        if (role == UserRole.ROLE_ADMIN) return;
+        if (bakery.getOwner() == null || !bakery.getOwner().getId().equals(userId)) {
+            log.warn("빵집 접근 권한 없음: bakeryId={}, userId={}", bakery.getId(), userId);
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/ReviewService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/ReviewService.java
@@ -1,0 +1,130 @@
+package com.breadbread.bakery.service;
+
+import com.breadbread.bakery.dto.CreateReviewRequest;
+import com.breadbread.bakery.dto.ReviewListResponse;
+import com.breadbread.bakery.dto.ReviewResponse;
+import com.breadbread.bakery.dto.UpdateReviewRequest;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.entity.ReviewSortType;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.ReviewRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.GcsService;
+import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final BakeryRepository bakeryRepository;
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final GcsService gcsService;
+
+    @Transactional
+    public Long createReview(Long bakeryId, Long userId, CreateReviewRequest request) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Review review =
+                Review.builder()
+                        .content(request.getContent())
+                        .rating(request.getRating())
+                        .imageUrls(request.getImageUrls())
+                        .bakery(bakery)
+                        .user(user)
+                        .build();
+        reviewRepository.save(review);
+        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
+        return review.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewListResponse getReviews(
+            Long bakeryId, ReviewSortType sort, int page, int size, Long userId) {
+        if (!bakeryRepository.existsByIdAndActiveTrue(bakeryId)) {
+            throw new CustomException(ErrorCode.BAKERY_NOT_FOUND);
+        }
+        Sort sorting =
+                switch (sort) {
+                    case RATING_HIGH -> Sort.by("rating").descending();
+                    case RATING_LOW -> Sort.by("rating").ascending();
+                    default -> Sort.by("createdAt").descending();
+                };
+        Page<Review> result =
+                reviewRepository.findAllByBakeryIdAndActiveTrue(
+                        bakeryId, PageRequest.of(page, size, sorting));
+        return ReviewListResponse.builder()
+                .reviews(
+                        result.getContent().stream()
+                                .map(r -> ReviewResponse.from(r, userId))
+                                .toList())
+                .total((int) result.getTotalElements())
+                .page(page)
+                .size(size)
+                .hasNext(result.hasNext())
+                .build();
+    }
+
+    @Transactional
+    public void updateReview(
+            Long bakeryId, Long reviewId, Long userId, UpdateReviewRequest request) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        Review review =
+                reviewRepository
+                        .findByIdAndBakeryIdAndActiveTrue(reviewId, bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (!review.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        review.update(request);
+        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
+        log.info("리뷰 수정: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
+    }
+
+    @Transactional
+    public void deleteReview(Long bakeryId, Long reviewId, Long userId, UserRole role) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        Review review =
+                reviewRepository
+                        .findByIdAndBakeryIdAndActiveTrue(reviewId, bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (role != UserRole.ROLE_ADMIN && !review.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        review.getImageUrls().forEach(gcsService::deleteQuietly);
+        review.deactivate();
+        bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
+        log.info("리뷰 삭제: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/community/repository/CommentRepository.java
+++ b/apps/be/src/main/java/com/breadbread/community/repository/CommentRepository.java
@@ -1,4 +1,4 @@
-package com.breadbread.community.respository;
+package com.breadbread.community.repository;
 
 import com.breadbread.community.entity.Comment;
 import java.util.List;

--- a/apps/be/src/main/java/com/breadbread/community/repository/PostLikeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/community/repository/PostLikeRepository.java
@@ -1,4 +1,4 @@
-package com.breadbread.community.respository;
+package com.breadbread.community.repository;
 
 import com.breadbread.community.entity.PostLike;
 import java.util.List;

--- a/apps/be/src/main/java/com/breadbread/community/repository/PostRepository.java
+++ b/apps/be/src/main/java/com/breadbread/community/repository/PostRepository.java
@@ -1,4 +1,4 @@
-package com.breadbread.community.respository;
+package com.breadbread.community.repository;
 
 import com.breadbread.community.entity.Post;
 import java.util.Optional;

--- a/apps/be/src/main/java/com/breadbread/community/repository/PostRepositoryCustom.java
+++ b/apps/be/src/main/java/com/breadbread/community/repository/PostRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.breadbread.community.respository;
+package com.breadbread.community.repository;
 
 import com.breadbread.community.dto.PostSearch;
 import com.breadbread.community.entity.Post;

--- a/apps/be/src/main/java/com/breadbread/community/repository/PostRepositoryImpl.java
+++ b/apps/be/src/main/java/com/breadbread/community/repository/PostRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.breadbread.community.respository;
+package com.breadbread.community.repository;
 
 import com.breadbread.community.dto.PostListSort;
 import com.breadbread.community.dto.PostSearch;

--- a/apps/be/src/main/java/com/breadbread/community/service/CommunityService.java
+++ b/apps/be/src/main/java/com/breadbread/community/service/CommunityService.java
@@ -15,9 +15,9 @@ import com.breadbread.community.entity.Comment;
 import com.breadbread.community.entity.Post;
 import com.breadbread.community.entity.PostLike;
 import com.breadbread.community.entity.PostType;
-import com.breadbread.community.respository.CommentRepository;
-import com.breadbread.community.respository.PostLikeRepository;
-import com.breadbread.community.respository.PostRepository;
+import com.breadbread.community.repository.CommentRepository;
+import com.breadbread.community.repository.PostLikeRepository;
+import com.breadbread.community.repository.PostRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.service.GcsService;
@@ -219,13 +219,14 @@ public class CommunityService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (postLikeRepository.existsByUserIdAndPostId(userId, postId)) {
-            throw new CustomException(ErrorCode.ALREADY_POST_LIKED);
-        }
-
         try {
-            postLikeRepository.save(PostLike.builder().post(post).user(user).build());
+            postLikeRepository.saveAndFlush(PostLike.builder().post(post).user(user).build());
         } catch (DataIntegrityViolationException e) {
+            log.warn(
+                    "[게시글 좋아요 중복 또는 무결성 위반] postId={}, userId={}, msg={}",
+                    postId,
+                    userId,
+                    e.getMessage());
             throw new CustomException(ErrorCode.ALREADY_POST_LIKED);
         }
 

--- a/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
+++ b/apps/be/src/main/java/com/breadbread/payment/service/PaymentService.java
@@ -26,6 +26,7 @@ import io.portone.sdk.server.webhook.WebhookVerifier;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -104,7 +105,9 @@ public class PaymentService {
                     .build();
         }
 
-        PortOnePaymentResponse response = fetchPortOnePaymentOrThrow(payment.getPaymentId());
+        PortOnePaymentResponse response =
+                fetchPortOnePayment(payment.getPaymentId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_FAILED));
         assertPaidMatchesOrder(payment, response);
         confirmPaidPayment(payment, response);
         log.info("결제 완료: paymentId={}, userId={}", request.getPaymentId(), userId);
@@ -205,7 +208,7 @@ public class PaymentService {
         if (payment.getStatus() == PaymentStatus.PAID) {
             return;
         }
-        PortOnePaymentResponse remote = fetchPortOnePaymentSilent(paymentId);
+        PortOnePaymentResponse remote = fetchPortOnePayment(paymentId).orElse(null);
         if (remote == null) {
             log.warn("[포트원 웹훅] 포트원에서 결제 정보 조회 실패: paymentId={}", paymentId);
             return;
@@ -246,7 +249,7 @@ public class PaymentService {
             log.warn("[포트원 웹훅] 알 수 없는 paymentId: paymentId={}", paymentId);
             return;
         }
-        PortOnePaymentResponse remote = fetchPortOnePaymentSilent(paymentId);
+        PortOnePaymentResponse remote = fetchPortOnePayment(paymentId).orElse(null);
         if (remote == null || remote.getStatus() != PaymentStatus.FAILED) {
             return;
         }
@@ -264,7 +267,7 @@ public class PaymentService {
             log.warn("[포트원 웹훅] 알 수 없는 paymentId: paymentId={}", paymentId);
             return;
         }
-        PortOnePaymentResponse remote = fetchPortOnePaymentSilent(paymentId);
+        PortOnePaymentResponse remote = fetchPortOnePayment(paymentId).orElse(null);
         if (remote == null) {
             return;
         }
@@ -289,7 +292,7 @@ public class PaymentService {
             log.warn("[포트원 웹훅] 알 수 없는 paymentId: paymentId={}", paymentId);
             return;
         }
-        PortOnePaymentResponse remote = fetchPortOnePaymentSilent(paymentId);
+        PortOnePaymentResponse remote = fetchPortOnePayment(paymentId).orElse(null);
         if (remote == null || remote.getStatus() != PaymentStatus.VIRTUAL_ACCOUNT_ISSUED) {
             return;
         }
@@ -306,7 +309,7 @@ public class PaymentService {
             log.warn("[포트원 웹훅] 알 수 없는 paymentId: paymentId={}", paymentId);
             return;
         }
-        PortOnePaymentResponse remote = fetchPortOnePaymentSilent(paymentId);
+        PortOnePaymentResponse remote = fetchPortOnePayment(paymentId).orElse(null);
         if (remote == null || remote.getStatus() != PaymentStatus.PAY_PENDING) {
             return;
         }
@@ -317,44 +320,22 @@ public class PaymentService {
         }
     }
 
-    private PortOnePaymentResponse fetchPortOnePaymentOrThrow(String paymentId) {
+    private Optional<PortOnePaymentResponse> fetchPortOnePayment(String paymentId) {
         try {
-            return portOneClient
-                    .http()
-                    .get()
-                    .uri("/payments/{paymentId}", paymentId)
-                    .retrieve()
-                    .bodyToMono(PortOnePaymentResponse.class)
-                    .block();
+            return Optional.ofNullable(
+                    portOneClient
+                            .http()
+                            .get()
+                            .uri("/payments/{paymentId}", paymentId)
+                            .retrieve()
+                            .bodyToMono(PortOnePaymentResponse.class)
+                            .block());
         } catch (WebClientResponseException e) {
-            if (e.getStatusCode().value() == 404) {
-                throw new CustomException(ErrorCode.PAYMENT_FAILED);
-            }
-            throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            log.warn("[포트원] API 응답 오류: paymentId={}, status={}", paymentId, e.getStatusCode());
+            return Optional.empty();
         } catch (WebClientRequestException e) {
-            log.warn("PortOne API 연결 실패 paymentId={}: {}", paymentId, e.getMessage());
-            throw new CustomException(ErrorCode.PAYMENT_FAILED);
-        }
-    }
-
-    private PortOnePaymentResponse fetchPortOnePaymentSilent(String paymentId) {
-        try {
-            return portOneClient
-                    .http()
-                    .get()
-                    .uri("/payments/{paymentId}", paymentId)
-                    .retrieve()
-                    .bodyToMono(PortOnePaymentResponse.class)
-                    .block();
-        } catch (WebClientResponseException e) {
-            if (e.getStatusCode().value() == 404) {
-                return null;
-            }
-            log.warn("[포트원 웹훅] API 호출 실패: paymentId={}, status={}", paymentId, e.getStatusCode());
-            return null;
-        } catch (WebClientRequestException e) {
-            log.warn("[포트원 웹훅] API 연결 실패: paymentId={}, msg={}", paymentId, e.getMessage());
-            return null;
+            log.warn("[포트원] API 연결 실패: paymentId={}, msg={}", paymentId, e.getMessage());
+            return Optional.empty();
         }
     }
 

--- a/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/service/ReservationService.java
@@ -129,6 +129,11 @@ public class ReservationService {
                     request.getCourseId());
             return savedId;
         } catch (DataIntegrityViolationException e) {
+            log.warn(
+                    "[예약 생성 중복 또는 무결성 위반] userId={}, courseId={}, msg={}",
+                    userId,
+                    request.getCourseId(),
+                    e.getMessage());
             throw new CustomException(ErrorCode.ALREADY_RESERVED);
         }
     }

--- a/apps/be/src/main/java/com/breadbread/user/service/UserService.java
+++ b/apps/be/src/main/java/com/breadbread/user/service/UserService.java
@@ -93,7 +93,7 @@ public class UserService {
                             .waitingTolerance(request.getWaitingTolerance())
                             .build());
         } catch (DataIntegrityViolationException e) {
-            // 동시에 두 번 저장하면 user_id 유니크 충돌 → 처리되지 않으면 500
+            log.warn("[선호도 등록 중복 또는 무결성 위반] userId={}, msg={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.PREFERENCE_ALREADY_EXISTS);
         }
         log.info("선호도 등록: userId={}", userId);
@@ -163,6 +163,7 @@ public class UserService {
             user.updateProfile(request);
             userRepository.saveAndFlush(user);
         } catch (DataIntegrityViolationException e) {
+            log.warn("[프로필 수정 중복 또는 무결성 위반] userId={}, msg={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
         }
         log.info("프로필 수정: userId={}", userId);

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryImageServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryImageServiceTest.java
@@ -1,0 +1,291 @@
+package com.breadbread.bakery.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryImage;
+import com.breadbread.bakery.repository.BakeryImageRepository;
+import com.breadbread.bakery.service.BakeryImageService.PreviewBatch;
+import com.breadbread.global.service.GcsService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BakeryImageServiceTest {
+
+    @Mock private BakeryImageRepository bakeryImageRepository;
+    @Mock private BakeryImageUrlResolver bakeryImageUrlResolver;
+    @Mock private GcsService gcsService;
+
+    @InjectMocks private BakeryImageService bakeryImageService;
+
+    // ── saveImages ───────────────────────────────────────────────────────────
+
+    @Test
+    void saveImages_does_nothing_when_urls_null() {
+        Bakery bakery = bakeryWithId(1L);
+
+        bakeryImageService.saveImages(bakery, null);
+
+        verify(bakeryImageRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void saveImages_persists_images_with_correct_display_order() {
+        Bakery bakery = bakeryWithId(1L);
+        String[] urls = {"a.jpg", "b.jpg", "c.jpg"};
+
+        bakeryImageService.saveImages(bakery, urls);
+
+        ArgumentCaptor<List<BakeryImage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(bakeryImageRepository).saveAll(captor.capture());
+        List<BakeryImage> saved = captor.getValue();
+        assertThat(saved).hasSize(3);
+        assertThat(saved.get(0).getImageUrl()).isEqualTo("a.jpg");
+        assertThat(saved.get(0).getDisplayOrder()).isEqualTo(1);
+        assertThat(saved.get(1).getImageUrl()).isEqualTo("b.jpg");
+        assertThat(saved.get(1).getDisplayOrder()).isEqualTo(2);
+        assertThat(saved.get(2).getImageUrl()).isEqualTo("c.jpg");
+        assertThat(saved.get(2).getDisplayOrder()).isEqualTo(3);
+    }
+
+    // ── deleteAllImages ──────────────────────────────────────────────────────
+
+    @Test
+    void deleteAllImages_deletes_gcs_and_db() {
+        Bakery bakery = bakeryWithId(2L);
+        bakery.getImages()
+                .add(
+                        BakeryImage.builder()
+                                .imageUrl("x.jpg")
+                                .displayOrder(1)
+                                .bakery(bakery)
+                                .build());
+        bakery.getImages()
+                .add(
+                        BakeryImage.builder()
+                                .imageUrl("y.jpg")
+                                .displayOrder(2)
+                                .bakery(bakery)
+                                .build());
+
+        bakeryImageService.deleteAllImages(bakery);
+
+        verify(gcsService).deleteQuietly("x.jpg");
+        verify(gcsService).deleteQuietly("y.jpg");
+        verify(bakeryImageRepository).deleteAllByBakery(bakery);
+    }
+
+    @Test
+    void deleteAllImages_skips_gcs_when_url_is_null() {
+        Bakery bakery = bakeryWithId(3L);
+        bakery.getImages()
+                .add(BakeryImage.builder().imageUrl(null).displayOrder(1).bakery(bakery).build());
+
+        bakeryImageService.deleteAllImages(bakery);
+
+        verify(gcsService, never()).deleteQuietly(any());
+        verify(bakeryImageRepository).deleteAllByBakery(bakery);
+    }
+
+    // ── replaceImages ────────────────────────────────────────────────────────
+
+    @Test
+    void replaceImages_deletes_old_then_saves_new() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.getImages()
+                .add(
+                        BakeryImage.builder()
+                                .imageUrl("old.jpg")
+                                .displayOrder(1)
+                                .bakery(bakery)
+                                .build());
+        String[] newUrls = {"new1.jpg", "new2.jpg"};
+
+        bakeryImageService.replaceImages(bakery, newUrls);
+
+        verify(gcsService).deleteQuietly("old.jpg");
+        verify(bakeryImageRepository).deleteAllByBakery(bakery);
+        ArgumentCaptor<List<BakeryImage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(bakeryImageRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+        assertThat(captor.getValue().get(0).getImageUrl()).isEqualTo("new1.jpg");
+    }
+
+    @Test
+    void replaceImages_does_not_delete_gcs_when_url_is_reused() {
+        Bakery bakery = bakeryWithId(5L);
+        bakery.getImages()
+                .add(
+                        BakeryImage.builder()
+                                .imageUrl("keep.jpg")
+                                .displayOrder(1)
+                                .bakery(bakery)
+                                .build());
+        // 기존 URL을 새 목록에 그대로 포함 → GCS 삭제 불필요
+        String[] newUrls = {"keep.jpg", "added.jpg"};
+
+        bakeryImageService.replaceImages(bakery, newUrls);
+
+        verify(gcsService, never()).deleteQuietly("keep.jpg");
+        verify(bakeryImageRepository).deleteAllByBakery(bakery);
+        ArgumentCaptor<List<BakeryImage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(bakeryImageRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+    }
+
+    // ── resolvePreviewBatch ──────────────────────────────────────────────────
+
+    @Test
+    void resolvePreviewBatch_returns_empty_when_ids_empty() {
+        PreviewBatch result = bakeryImageService.resolvePreviewBatch(List.of());
+
+        assertThat(result.previewUrls()).isEmpty();
+        assertThat(result.remainingCounts()).isEmpty();
+        verify(bakeryImageRepository, never()).findAllByBakeryIdInOrderByDisplayOrderAsc(any());
+    }
+
+    @Test
+    void resolvePreviewBatch_returns_first_four_and_remaining_count() {
+        Bakery bakery = bakeryWithId(10L);
+        List<BakeryImage> images = new ArrayList<>();
+        for (int i = 1; i <= 6; i++) {
+            images.add(
+                    BakeryImage.builder()
+                            .imageUrl("u" + i + ".jpg")
+                            .displayOrder(i)
+                            .bakery(bakery)
+                            .build());
+        }
+        // limit(4) 적용 후 실제 resolve 호출 대상은 첫 4개뿐
+        for (int i = 0; i < 4; i++) {
+            when(bakeryImageUrlResolver.resolve(images.get(i))).thenReturn("u" + (i + 1) + ".jpg");
+        }
+        when(bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(List.of(10L)))
+                .thenReturn(images);
+
+        PreviewBatch result = bakeryImageService.resolvePreviewBatch(List.of(10L));
+
+        assertThat(result.previewUrls().get(10L))
+                .containsExactly("u1.jpg", "u2.jpg", "u3.jpg", "u4.jpg");
+        assertThat(result.remainingCounts().get(10L)).isEqualTo(2);
+    }
+
+    @Test
+    void resolvePreviewBatch_remaining_zero_when_four_or_fewer_images() {
+        Bakery bakery = bakeryWithId(11L);
+        List<BakeryImage> images = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            BakeryImage img =
+                    BakeryImage.builder()
+                            .imageUrl("img" + i + ".jpg")
+                            .displayOrder(i)
+                            .bakery(bakery)
+                            .build();
+            images.add(img);
+            when(bakeryImageUrlResolver.resolve(img)).thenReturn("img" + i + ".jpg");
+        }
+        when(bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(List.of(11L)))
+                .thenReturn(images);
+
+        PreviewBatch result = bakeryImageService.resolvePreviewBatch(List.of(11L));
+
+        assertThat(result.previewUrls().get(11L)).hasSize(3);
+        assertThat(result.remainingCounts().get(11L)).isZero();
+    }
+
+    // ── resolveThumbnails ────────────────────────────────────────────────────
+
+    @Test
+    void resolveThumbnails_returns_empty_when_ids_empty() {
+        var result = bakeryImageService.resolveThumbnails(List.of());
+
+        assertThat(result).isEmpty();
+        verify(bakeryImageRepository, never()).findAllByBakeryIdInAndDisplayOrder(any(), anyInt());
+    }
+
+    @Test
+    void resolveThumbnails_returns_first_image_per_bakery() {
+        Bakery bakery = bakeryWithId(20L);
+        BakeryImage first =
+                BakeryImage.builder().imageUrl("thumb.jpg").displayOrder(1).bakery(bakery).build();
+        when(bakeryImageRepository.findAllByBakeryIdInAndDisplayOrder(List.of(20L), 1))
+                .thenReturn(List.of(first));
+        when(bakeryImageUrlResolver.resolve(first)).thenReturn("thumb.jpg");
+
+        var result = bakeryImageService.resolveThumbnails(List.of(20L));
+
+        assertThat(result.get(20L)).isEqualTo("thumb.jpg");
+    }
+
+    // ── resolveDetailUrls ────────────────────────────────────────────────────
+
+    @Test
+    void resolveDetailUrls_returns_empty_when_images_empty() {
+        var result = bakeryImageService.resolveDetailUrls(List.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolveDetailUrls_sorts_by_display_order_and_resolves_urls() {
+        Bakery bakery = bakeryWithId(30L);
+        BakeryImage img2 =
+                BakeryImage.builder().imageUrl("b.jpg").displayOrder(2).bakery(bakery).build();
+        BakeryImage img1 =
+                BakeryImage.builder().imageUrl("a.jpg").displayOrder(1).bakery(bakery).build();
+        when(bakeryImageUrlResolver.resolve(img1)).thenReturn("a.jpg");
+        when(bakeryImageUrlResolver.resolve(img2)).thenReturn("b.jpg");
+
+        var result = bakeryImageService.resolveDetailUrls(List.of(img2, img1));
+
+        assertThat(result).containsExactly("a.jpg", "b.jpg");
+    }
+
+    @Test
+    void resolveDetailUrls_filters_null_urls() {
+        Bakery bakery = bakeryWithId(31L);
+        BakeryImage img1 =
+                BakeryImage.builder().imageUrl("ok.jpg").displayOrder(1).bakery(bakery).build();
+        BakeryImage img2 =
+                BakeryImage.builder().imageUrl("broken.jpg").displayOrder(2).bakery(bakery).build();
+        when(bakeryImageUrlResolver.resolve(img1)).thenReturn("ok.jpg");
+        when(bakeryImageUrlResolver.resolve(img2)).thenReturn(null);
+
+        var result = bakeryImageService.resolveDetailUrls(List.of(img1, img2));
+
+        assertThat(result).containsExactly("ok.jpg");
+    }
+
+    private static Bakery bakeryWithId(long id) {
+        Bakery b =
+                Bakery.builder()
+                        .name("테스트빵집")
+                        .address("주소")
+                        .region("대전")
+                        .latitude(36.0)
+                        .longitude(127.0)
+                        .phone("010")
+                        .rating(null)
+                        .mapLink("m")
+                        .dineInAvailable(true)
+                        .parkingAvailable(false)
+                        .drinkAvailable(true)
+                        .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -12,41 +12,33 @@ import static org.mockito.Mockito.when;
 import com.breadbread.bakery.dto.BakeryAiSearch;
 import com.breadbread.bakery.dto.BakerySearch;
 import com.breadbread.bakery.dto.CreateBakeryRequest;
-import com.breadbread.bakery.dto.CreateBreadRequest;
-import com.breadbread.bakery.dto.CreateReviewRequest;
 import com.breadbread.bakery.dto.UpdateBakeryRequest;
-import com.breadbread.bakery.dto.UpdateBreadRequest;
-import com.breadbread.bakery.dto.UpdateReviewRequest;
 import com.breadbread.bakery.entity.Bakery;
-import com.breadbread.bakery.entity.BakeryImage;
 import com.breadbread.bakery.entity.BakeryLike;
 import com.breadbread.bakery.entity.Bread;
 import com.breadbread.bakery.entity.BreadType;
-import com.breadbread.bakery.entity.BusinessHours;
 import com.breadbread.bakery.entity.CrowdLevel;
 import com.breadbread.bakery.entity.CrowdTime;
 import com.breadbread.bakery.entity.DayType;
-import com.breadbread.bakery.entity.Review;
-import com.breadbread.bakery.entity.ReviewSortType;
 import com.breadbread.bakery.repository.BakeryImageRepository;
 import com.breadbread.bakery.repository.BakeryLikeRepository;
 import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.bakery.repository.BreadRepository;
 import com.breadbread.bakery.repository.CrowdTimeRepository;
 import com.breadbread.bakery.repository.ReviewRepository;
+import com.breadbread.bakery.service.BakeryImageService.PreviewBatch;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
-import com.breadbread.global.service.GcsService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +50,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,11 +62,10 @@ class BakeryServiceTest {
     @Mock private BakeryImageRepository bakeryImageRepository;
     @Mock private BakeryLikeRepository bakeryLikeRepository;
     @Mock private ReviewRepository reviewRepository;
-    @Mock private GcsService gcsService;
     @Mock private CourseBakeryRepository courseBakeryRepository;
     @Mock private CourseDrivingRouteRepository courseDrivingRouteRepository;
-    @Mock private BakeryImageUrlResolver bakeryImageUrlResolver;
     @Mock private GooglePlacesUpdateService googlePlacesUpdateService;
+    @Mock private BakeryImageService bakeryImageService;
 
     @InjectMocks private BakeryService bakeryService;
 
@@ -167,8 +157,8 @@ class BakeryServiceTest {
     @Test
     void findAllForAi_shows_weekday_hours_only_when_weekday_open() {
         Bakery b = bakeryWithId(1L);
-        BusinessHours bh =
-                BusinessHours.builder()
+        com.breadbread.bakery.entity.BusinessHours bh =
+                com.breadbread.bakery.entity.BusinessHours.builder()
                         .weekdayOpen(LocalTime.of(9, 0))
                         .weekdayClose(LocalTime.of(18, 0))
                         .weekendOpen(LocalTime.of(10, 0))
@@ -194,8 +184,8 @@ class BakeryServiceTest {
     @Test
     void findAllForAi_shows_weekend_hours_only_when_weekend_open() {
         Bakery b = bakeryWithId(1L);
-        BusinessHours bh =
-                BusinessHours.builder()
+        com.breadbread.bakery.entity.BusinessHours bh =
+                com.breadbread.bakery.entity.BusinessHours.builder()
                         .weekdayOpen(LocalTime.of(9, 0))
                         .weekdayClose(LocalTime.of(18, 0))
                         .weekendOpen(LocalTime.of(10, 0))
@@ -221,8 +211,8 @@ class BakeryServiceTest {
     @Test
     void findAllForAi_shows_all_hours_when_open_false() {
         Bakery b = bakeryWithId(1L);
-        BusinessHours bh =
-                BusinessHours.builder()
+        com.breadbread.bakery.entity.BusinessHours bh =
+                com.breadbread.bakery.entity.BusinessHours.builder()
                         .weekdayOpen(LocalTime.of(9, 0))
                         .weekdayClose(LocalTime.of(18, 0))
                         .weekendOpen(LocalTime.of(10, 0))
@@ -299,11 +289,8 @@ class BakeryServiceTest {
         Pageable pageable = PageRequest.of(0, 5);
         when(bakeryRepository.search(any(BakerySearch.class), eq(pageable)))
                 .thenReturn(new PageImpl<>(List.of(b), pageable, 1));
-        BakeryImage thumb =
-                BakeryImage.builder().imageUrl("thumb.jpg").displayOrder(1).bakery(b).build();
-        when(bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(List.of(10L)))
-                .thenReturn(List.of(thumb));
-        when(bakeryImageUrlResolver.resolve(thumb)).thenReturn("thumb.jpg");
+        when(bakeryImageService.resolvePreviewBatch(List.of(10L)))
+                .thenReturn(new PreviewBatch(Map.of(10L, List.of("thumb.jpg")), Map.of(10L, 0)));
         when(bakeryLikeRepository.countByBakeryIdIn(List.of(10L)))
                 .thenReturn(Collections.singletonList(new Object[] {10L, 7L}));
         when(bakeryLikeRepository.findLikedBakeryIdsByUserId(List.of(10L), 5L))
@@ -325,14 +312,10 @@ class BakeryServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         when(bakeryRepository.search(any(BakerySearch.class), eq(pageable)))
                 .thenReturn(new PageImpl<>(List.of(b), pageable, 1));
-        List<BakeryImage> gallery = new ArrayList<>();
-        for (int i = 1; i <= 6; i++) {
-            gallery.add(BakeryImage.builder().imageUrl("u" + i).displayOrder(i).bakery(b).build());
-        }
-        when(bakeryImageRepository.findAllByBakeryIdInOrderByDisplayOrderAsc(List.of(2L)))
-                .thenReturn(gallery);
-        when(bakeryImageUrlResolver.resolve(any(BakeryImage.class)))
-                .thenAnswer(inv -> ((BakeryImage) inv.getArgument(0)).getImageUrl());
+        when(bakeryImageService.resolvePreviewBatch(List.of(2L)))
+                .thenReturn(
+                        new PreviewBatch(
+                                Map.of(2L, List.of("u1", "u2", "u3", "u4")), Map.of(2L, 2)));
         when(bakeryLikeRepository.countByBakeryIdIn(List.of(2L))).thenReturn(List.of());
 
         var result = bakeryService.search(BakerySearch.builder().build(), pageable, null);
@@ -395,11 +378,8 @@ class BakeryServiceTest {
         Long id = bakeryService.createBakery(10L, request);
 
         assertThat(id).isEqualTo(100L);
-        ArgumentCaptor<List<BakeryImage>> captor = ArgumentCaptor.forClass(List.class);
-        verify(bakeryImageRepository).saveAll(captor.capture());
-        assertThat(captor.getValue()).hasSize(2);
-        assertThat(captor.getValue().get(0).getDisplayOrder()).isEqualTo(1);
-        assertThat(captor.getValue().get(1).getDisplayOrder()).isEqualTo(2);
+        verify(bakeryImageService)
+                .saveImages(any(Bakery.class), eq(new String[] {"a.jpg", "b.jpg"}));
         verify(bakeryRepository).save(any(Bakery.class));
     }
 
@@ -438,43 +418,25 @@ class BakeryServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.FORBIDDEN);
 
-        verify(bakeryImageRepository, never()).deleteAllByBakery(any());
+        verify(bakeryImageService, never()).replaceImages(any(), any());
     }
 
     @Test
     void updateBakery_replaces_images_when_admin_updates() {
         Bakery bakery = bakeryWithId(5L);
-        bakery.getImages()
-                .add(
-                        BakeryImage.builder()
-                                .imageUrl("old.jpg")
-                                .displayOrder(1)
-                                .bakery(bakery)
-                                .build());
         UpdateBakeryRequest request = new UpdateBakeryRequest();
         ReflectionTestUtils.setField(request, "imageUrls", new String[] {"new.jpg"});
         when(bakeryRepository.findByIdAndActiveTrue(5L)).thenReturn(Optional.of(bakery));
 
         bakeryService.updateBakery(999L, UserRole.ROLE_ADMIN, 5L, request);
 
-        verify(gcsService).deleteQuietly("old.jpg");
-        verify(bakeryImageRepository).deleteAllByBakery(bakery);
-        ArgumentCaptor<List<BakeryImage>> captor = ArgumentCaptor.forClass(List.class);
-        verify(bakeryImageRepository).saveAll(captor.capture());
-        assertThat(captor.getValue().get(0).getImageUrl()).isEqualTo("new.jpg");
+        verify(bakeryImageService).replaceImages(eq(bakery), eq(new String[] {"new.jpg"}));
     }
 
     @Test
     void updateBakery_skipsImageReplacement_whenImageUrlsIsNull() {
         Bakery bakery = bakeryWithId(12L);
         bakery.assignOwner(user(50L, UserRole.ROLE_BUSINESS));
-        bakery.getImages()
-                .add(
-                        BakeryImage.builder()
-                                .imageUrl("keep.jpg")
-                                .displayOrder(1)
-                                .bakery(bakery)
-                                .build());
         UpdateBakeryRequest request = new UpdateBakeryRequest();
         ReflectionTestUtils.setField(request, "name", "이름만변경");
         when(bakeryRepository.findByIdAndActiveTrue(12L)).thenReturn(Optional.of(bakery));
@@ -482,9 +444,7 @@ class BakeryServiceTest {
         bakeryService.updateBakery(50L, UserRole.ROLE_BUSINESS, 12L, request);
 
         assertThat(bakery.getName()).isEqualTo("이름만변경");
-        verify(gcsService, never()).deleteQuietly(any());
-        verify(bakeryImageRepository, never()).deleteAllByBakery(any());
-        verify(bakeryImageRepository, never()).saveAll(any());
+        verify(bakeryImageService, never()).replaceImages(any(), any());
     }
 
     @Test
@@ -492,19 +452,11 @@ class BakeryServiceTest {
         Bakery bakery = bakeryWithId(8L);
         User owner = user(3L, UserRole.ROLE_BUSINESS);
         bakery.assignOwner(owner);
-        bakery.getImages()
-                .add(
-                        BakeryImage.builder()
-                                .imageUrl("x.jpg")
-                                .displayOrder(1)
-                                .bakery(bakery)
-                                .build());
         when(bakeryRepository.findByIdAndActiveTrue(8L)).thenReturn(Optional.of(bakery));
 
         bakeryService.deleteBakery(3L, UserRole.ROLE_BUSINESS, 8L);
 
-        verify(gcsService).deleteQuietly("x.jpg");
-        verify(bakeryImageRepository).deleteAllByBakery(bakery);
+        verify(bakeryImageService).deleteAllImages(bakery);
         assertThat(bakery.isActive()).isFalse();
     }
 
@@ -520,117 +472,17 @@ class BakeryServiceTest {
                 .isEqualTo(ErrorCode.FORBIDDEN);
 
         verify(bakeryRepository, never()).delete(any(Bakery.class));
-        verify(gcsService, never()).deleteQuietly(any());
-    }
-
-    @Test
-    void createBread_throws_whenForbidden() {
-        Bakery bakery = bakeryWithId(1L);
-        bakery.assignOwner(user(1L, UserRole.ROLE_BUSINESS));
-        when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(bakery));
-        CreateBreadRequest request = createBreadRequest("메론빵");
-
-        assertThatThrownBy(() -> bakeryService.createBread(2L, UserRole.ROLE_BUSINESS, 1L, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-
-        verify(breadRepository, never()).save(any());
-    }
-
-    @Test
-    void createBread_returnsBreadId_whenOwner() {
-        Bakery bakery = bakeryWithId(4L);
-        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
-        CreateBreadRequest request = createBreadRequest("소금빵");
-        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
-        when(breadRepository.save(any(Bread.class)))
-                .thenAnswer(
-                        inv -> {
-                            Bread saved = inv.getArgument(0);
-                            ReflectionTestUtils.setField(saved, "id", 400L);
-                            return saved;
-                        });
-
-        Long breadId = bakeryService.createBread(7L, UserRole.ROLE_BUSINESS, 4L, request);
-
-        assertThat(breadId).isEqualTo(400L);
-    }
-
-    @Test
-    void updateBread_deletesOldImage_whenUrlChanges() {
-        Bakery bakery = bakeryWithId(4L);
-        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
-        Bread bread =
-                Bread.builder()
-                        .name("old")
-                        .price(1000)
-                        .imageUrl("prev.jpg")
-                        .bakery(bakery)
-                        .breadType(BreadType.BREAD)
-                        .signature(false)
-                        .selloutMin(0)
-                        .build();
-        ReflectionTestUtils.setField(bread, "id", 50L);
-        UpdateBreadRequest request = new UpdateBreadRequest();
-        ReflectionTestUtils.setField(request, "imageUrl", "next.jpg");
-        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
-        when(breadRepository.findById(50L)).thenReturn(Optional.of(bread));
-
-        bakeryService.updateBread(7L, UserRole.ROLE_BUSINESS, 4L, 50L, request);
-
-        verify(gcsService).deleteQuietly("prev.jpg");
-    }
-
-    @Test
-    void updateBread_throws_whenBreadMissing() {
-        Bakery bakery = bakeryWithId(4L);
-        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
-        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
-        when(breadRepository.findById(999L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(
-                        () ->
-                                bakeryService.updateBread(
-                                        7L,
-                                        UserRole.ROLE_BUSINESS,
-                                        4L,
-                                        999L,
-                                        new UpdateBreadRequest()))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.MENU_NOT_FOUND);
-    }
-
-    @Test
-    void deleteBread_deletesImage_whenPresent() {
-        Bakery bakery = bakeryWithId(4L);
-        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
-        Bread bread =
-                Bread.builder()
-                        .name("x")
-                        .price(500)
-                        .imageUrl("gone.jpg")
-                        .bakery(bakery)
-                        .breadType(BreadType.BREAD)
-                        .signature(false)
-                        .selloutMin(0)
-                        .build();
-        ReflectionTestUtils.setField(bread, "id", 60L);
-        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
-        when(breadRepository.findById(60L)).thenReturn(Optional.of(bread));
-
-        bakeryService.deleteBread(7L, UserRole.ROLE_BUSINESS, 4L, 60L);
-
-        verify(gcsService).deleteQuietly("gone.jpg");
-        verify(breadRepository).delete(bread);
+        verify(bakeryImageService, never()).deleteAllImages(any());
     }
 
     @Test
     void like_throws_whenAlreadyLiked() {
         Bakery bakery = bakeryWithId(1L);
         when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(bakery));
-        when(bakeryLikeRepository.existsByBakeryIdAndUserId(1L, 5L)).thenReturn(true);
+        when(userRepository.findById(5L)).thenReturn(Optional.of(user(5L, UserRole.ROLE_USER)));
+        doThrow(new DataIntegrityViolationException("dup"))
+                .when(bakeryLikeRepository)
+                .saveAndFlush(any(BakeryLike.class));
 
         assertThatThrownBy(() -> bakeryService.like(1L, 5L))
                 .isInstanceOf(CustomException.class)
@@ -643,11 +495,10 @@ class BakeryServiceTest {
         Bakery bakery = bakeryWithId(1L);
         User user = user(5L, UserRole.ROLE_USER);
         when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(bakery));
-        when(bakeryLikeRepository.existsByBakeryIdAndUserId(1L, 5L)).thenReturn(false);
         when(userRepository.findById(5L)).thenReturn(Optional.of(user));
         doThrow(new DataIntegrityViolationException("dup"))
                 .when(bakeryLikeRepository)
-                .save(any(BakeryLike.class));
+                .saveAndFlush(any(BakeryLike.class));
 
         assertThatThrownBy(() -> bakeryService.like(1L, 5L))
                 .isInstanceOf(CustomException.class)
@@ -684,258 +535,14 @@ class BakeryServiceTest {
         Bakery bakery = bakeryWithId(1L);
         User liker = user(5L, UserRole.ROLE_USER);
         when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(bakery));
-        when(bakeryLikeRepository.existsByBakeryIdAndUserId(1L, 5L)).thenReturn(false);
         when(userRepository.findById(5L)).thenReturn(Optional.of(liker));
 
         bakeryService.like(1L, 5L);
 
         ArgumentCaptor<BakeryLike> captor = ArgumentCaptor.forClass(BakeryLike.class);
-        verify(bakeryLikeRepository).save(captor.capture());
+        verify(bakeryLikeRepository).saveAndFlush(captor.capture());
         assertThat(captor.getValue().getBakery()).isSameAs(bakery);
         assertThat(captor.getValue().getUser()).isSameAs(liker);
-    }
-
-    @Test
-    void createReview_updates_rating_when_save_succeeds() {
-        Bakery bakery = bakeryWithId(20L);
-        User author = user(30L, UserRole.ROLE_USER);
-        CreateReviewRequest request = createReviewRequest("좋아요", 5);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(userRepository.findById(30L)).thenReturn(Optional.of(author));
-        when(reviewRepository.save(any(Review.class)))
-                .thenAnswer(
-                        inv -> {
-                            Review r = inv.getArgument(0);
-                            ReflectionTestUtils.setField(r, "id", 900L);
-                            return r;
-                        });
-        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.of(4.25));
-
-        Long reviewId = bakeryService.createReview(20L, 30L, request);
-
-        assertThat(reviewId).isEqualTo(900L);
-        assertThat(bakery.getRating()).isEqualTo(4.25);
-    }
-
-    @Test
-    void createReview_throws_when_bakery_missing() {
-        CreateReviewRequest request = createReviewRequest("nice", 5);
-        when(bakeryRepository.findByIdAndActiveTrue(99L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> bakeryService.createReview(99L, 30L, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
-
-        verify(reviewRepository, never()).save(any(Review.class));
-    }
-
-    @Test
-    void createReview_throws_when_user_missing() {
-        CreateReviewRequest request = createReviewRequest("nice", 5);
-        when(bakeryRepository.findByIdAndActiveTrue(20L))
-                .thenReturn(Optional.of(bakeryWithId(20L)));
-        when(userRepository.findById(77L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> bakeryService.createReview(20L, 77L, request))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.USER_NOT_FOUND);
-
-        verify(reviewRepository, never()).save(any(Review.class));
-    }
-
-    @Test
-    void getReviews_throws_whenBakeryMissing() {
-        when(bakeryRepository.existsByIdAndActiveTrue(1L)).thenReturn(false);
-
-        assertThatThrownBy(() -> bakeryService.getReviews(1L, ReviewSortType.LATEST, 0, 10, null))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
-    }
-
-    @Test
-    void getReviews_returns_paged_sorted_by_created_desc_when_default_sort() {
-        Review review =
-                Review.builder()
-                        .content("review")
-                        .rating(4)
-                        .imageUrls(List.of("r1.jpg"))
-                        .user(user(30L, UserRole.ROLE_USER))
-                        .bakery(bakeryWithId(20L))
-                        .build();
-        ReflectionTestUtils.setField(review, "id", 101L);
-
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
-        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
-                .thenReturn(new PageImpl<>(List.of(review), PageRequest.of(0, 10), 1));
-
-        var result = bakeryService.getReviews(20L, ReviewSortType.LATEST, 0, 10, 30L);
-
-        assertThat(result.getReviews()).hasSize(1);
-        assertThat(result.getReviews().get(0).getId()).isEqualTo(101L);
-        assertThat(result.getReviews().get(0).isAuthor()).isTrue();
-        assertThat(result.getTotal()).isEqualTo(1);
-        assertThat(result.isHasNext()).isFalse();
-        assertThat(pageableCaptor.getValue().getSort())
-                .isEqualTo(Sort.by("createdAt").descending());
-    }
-
-    @Test
-    void getReviews_sortsByRatingDescending_whenHighRatingRequested() {
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
-        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
-                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
-
-        bakeryService.getReviews(20L, ReviewSortType.RATING_HIGH, 0, 10, null);
-
-        assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by("rating").descending());
-    }
-
-    @Test
-    void getReviews_sortsByRatingAscending_whenLowRatingRequested() {
-        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
-        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
-                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
-
-        bakeryService.getReviews(20L, ReviewSortType.RATING_LOW, 0, 10, null);
-
-        assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by("rating").ascending());
-    }
-
-    @Test
-    void updateReview_throws_when_review_missing() {
-        Bakery bakery = bakeryWithId(20L);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(999L, 20L))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(
-                        () -> bakeryService.updateReview(20L, 999L, 40L, new UpdateReviewRequest()))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
-    }
-
-    @Test
-    void updateReview_throws_whenNotAuthor() {
-        Bakery bakery = bakeryWithId(20L);
-        User author = user(40L, UserRole.ROLE_USER);
-        Review review =
-                Review.builder()
-                        .content("a")
-                        .rating(3)
-                        .imageUrls(List.of())
-                        .user(author)
-                        .bakery(bakery)
-                        .build();
-        ReflectionTestUtils.setField(review, "id", 11L);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
-                .thenReturn(Optional.of(review));
-
-        assertThatThrownBy(
-                        () -> bakeryService.updateReview(20L, 11L, 77L, new UpdateReviewRequest()))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-    }
-
-    @Test
-    void updateReview_updatesContentAndRating_whenAuthorMatches() {
-        Bakery bakery = bakeryWithId(20L);
-        User author = user(40L, UserRole.ROLE_USER);
-        Review review =
-                Review.builder()
-                        .content("before")
-                        .rating(3)
-                        .imageUrls(List.of("old.jpg"))
-                        .user(author)
-                        .bakery(bakery)
-                        .build();
-        ReflectionTestUtils.setField(review, "id", 11L);
-        UpdateReviewRequest request = new UpdateReviewRequest();
-        ReflectionTestUtils.setField(request, "content", "after");
-        ReflectionTestUtils.setField(request, "rating", 5);
-        ReflectionTestUtils.setField(request, "imageUrls", List.of("new.jpg"));
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
-                .thenReturn(Optional.of(review));
-        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.of(4.75));
-
-        bakeryService.updateReview(20L, 11L, 40L, request);
-
-        assertThat(review.getContent()).isEqualTo("after");
-        assertThat(review.getRating()).isEqualTo(5);
-        assertThat(review.getImageUrls()).containsExactly("new.jpg");
-        assertThat(bakery.getRating()).isEqualTo(4.75);
-        verify(gcsService, never()).deleteQuietly(any());
-    }
-
-    @Test
-    void deleteReview_succeeds_when_admin_not_author() {
-        Bakery bakery = bakeryWithId(20L);
-        User author = user(40L, UserRole.ROLE_USER);
-        Review review =
-                Review.builder()
-                        .content("a")
-                        .rating(3)
-                        .imageUrls(List.of())
-                        .user(author)
-                        .bakery(bakery)
-                        .build();
-        ReflectionTestUtils.setField(review, "id", 11L);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
-                .thenReturn(Optional.of(review));
-        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
-
-        bakeryService.deleteReview(20L, 11L, 999L, UserRole.ROLE_ADMIN);
-
-        assertThat(review.isActive()).isFalse();
-        verify(reviewRepository).findAverageRatingByBakeryId(20L);
-    }
-
-    @Test
-    void deleteReview_throws_when_review_missing() {
-        Bakery bakery = bakeryWithId(20L);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(999L, 20L))
-                .thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> bakeryService.deleteReview(20L, 999L, 40L, UserRole.ROLE_USER))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
-
-        verify(reviewRepository, never()).delete(any(Review.class));
-    }
-
-    @Test
-    void deleteReview_throws_whenRequesterIsNeitherAuthorNorAdmin() {
-        Bakery bakery = bakeryWithId(20L);
-        User author = user(40L, UserRole.ROLE_USER);
-        Review review =
-                Review.builder()
-                        .content("a")
-                        .rating(3)
-                        .imageUrls(List.of())
-                        .user(author)
-                        .bakery(bakery)
-                        .build();
-        ReflectionTestUtils.setField(review, "id", 11L);
-        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
-        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
-                .thenReturn(Optional.of(review));
-
-        assertThatThrownBy(() -> bakeryService.deleteReview(20L, 11L, 999L, UserRole.ROLE_USER))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
     }
 
     @Test
@@ -1016,21 +623,6 @@ class BakeryServiceTest {
         ReflectionTestUtils.setField(request, "parkingAvailable", false);
         ReflectionTestUtils.setField(request, "drinkAvailable", true);
         ReflectionTestUtils.setField(request, "holidayClosed", false);
-        return request;
-    }
-
-    private static CreateBreadRequest createBreadRequest(String name) {
-        CreateBreadRequest request = new CreateBreadRequest();
-        ReflectionTestUtils.setField(request, "name", name);
-        ReflectionTestUtils.setField(request, "price", 2000);
-        ReflectionTestUtils.setField(request, "signature", false);
-        return request;
-    }
-
-    private static CreateReviewRequest createReviewRequest(String content, int rating) {
-        CreateReviewRequest request = new CreateReviewRequest();
-        ReflectionTestUtils.setField(request, "content", content);
-        ReflectionTestUtils.setField(request, "rating", rating);
         return request;
     }
 

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BreadServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BreadServiceTest.java
@@ -1,0 +1,208 @@
+package com.breadbread.bakery.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.dto.CreateBreadRequest;
+import com.breadbread.bakery.dto.UpdateBreadRequest;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.Bread;
+import com.breadbread.bakery.entity.BreadType;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BreadRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.GcsService;
+import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserRole;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BreadServiceTest {
+
+    @Mock private BakeryRepository bakeryRepository;
+    @Mock private BreadRepository breadRepository;
+    @Mock private GcsService gcsService;
+
+    @InjectMocks private BreadService breadService;
+
+    @Test
+    void createBread_throws_whenForbidden() {
+        Bakery bakery = bakeryWithId(1L);
+        bakery.assignOwner(user(1L, UserRole.ROLE_BUSINESS));
+        when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(bakery));
+        CreateBreadRequest request = createBreadRequest("메론빵");
+
+        assertThatThrownBy(() -> breadService.createBread(2L, UserRole.ROLE_BUSINESS, 1L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(breadRepository, never()).save(any());
+    }
+
+    @Test
+    void createBread_returnsBreadId_whenOwner() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
+        CreateBreadRequest request = createBreadRequest("소금빵");
+        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
+        when(breadRepository.save(any(Bread.class)))
+                .thenAnswer(
+                        inv -> {
+                            Bread saved = inv.getArgument(0);
+                            ReflectionTestUtils.setField(saved, "id", 400L);
+                            return saved;
+                        });
+
+        Long breadId = breadService.createBread(7L, UserRole.ROLE_BUSINESS, 4L, request);
+
+        assertThat(breadId).isEqualTo(400L);
+    }
+
+    @Test
+    void updateBread_deletesOldImage_whenUrlChanges() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
+        Bread bread =
+                Bread.builder()
+                        .name("old")
+                        .price(1000)
+                        .imageUrl("prev.jpg")
+                        .bakery(bakery)
+                        .breadType(BreadType.BREAD)
+                        .signature(false)
+                        .selloutMin(0)
+                        .build();
+        ReflectionTestUtils.setField(bread, "id", 50L);
+        UpdateBreadRequest request = new UpdateBreadRequest();
+        ReflectionTestUtils.setField(request, "imageUrl", "next.jpg");
+        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
+        when(breadRepository.findByIdAndBakeryId(50L, 4L)).thenReturn(Optional.of(bread));
+
+        breadService.updateBread(7L, UserRole.ROLE_BUSINESS, 4L, 50L, request);
+
+        verify(gcsService).deleteQuietly("prev.jpg");
+    }
+
+    @Test
+    void updateBread_throws_whenBreadMissing() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
+        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
+        when(breadRepository.findByIdAndBakeryId(999L, 4L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                        () ->
+                                breadService.updateBread(
+                                        7L,
+                                        UserRole.ROLE_BUSINESS,
+                                        4L,
+                                        999L,
+                                        new UpdateBreadRequest()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MENU_NOT_FOUND);
+    }
+
+    @Test
+    void updateBread_throws_whenBreadBelongsToDifferentBakery() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
+        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
+        when(breadRepository.findByIdAndBakeryId(50L, 4L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                        () ->
+                                breadService.updateBread(
+                                        7L,
+                                        UserRole.ROLE_BUSINESS,
+                                        4L,
+                                        50L,
+                                        new UpdateBreadRequest()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MENU_NOT_FOUND);
+
+        verify(gcsService, never()).deleteQuietly(any());
+    }
+
+    @Test
+    void deleteBread_deletesImage_whenPresent() {
+        Bakery bakery = bakeryWithId(4L);
+        bakery.assignOwner(user(7L, UserRole.ROLE_BUSINESS));
+        Bread bread =
+                Bread.builder()
+                        .name("x")
+                        .price(500)
+                        .imageUrl("gone.jpg")
+                        .bakery(bakery)
+                        .breadType(BreadType.BREAD)
+                        .signature(false)
+                        .selloutMin(0)
+                        .build();
+        ReflectionTestUtils.setField(bread, "id", 60L);
+        when(bakeryRepository.findByIdAndActiveTrue(4L)).thenReturn(Optional.of(bakery));
+        when(breadRepository.findByIdAndBakeryId(60L, 4L)).thenReturn(Optional.of(bread));
+
+        breadService.deleteBread(7L, UserRole.ROLE_BUSINESS, 4L, 60L);
+
+        verify(gcsService).deleteQuietly("gone.jpg");
+        verify(breadRepository).delete(bread);
+    }
+
+    private static Bakery bakeryWithId(long id) {
+        Bakery b =
+                Bakery.builder()
+                        .name("테스트빵집")
+                        .address("주소")
+                        .region("대전")
+                        .latitude(36.0)
+                        .longitude(127.0)
+                        .phone("010")
+                        .rating(null)
+                        .mapLink("m")
+                        .dineInAvailable(true)
+                        .parkingAvailable(false)
+                        .drinkAvailable(true)
+                        .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+
+    private static User user(long id, UserRole role) {
+        User u =
+                User.builder()
+                        .loginId("u" + id)
+                        .password("p")
+                        .name("n" + id)
+                        .nickname("nick" + id)
+                        .email(id + "@t.com")
+                        .phone("0100000" + String.format("%04d", id))
+                        .role(role)
+                        .termsAgreed(true)
+                        .privacyAgreed(true)
+                        .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private static CreateBreadRequest createBreadRequest(String name) {
+        CreateBreadRequest request = new CreateBreadRequest();
+        ReflectionTestUtils.setField(request, "name", name);
+        ReflectionTestUtils.setField(request, "price", 2000);
+        ReflectionTestUtils.setField(request, "signature", false);
+        return request;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/bakery/service/ReviewServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/ReviewServiceTest.java
@@ -1,0 +1,334 @@
+package com.breadbread.bakery.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.dto.CreateReviewRequest;
+import com.breadbread.bakery.dto.UpdateReviewRequest;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.entity.ReviewSortType;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.ReviewRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.GcsService;
+import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserRole;
+import com.breadbread.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock private BakeryRepository bakeryRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ReviewRepository reviewRepository;
+    @Mock private GcsService gcsService;
+
+    @InjectMocks private ReviewService reviewService;
+
+    @Test
+    void createReview_updates_rating_when_save_succeeds() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(30L, UserRole.ROLE_USER);
+        CreateReviewRequest request = createReviewRequest("좋아요", 5);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(userRepository.findById(30L)).thenReturn(Optional.of(author));
+        when(reviewRepository.save(any(Review.class)))
+                .thenAnswer(
+                        inv -> {
+                            Review r = inv.getArgument(0);
+                            ReflectionTestUtils.setField(r, "id", 900L);
+                            return r;
+                        });
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.of(4.25));
+
+        Long reviewId = reviewService.createReview(20L, 30L, request);
+
+        assertThat(reviewId).isEqualTo(900L);
+        assertThat(bakery.getRating()).isEqualTo(4.25);
+    }
+
+    @Test
+    void createReview_throws_when_bakery_missing() {
+        CreateReviewRequest request = createReviewRequest("nice", 5);
+        when(bakeryRepository.findByIdAndActiveTrue(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewService.createReview(99L, 30L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+
+    @Test
+    void createReview_throws_when_user_missing() {
+        CreateReviewRequest request = createReviewRequest("nice", 5);
+        when(bakeryRepository.findByIdAndActiveTrue(20L))
+                .thenReturn(Optional.of(bakeryWithId(20L)));
+        when(userRepository.findById(77L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewService.createReview(20L, 77L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+
+    @Test
+    void getReviews_throws_whenBakeryMissing() {
+        when(bakeryRepository.existsByIdAndActiveTrue(1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> reviewService.getReviews(1L, ReviewSortType.LATEST, 0, 10, null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+    }
+
+    @Test
+    void getReviews_returns_paged_sorted_by_created_desc_when_default_sort() {
+        Review review =
+                Review.builder()
+                        .content("review")
+                        .rating(4)
+                        .imageUrls(List.of("r1.jpg"))
+                        .user(user(30L, UserRole.ROLE_USER))
+                        .bakery(bakeryWithId(20L))
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 101L);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
+        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
+                .thenReturn(new PageImpl<>(List.of(review), PageRequest.of(0, 10), 1));
+
+        var result = reviewService.getReviews(20L, ReviewSortType.LATEST, 0, 10, 30L);
+
+        assertThat(result.getReviews()).hasSize(1);
+        assertThat(result.getReviews().get(0).getId()).isEqualTo(101L);
+        assertThat(result.getReviews().get(0).isAuthor()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(1);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(pageableCaptor.getValue().getSort())
+                .isEqualTo(Sort.by("createdAt").descending());
+    }
+
+    @Test
+    void getReviews_sortsByRatingDescending_whenHighRatingRequested() {
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
+        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        reviewService.getReviews(20L, ReviewSortType.RATING_HIGH, 0, 10, null);
+
+        assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by("rating").descending());
+    }
+
+    @Test
+    void getReviews_sortsByRatingAscending_whenLowRatingRequested() {
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        when(bakeryRepository.existsByIdAndActiveTrue(20L)).thenReturn(true);
+        when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        reviewService.getReviews(20L, ReviewSortType.RATING_LOW, 0, 10, null);
+
+        assertThat(pageableCaptor.getValue().getSort()).isEqualTo(Sort.by("rating").ascending());
+    }
+
+    @Test
+    void updateReview_throws_when_review_missing() {
+        Bakery bakery = bakeryWithId(20L);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(999L, 20L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                        () -> reviewService.updateReview(20L, 999L, 40L, new UpdateReviewRequest()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+    }
+
+    @Test
+    void updateReview_throws_whenNotAuthor() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(40L, UserRole.ROLE_USER);
+        Review review =
+                Review.builder()
+                        .content("a")
+                        .rating(3)
+                        .imageUrls(List.of())
+                        .user(author)
+                        .bakery(bakery)
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 11L);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
+                .thenReturn(Optional.of(review));
+
+        assertThatThrownBy(
+                        () -> reviewService.updateReview(20L, 11L, 77L, new UpdateReviewRequest()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void updateReview_updatesContentAndRating_whenAuthorMatches() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(40L, UserRole.ROLE_USER);
+        Review review =
+                Review.builder()
+                        .content("before")
+                        .rating(3)
+                        .imageUrls(List.of("old.jpg"))
+                        .user(author)
+                        .bakery(bakery)
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 11L);
+        UpdateReviewRequest request = new UpdateReviewRequest();
+        ReflectionTestUtils.setField(request, "content", "after");
+        ReflectionTestUtils.setField(request, "rating", 5);
+        ReflectionTestUtils.setField(request, "imageUrls", List.of("new.jpg"));
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
+                .thenReturn(Optional.of(review));
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.of(4.75));
+
+        reviewService.updateReview(20L, 11L, 40L, request);
+
+        assertThat(review.getContent()).isEqualTo("after");
+        assertThat(review.getRating()).isEqualTo(5);
+        assertThat(review.getImageUrls()).containsExactly("new.jpg");
+        assertThat(bakery.getRating()).isEqualTo(4.75);
+        verify(gcsService, never()).deleteQuietly(any());
+    }
+
+    @Test
+    void deleteReview_succeeds_when_admin_not_author() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(40L, UserRole.ROLE_USER);
+        Review review =
+                Review.builder()
+                        .content("a")
+                        .rating(3)
+                        .imageUrls(List.of())
+                        .user(author)
+                        .bakery(bakery)
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 11L);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
+                .thenReturn(Optional.of(review));
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
+
+        reviewService.deleteReview(20L, 11L, 999L, UserRole.ROLE_ADMIN);
+
+        assertThat(review.isActive()).isFalse();
+        verify(reviewRepository).findAverageRatingByBakeryId(20L);
+    }
+
+    @Test
+    void deleteReview_throws_when_review_missing() {
+        Bakery bakery = bakeryWithId(20L);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(999L, 20L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewService.deleteReview(20L, 999L, 40L, UserRole.ROLE_USER))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+
+        verify(reviewRepository, never()).delete(any(Review.class));
+    }
+
+    @Test
+    void deleteReview_throws_whenRequesterIsNeitherAuthorNorAdmin() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(40L, UserRole.ROLE_USER);
+        Review review =
+                Review.builder()
+                        .content("a")
+                        .rating(3)
+                        .imageUrls(List.of())
+                        .user(author)
+                        .bakery(bakery)
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 11L);
+        when(bakeryRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
+                .thenReturn(Optional.of(review));
+
+        assertThatThrownBy(() -> reviewService.deleteReview(20L, 11L, 999L, UserRole.ROLE_USER))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    private static Bakery bakeryWithId(long id) {
+        Bakery b =
+                Bakery.builder()
+                        .name("테스트빵집")
+                        .address("주소")
+                        .region("대전")
+                        .latitude(36.0)
+                        .longitude(127.0)
+                        .phone("010")
+                        .rating(null)
+                        .mapLink("m")
+                        .dineInAvailable(true)
+                        .parkingAvailable(false)
+                        .drinkAvailable(true)
+                        .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+
+    private static User user(long id, UserRole role) {
+        User u =
+                User.builder()
+                        .loginId("u" + id)
+                        .password("p")
+                        .name("n" + id)
+                        .nickname("nick" + id)
+                        .email(id + "@t.com")
+                        .phone("0100000" + String.format("%04d", id))
+                        .role(role)
+                        .termsAgreed(true)
+                        .privacyAgreed(true)
+                        .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private static CreateReviewRequest createReviewRequest(String content, int rating) {
+        CreateReviewRequest request = new CreateReviewRequest();
+        ReflectionTestUtils.setField(request, "content", content);
+        ReflectionTestUtils.setField(request, "rating", rating);
+        return request;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/community/service/CommunityServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/community/service/CommunityServiceTest.java
@@ -18,9 +18,9 @@ import com.breadbread.community.entity.Comment;
 import com.breadbread.community.entity.Post;
 import com.breadbread.community.entity.PostLike;
 import com.breadbread.community.entity.PostType;
-import com.breadbread.community.respository.CommentRepository;
-import com.breadbread.community.respository.PostLikeRepository;
-import com.breadbread.community.respository.PostRepository;
+import com.breadbread.community.repository.CommentRepository;
+import com.breadbread.community.repository.PostLikeRepository;
+import com.breadbread.community.repository.PostRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.service.GcsService;
@@ -405,14 +405,14 @@ class CommunityServiceTest {
         Post post = post(1L, "t", PostType.FREE, user(1L), List.of());
         when(postRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(user(2L)));
-        when(postLikeRepository.existsByUserIdAndPostId(2L, 1L)).thenReturn(true);
+        doThrow(new DataIntegrityViolationException("dup"))
+                .when(postLikeRepository)
+                .saveAndFlush(any(PostLike.class));
 
         assertThatThrownBy(() -> communityService.likePost(1L, 2L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ALREADY_POST_LIKED);
-
-        verify(postLikeRepository, never()).save(any(PostLike.class));
     }
 
     @Test
@@ -420,10 +420,9 @@ class CommunityServiceTest {
         Post post = post(1L, "t", PostType.FREE, user(1L), List.of());
         when(postRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(post));
         when(userRepository.findById(2L)).thenReturn(Optional.of(user(2L)));
-        when(postLikeRepository.existsByUserIdAndPostId(2L, 1L)).thenReturn(false);
         doThrow(new DataIntegrityViolationException("dup"))
                 .when(postLikeRepository)
-                .save(any(PostLike.class));
+                .saveAndFlush(any(PostLike.class));
 
         assertThatThrownBy(() -> communityService.likePost(1L, 2L))
                 .isInstanceOf(CustomException.class)

--- a/apps/fe/src/components/domain/curator/BreadBotConfetti.tsx
+++ b/apps/fe/src/components/domain/curator/BreadBotConfetti.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/utils/cn";
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  rotation: number;
+  rotationSpeed: number;
+  color: string;
+  life: number;
+};
+
+type BreadBotConfettiProps = {
+  active: boolean;
+  className?: string;
+  onComplete?: () => void;
+};
+
+const COLORS = ["#ff8648", "#ffb347", "#ffd166", "#06d6a0", "#118ab2", "#ef476f", "#8338ec"];
+
+function createParticle(width: number): Particle {
+  return {
+    x: width * (0.25 + Math.random() * 0.5),
+    y: -12,
+    vx: (Math.random() - 0.5) * 7,
+    vy: 2 + Math.random() * 4,
+    size: 5 + Math.random() * 7,
+    rotation: Math.random() * 360,
+    rotationSpeed: (Math.random() - 0.5) * 12,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)]!,
+    life: 1,
+  };
+}
+
+export default function BreadBotConfetti({ active, className, onComplete }: BreadBotConfettiProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const onCompleteRef = useRef(onComplete);
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    if (!active) return undefined;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+
+    const context = canvas.getContext("2d");
+    if (!context) return undefined;
+
+    let animationId = 0;
+    let cancelled = false;
+    const particles: Particle[] = [];
+    const startedAt = performance.now();
+    const durationMs = 3200;
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+
+    resize();
+    window.addEventListener("resize", resize);
+
+    for (let i = 0; i < 120; i++) {
+      particles.push(createParticle(canvas.width));
+    }
+
+    const tick = (now: number) => {
+      if (cancelled) return;
+
+      context.clearRect(0, 0, canvas.width, canvas.height);
+
+      for (const particle of particles) {
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+        particle.vy += 0.12;
+        particle.vx *= 0.99;
+        particle.rotation += particle.rotationSpeed;
+        particle.life = Math.max(0, 1 - (now - startedAt) / durationMs);
+
+        context.save();
+        context.translate(particle.x, particle.y);
+        context.rotate((particle.rotation * Math.PI) / 180);
+        context.globalAlpha = particle.life;
+        context.fillStyle = particle.color;
+        context.fillRect(-particle.size / 2, -particle.size / 4, particle.size, particle.size / 2);
+        context.restore();
+      }
+
+      if (now - startedAt < durationMs) {
+        animationId = window.requestAnimationFrame(tick);
+      } else {
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        onCompleteRef.current?.();
+      }
+    };
+
+    animationId = window.requestAnimationFrame(tick);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(animationId);
+      window.removeEventListener("resize", resize);
+    };
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className={cn("pointer-events-none fixed inset-0 z-[80]", className)}
+    />
+  );
+}

--- a/apps/fe/src/components/domain/curator/BreadBotWidget.tsx
+++ b/apps/fe/src/components/domain/curator/BreadBotWidget.tsx
@@ -31,6 +31,7 @@ import {
   buildCongestionCheckReply,
   findAlternativeBakerySuggestion,
   findPrimaryCongestionAlert,
+  isCongestionAlertResult,
   isCongestionCheckIntent,
 } from "@/utils/congestionCheck";
 import {
@@ -43,6 +44,7 @@ import {
   reservationStartMs,
   resolvePreDepartureReminderStage,
 } from "@/utils/tourReminders";
+import { consumeTourCompleteCelebration, TOUR_COMPLETE_EVENT } from "@/utils/tourCelebration";
 import { cn } from "@/utils/cn";
 import ChatBotImage from "@/assets/images/Img_ChatBot.svg";
 import ChatbotCourseSpeechBubble, {
@@ -50,11 +52,15 @@ import ChatbotCourseSpeechBubble, {
   CHATBOT_FAB_SIZE,
 } from "@/components/domain/curator/ChatbotCourseSpeechBubble";
 import BreadBotChatModal from "@/components/domain/curator/BreadBotChatModal";
+import BreadBotConfetti from "@/components/domain/curator/BreadBotConfetti";
 import {
   buildCourseExplainMessage,
+  buildTourCompleteCelebrationMessage,
   COURSE_NOT_IN_PROGRESS_MESSAGE,
   getBreadBotErrorMessage,
   isCourseExplainIntent,
+  isCourseReorderIntent,
+  isNextBakeryRecommendIntent,
   type ChatMessage,
   type CongestionChatContext,
   type CourseMovementBubble,
@@ -177,6 +183,155 @@ function markFiredReserveNudge(key: string): void {
   }
 }
 
+async function resolveChatCourseId(courseId?: number | null): Promise<number | null> {
+  if (courseId != null && courseId > 0) return courseId;
+
+  try {
+    const tour = await getCurrentTour();
+    if (tour?.status === "IN_PROGRESS" && tour.courseId > 0) {
+      return tour.courseId;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return null;
+}
+
+async function buildCourseReorderReply(
+  resolvedCourseId: number,
+  lastCongestionResultsRef: { current: CongestionCheckResult[] },
+  lastCongestionContextRef: { current: CongestionChatContext | null },
+): Promise<Omit<ChatMessage, "id" | "role"> | null> {
+  const course = await getCourseDetail(resolvedCourseId);
+  const bakeryIds = course.bakeries.map((bakery) => bakery.id).filter((id) => id > 0);
+  if (bakeryIds.length === 0) {
+    throw new Error("코스에 빵집 정보가 없어 순서를 변경할 수 없습니다.");
+  }
+
+  const res = await checkTourCongestion({ courseId: resolvedCourseId, bakeryIds });
+  const results = res.data ?? [];
+  lastCongestionResultsRef.current = results;
+  const bakeryNamesById = buildBakeryNameLookup(course.bakeries);
+  const congestionMessage = buildCongestionChatBotMessage(results, bakeryNamesById);
+
+  if (congestionMessage) {
+    if (congestionMessage.congestionContext) {
+      lastCongestionContextRef.current = congestionMessage.congestionContext;
+    }
+    return congestionMessage;
+  }
+
+  return {
+    text: `${buildCourseExplainMessage(course)}\n\n지금은 혼잡한 빵집이 없어요. 위 순서 그대로 진행해도 괜찮아 보여요!`,
+    showCourseMap: true,
+    showBackToStart: true,
+  };
+}
+
+async function buildNextBakeryRecommendReply(
+  resolvedCourseId: number,
+  lastCongestionResultsRef: { current: CongestionCheckResult[] },
+  lastCongestionContextRef: { current: CongestionChatContext | null },
+): Promise<Omit<ChatMessage, "id" | "role">> {
+  const course = await getCourseDetail(resolvedCourseId);
+  const bakeries = course.bakeries ?? [];
+  if (bakeries.length === 0) {
+    throw new Error("코스에 빵집 정보가 없어 추천할 수 없습니다.");
+  }
+
+  const tour = await getCurrentTour();
+  let nextIndex = 0;
+  if (tour?.status === "IN_PROGRESS" && tour.courseId === resolvedCourseId) {
+    nextIndex = tour.currentVisitOrder ?? 0;
+  }
+
+  const nextBakery = bakeries[nextIndex];
+  if (!nextBakery) {
+    return {
+      text: "코스의 모든 빵집 방문을 마쳤어요! 오늘 빵 투어도 수고하셨어요 🍞",
+      showBackToStart: true,
+    };
+  }
+
+  const bakeryIds = bakeries.map((bakery) => bakery.id).filter((id) => id > 0);
+  const res = await checkTourCongestion({ courseId: resolvedCourseId, bakeryIds });
+  const results = res.data ?? [];
+  lastCongestionResultsRef.current = results;
+
+  const bakeryNamesById = buildBakeryNameLookup(bakeries);
+  const nextName = nextBakery.name?.trim() || `빵집 ${nextIndex + 1}`;
+  const lines = [
+    `다음 방문 추천은 코스 ${nextIndex + 1}/${bakeries.length}번째 빵집 '${nextName}'이에요!`,
+  ];
+
+  if (nextBakery.address?.trim()) {
+    lines.push(`📍 ${nextBakery.address.trim()}`);
+  }
+  if (Number.isFinite(nextBakery.rating) && nextBakery.rating > 0) {
+    lines.push(`⭐ 평점 ${nextBakery.rating}`);
+  }
+
+  const nextCongestion = results.find((item) => item.bakeryId === nextBakery.id);
+  if (nextCongestion && isCongestionAlertResult(nextCongestion)) {
+    const waitText =
+      nextCongestion.expectedWaitMin != null && nextCongestion.expectedWaitMin > 0
+        ? ` 예상 대기 약 ${nextCongestion.expectedWaitMin}분`
+        : "";
+    lines.push("", `지금 ${nextName}은(는) 혼잡해요.${waitText}`);
+
+    const upcomingBakeryIds = new Set(bakeries.slice(nextIndex + 1).map((bakery) => bakery.id));
+    const upcomingResults = results.filter((item) => upcomingBakeryIds.has(item.bakeryId));
+    const alternative = findAlternativeBakerySuggestion(
+      upcomingResults,
+      nextCongestion,
+      bakeryNamesById,
+    );
+
+    if (alternative) {
+      lines.push(
+        "",
+        `같은 코스 안에서는 '${alternative.bakeryName}'을(를) 먼저 방문하면 대기 시간을 줄일 수 있어요.`,
+      );
+      lastCongestionContextRef.current = {
+        congestedBakeryId: nextBakery.id,
+        congestedBakeryName: nextName,
+        alternativeBakeryId: alternative.bakeryId,
+        alternativeBakeryName: alternative.bakeryName,
+      };
+      return {
+        text: lines.join("\n"),
+        actions: buildCongestionChatButtons(alternative.bakeryName, alternative.bakeryId),
+        showSadBread: true,
+        showCourseMap: true,
+        showBackToStart: true,
+        congestionContext: lastCongestionContextRef.current,
+      };
+    }
+
+    lines.push("", "코스 순서를 바꿀까요? '코스 순서 바꿀까?'를 눌러주세요.");
+  } else {
+    lines.push("", "지금은 웨이팅이 길지 않아 보여요. 편하게 방문해 보세요!");
+  }
+
+  const upcomingNames = bakeries
+    .slice(nextIndex + 1)
+    .map(
+      (bakery, index) =>
+        `${nextIndex + index + 2}. ${bakery.name?.trim() || `빵집 ${nextIndex + index + 2}`}`,
+    )
+    .join("\n");
+  if (upcomingNames) {
+    lines.push("", "이후 코스 방문 예정:", upcomingNames);
+  }
+
+  return {
+    text: lines.join("\n"),
+    showCourseMap: true,
+    showBackToStart: true,
+  };
+}
+
 type BreadBotWidgetProps = {
   courseId?: number | null;
   showFloatingButton?: boolean;
@@ -239,8 +394,10 @@ export default function BreadBotWidget({
   const [courseMovementBubble, setCourseMovementBubble] = useState<CourseMovementBubble | null>(
     null,
   );
+  const [showConfetti, setShowConfetti] = useState(false);
 
   const dismissedTourRef = useRef<Set<string>>(new Set());
+  const celebratedTourRef = useRef<Set<string>>(new Set());
   const dismissedMovementRef = useRef<Set<string>>(new Set());
   const lastCongestionResultsRef = useRef<CongestionCheckResult[]>([]);
   const lastCongestionContextRef = useRef<CongestionChatContext | null>(null);
@@ -349,16 +506,85 @@ export default function BreadBotWidget({
     [startCourseGuide],
   );
 
+  const celebrateTourComplete = useCallback(async (completedCourseId: number) => {
+    const key = `celebrated:${completedCourseId}`;
+    if (celebratedTourRef.current.has(key)) return;
+    celebratedTourRef.current.add(key);
+
+    setTourBubble((prev) => (prev?.mode === "resume" ? null : prev));
+    setCourseMovementBubble(null);
+
+    let courseName = "";
+    try {
+      const course = await getCourseDetail(completedCourseId);
+      courseName = course.name?.trim() || "";
+    } catch {
+      /* ignore */
+    }
+
+    setShowConfetti(true);
+    setMessages((prev) => {
+      const celebrationId = `tour-complete-${completedCourseId}`;
+      if (prev.some((message) => message.id === celebrationId)) return prev;
+      return [
+        ...prev,
+        {
+          id: celebrationId,
+          role: "bot",
+          text: buildTourCompleteCelebrationMessage(courseName),
+          showCelebration: true,
+          showBackToStart: true,
+        },
+      ];
+    });
+  }, []);
+
+  const clearResumeTourBubble = useCallback(() => {
+    setTourBubble((prev) => (prev?.mode === "resume" ? null : prev));
+  }, []);
+
+  useEffect(() => {
+    const pendingCelebrationId = consumeTourCompleteCelebration();
+    if (pendingCelebrationId) {
+      void celebrateTourComplete(pendingCelebrationId);
+    }
+  }, [celebrateTourComplete]);
+
+  useEffect(() => {
+    const handleTourComplete = (event: Event) => {
+      const courseId = (event as CustomEvent<{ courseId?: number }>).detail?.courseId;
+      if (courseId && courseId > 0) {
+        void celebrateTourComplete(courseId);
+      }
+    };
+
+    window.addEventListener(TOUR_COMPLETE_EVENT, handleTourComplete);
+    return () => window.removeEventListener(TOUR_COMPLETE_EVENT, handleTourComplete);
+  }, [celebrateTourComplete]);
+
   useEffect(() => {
     if (!isLoggedIn()) return;
     let cancelled = false;
 
     const check = async () => {
       try {
-        const current = await getCurrentTour();
+        const pendingCelebrationId = consumeTourCompleteCelebration();
+        if (pendingCelebrationId) {
+          await celebrateTourComplete(pendingCelebrationId);
+        }
+
+        const current = await getCurrentTour().catch(() => null);
         if (cancelled) return;
 
-        if (current && current.status === "IN_PROGRESS") {
+        if (current?.status === "COMPLETED") {
+          clearResumeTourBubble();
+          setCourseMovementBubble(null);
+          await celebrateTourComplete(current.courseId);
+        } else if (!current || current.status !== "IN_PROGRESS") {
+          clearResumeTourBubble();
+        }
+
+        if (current?.status === "IN_PROGRESS") {
           const key = `resume:${current.courseId}`;
           if (!dismissedTourRef.current.has(key)) {
             setTourBubble({
@@ -475,7 +701,7 @@ export default function BreadBotWidget({
 
         setReserveNudgeBubble(null);
       } catch {
-        // 네트워크/권한 등 오류는 조용히 무시
+        clearResumeTourBubble();
       }
     };
 
@@ -485,7 +711,7 @@ export default function BreadBotWidget({
       cancelled = true;
       clearInterval(timer);
     };
-  }, [courseId, handleAutoTourStart, onRoutePage]);
+  }, [celebrateTourComplete, clearResumeTourBubble, courseId, handleAutoTourStart, onRoutePage]);
 
   const applyCourseMovementBubble = useCallback((next: CourseMovementBubble | null) => {
     if (next && dismissedMovementRef.current.has(next.dismissKey)) return;
@@ -730,6 +956,73 @@ export default function BreadBotWidget({
           return;
         }
 
+        if (isCourseReorderIntent(text)) {
+          const resolvedCourseId = await resolveChatCourseId(courseId);
+          if (!resolvedCourseId) {
+            appendBotMessage(
+              "코스 정보를 찾을 수 없어요. 루트에서 코스를 선택하거나 코스 안내를 시작한 뒤 다시 시도해 주세요.",
+            );
+            return;
+          }
+
+          const reorderMessage = await buildCourseReorderReply(
+            resolvedCourseId,
+            lastCongestionResultsRef,
+            lastCongestionContextRef,
+          );
+          if (!reorderMessage) return;
+
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `course-reorder-${Date.now()}`,
+              role: "bot",
+              ...reorderMessage,
+            },
+          ]);
+
+          if (reorderMessage.actions && reorderMessage.actions.length > 0) {
+            setChangeBubble({
+              text: reorderMessage.text,
+              actions: reorderMessage.actions,
+            });
+          }
+          return;
+        }
+
+        if (isNextBakeryRecommendIntent(text)) {
+          const resolvedCourseId = await resolveChatCourseId(courseId);
+          if (!resolvedCourseId) {
+            appendBotMessage(
+              "코스 정보를 찾을 수 없어요. 코스 안내를 시작한 뒤 다시 시도해 주세요.",
+            );
+            return;
+          }
+
+          const recommendMessage = await buildNextBakeryRecommendReply(
+            resolvedCourseId,
+            lastCongestionResultsRef,
+            lastCongestionContextRef,
+          );
+
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `next-bakery-${Date.now()}`,
+              role: "bot",
+              ...recommendMessage,
+            },
+          ]);
+
+          if (recommendMessage.actions && recommendMessage.actions.length > 0) {
+            setChangeBubble({
+              text: recommendMessage.text,
+              actions: recommendMessage.actions,
+            });
+          }
+          return;
+        }
+
         if (courseId && courseId > 0 && isCongestionCheckIntent(text)) {
           const course = await getCourseDetail(courseId);
           const bakeryIds = course.bakeries.map((bakery) => bakery.id).filter((id) => id > 0);
@@ -882,7 +1175,11 @@ export default function BreadBotWidget({
 
   const showCourseMovementBubble =
     courseMovementBubble !== null && showFloatingButton && !open && courseGuideActive;
-  const showTourBubble = tourBubble !== null && !open && !onTourPage;
+  const showTourBubble =
+    tourBubble !== null &&
+    !open &&
+    !onTourPage &&
+    (tourBubble.mode !== "resume" || courseGuideActive);
   const showChangeBubble =
     !showCourseMovementBubble &&
     tourBubble === null &&
@@ -898,6 +1195,7 @@ export default function BreadBotWidget({
 
   return (
     <>
+      <BreadBotConfetti active={showConfetti} onComplete={() => setShowConfetti(false)} />
       {open ? (
         <BreadBotChatModal
           listRef={listRef}

--- a/apps/fe/src/components/domain/curator/breadBotChat.types.ts
+++ b/apps/fe/src/components/domain/curator/breadBotChat.types.ts
@@ -23,6 +23,7 @@ export type ChatMessage = {
   showBackToStart?: boolean;
   showBakeryInfoId?: number;
   congestionContext?: CongestionChatContext;
+  showCelebration?: boolean;
 };
 
 export type CourseMovementBubble = {
@@ -43,6 +44,11 @@ export const WELCOME_SUBTITLE = "궁금한 것을 클릭해보세요!";
 export const BACK_TO_START_LABEL = "처음으로";
 export const BACK_TO_START_FOOTER_LABEL = "처음으로 돌아가기";
 export const COURSE_NOT_IN_PROGRESS_MESSAGE = "현재 코스 진행중이 아닙니다!";
+
+export function buildTourCompleteCelebrationMessage(courseName: string): string {
+  const label = courseName.trim() || "오늘의 빵 투어";
+  return `'${label}' 완주! 🎉\n수고 많으셨어요. 달콤한 하루 보내세요!`;
+}
 
 export function getBreadBotErrorMessage(error: unknown): string {
   const message = getErrorMessage(error);
@@ -79,4 +85,12 @@ export function buildCourseExplainMessage(course: CourseDetail): string {
 
 export function isCourseExplainIntent(text: string): boolean {
   return /현재\s*코스\s*설명|코스\s*설명해/.test(text.trim());
+}
+
+export function isCourseReorderIntent(text: string): boolean {
+  return /코스\s*순서|순서\s*바꿀|방문\s*순서|경로\s*변경|순서\s*변경/.test(text.trim());
+}
+
+export function isNextBakeryRecommendIntent(text: string): boolean {
+  return /다음\s*빵집|빵집\s*추천|다음\s*방문|다음\s*으로\s*갈/.test(text.trim());
 }

--- a/apps/fe/src/lib/auth/LoginRequiredProvider.tsx
+++ b/apps/fe/src/lib/auth/LoginRequiredProvider.tsx
@@ -6,21 +6,25 @@ import { getCurrentTour } from "@/api/tours";
 import { isBotFloatingHiddenPath } from "@/lib/courseGuide";
 import { isLoggedIn } from "@/lib/auth/isLoggedIn";
 import { tryPostLoginRedirectPath } from "@/lib/postLoginRedirect";
+import { readRouteFocusCourseId } from "@/utils/aiCourseStorage";
 import { LoginRequiredContext } from "@/lib/auth/LoginRequiredContext";
+
+function parseSearchCourseId(search: unknown): number | null {
+  if (!search || typeof search !== "object") return null;
+  const courseId = (search as { courseId?: unknown }).courseId;
+  if (typeof courseId === "number" && Number.isFinite(courseId) && courseId > 0) {
+    return Math.floor(courseId);
+  }
+  return null;
+}
 
 export function LoginRequiredProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const routeFlowCourseId = useRouterState({
-    select: (s) => {
-      if (s.location.pathname !== "/ai-search-result") return null;
-      const search = s.location.search as { courseId?: number; from?: string };
-      if (search.from === "route" && typeof search.courseId === "number" && search.courseId > 0) {
-        return search.courseId;
-      }
-      return null;
-    },
+  const searchCourseId = useRouterState({
+    select: (s) => parseSearchCourseId(s.location.search),
   });
+  const routeFocusCourseId = pathname === "/route" ? readRouteFocusCourseId() : null;
   const loggedIn = isLoggedIn();
 
   const [loginDialogOpen, setLoginDialogOpen] = useState(false);
@@ -90,11 +94,12 @@ export function LoginRequiredProvider({ children }: { children: ReactNode }) {
   const resolvedCourseGuideId = loggedIn ? courseGuideId : null;
 
   const isHomePath = pathname === "/home";
-  const isSavedRouteFlow = pathname === "/route" || routeFlowCourseId != null;
+  const isSavedRouteFlow =
+    pathname === "/route" || searchCourseId != null || routeFocusCourseId != null;
   /** 로그인 사용자: 홈·저장 루트·코스 안내 중 BreadBot 노출 */
   const showBot = loggedIn && (isHomePath || isSavedRouteFlow || resolvedCourseGuideActive);
   const showBotFloating = showBot && !isBotFloatingHiddenPath(pathname);
-  const botCourseId = resolvedCourseGuideId ?? routeFlowCourseId;
+  const botCourseId = resolvedCourseGuideId ?? searchCourseId ?? routeFocusCourseId;
 
   const value = useMemo(
     () => ({

--- a/apps/fe/src/pages/AISearchResultPage.tsx
+++ b/apps/fe/src/pages/AISearchResultPage.tsx
@@ -29,7 +29,7 @@ import { getErrorMessage } from "@/api/types/common";
 import { startTour } from "@/api/tours";
 import { useLoginRequired } from "@/lib/auth/useLoginRequired";
 import { mapCongestionByBakeryId } from "@/utils/congestionCheck";
-import { AI_COURSE_RESULT_STORAGE_KEY } from "@/utils/aiCourseStorage";
+import { AI_COURSE_RESULT_STORAGE_KEY, saveRouteFocusCourseId } from "@/utils/aiCourseStorage";
 import ResultCTASection from "@/components/domain/ai-course/ResultCTASection";
 import SaveRouteBanner from "@/components/domain/ai-course/SaveRouteBanner";
 import { AI_COURSE_FLOW_START } from "@/utils/aiCourseFlow";
@@ -220,6 +220,9 @@ export default function AISearchResultPage({ courseId, from }: AISearchResultPag
     if (!effectiveCourseId) {
       window.alert("안내할 코스 정보를 찾지 못했습니다.");
       return;
+    }
+    if (from === "route") {
+      saveRouteFocusCourseId(effectiveCourseId);
     }
     startCourseGuide(effectiveCourseId);
     try {

--- a/apps/fe/src/pages/RoutePage.tsx
+++ b/apps/fe/src/pages/RoutePage.tsx
@@ -6,6 +6,7 @@ import BottomNav from "@/components/layout/BottomNav";
 import MobileFrame from "@/components/layout/MobileFrame";
 import type { RouteCourse } from "@/components/domain/route";
 import { AI_COURSE_FLOW_START } from "@/utils/aiCourseFlow";
+import { saveRouteFocusCourseId } from "@/utils/aiCourseStorage";
 import { deleteAiCourse, getMyCourseRoutes, removeCourseRoute } from "@/api/courses";
 import { getErrorMessage } from "@/api/types/common";
 
@@ -59,6 +60,7 @@ export default function RoutePage() {
   const handleOpenCourse = (courseId: string) => {
     const parsed = Number.parseInt(courseId, 10);
     if (!Number.isFinite(parsed)) return;
+    saveRouteFocusCourseId(parsed);
     void navigate({ to: "/ai-search-result", search: { courseId: parsed, from: "route" } });
   };
 

--- a/apps/fe/src/pages/TourPage.tsx
+++ b/apps/fe/src/pages/TourPage.tsx
@@ -21,6 +21,7 @@ import {
   buildBakeryNameLookup,
   mapCongestionByBakeryId,
 } from "@/utils/congestionCheck";
+import { notifyTourCompleteCelebration } from "@/utils/tourCelebration";
 import { cn } from "@/utils/cn";
 
 interface TourPageProps {
@@ -147,6 +148,10 @@ export default function TourPage({ courseId }: TourPageProps) {
     try {
       const updated = await checkTourVisit(courseId, order);
       setTour(updated);
+      if (updated.status === "COMPLETED") {
+        endCourseGuide();
+        notifyTourCompleteCelebration(courseId);
+      }
     } catch (e) {
       setError(getErrorMessage(e));
     } finally {
@@ -163,6 +168,7 @@ export default function TourPage({ courseId }: TourPageProps) {
       setTour(updated);
       if (updated.status === "COMPLETED") {
         endCourseGuide();
+        notifyTourCompleteCelebration(courseId);
       }
     } catch (e) {
       setError(getErrorMessage(e));

--- a/apps/fe/src/utils/aiCourseStorage.ts
+++ b/apps/fe/src/utils/aiCourseStorage.ts
@@ -1,5 +1,26 @@
 export const AI_COURSE_PREFERENCE_STORAGE_KEY = "aiCoursePreference";
 export const AI_COURSE_RESULT_STORAGE_KEY = "aiCourseResult";
+export const ROUTE_FOCUS_COURSE_ID_KEY = "routeFocusCourseId";
+
+export function saveRouteFocusCourseId(courseId: number): void {
+  if (courseId <= 0) return;
+  try {
+    sessionStorage.setItem(ROUTE_FOCUS_COURSE_ID_KEY, String(courseId));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readRouteFocusCourseId(): number | null {
+  try {
+    const raw = sessionStorage.getItem(ROUTE_FOCUS_COURSE_ID_KEY);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 export type AiCoursePreferenceDraft = {
   companion: string;

--- a/apps/fe/src/utils/tourCelebration.ts
+++ b/apps/fe/src/utils/tourCelebration.ts
@@ -1,0 +1,29 @@
+export const TOUR_COMPLETE_CELEBRATION_KEY = "breadbot:tourCompletePending";
+export const TOUR_COMPLETE_EVENT = "breadbot:tour-complete";
+
+export function markTourCompleteCelebration(courseId: number): void {
+  if (courseId <= 0) return;
+  try {
+    sessionStorage.setItem(TOUR_COMPLETE_CELEBRATION_KEY, String(courseId));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function notifyTourCompleteCelebration(courseId: number): void {
+  markTourCompleteCelebration(courseId);
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(TOUR_COMPLETE_EVENT, { detail: { courseId } }));
+}
+
+export function consumeTourCompleteCelebration(): number | null {
+  try {
+    const raw = sessionStorage.getItem(TOUR_COMPLETE_CELEBRATION_KEY);
+    sessionStorage.removeItem(TOUR_COMPLETE_CELEBRATION_KEY);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Task
- BakeryImageService, BreadService, ReviewService 신규 분리
- 관련 테스트 추가
- BakeryService, CommunityService, PaymentService 등 existsBy → save/delete 예외 처리로 통합

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- #227 
