### PR TITLE
feat: Rate Limit 필터 및 테스트 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/global/config/RateLimitProperties.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/RateLimitProperties.java
@@ -1,0 +1,25 @@
+package com.breadbread.global.config;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "rate-limit")
+public class RateLimitProperties {
+
+    private List<Rule> rules = List.of();
+
+    @Getter
+    @Setter
+    public static class Rule {
+        private String method;
+        private List<String> uris;
+        private long ttlSeconds;
+        private long maxRequests;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
@@ -2,11 +2,14 @@ package com.breadbread.global.config;
 
 import com.breadbread.auth.service.CustomUserDetailsService;
 import com.breadbread.global.filter.AiApiKeyFilter;
+import com.breadbread.global.filter.AuthRateLimitFilter;
 import com.breadbread.global.filter.JwtAuthenticationFilter;
 import com.breadbread.global.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -30,7 +33,18 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService customUserDetailsService;
-    private final AiApiKeyFilter aiApiKeyFilter;
+    private final AuthRateLimitFilter authRateLimitFilter;
+    private final AiProperties aiProperties;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public FilterRegistrationBean<AuthRateLimitFilter> authRateLimitFilterRegistration(
+            AuthRateLimitFilter filter) {
+        FilterRegistrationBean<AuthRateLimitFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -115,10 +129,13 @@ public class SecurityConfig {
                                         .hasRole("ADMIN")
                                         .anyRequest()
                                         .authenticated())
-                .addFilterBefore(aiApiKeyFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(
+                        new AiApiKeyFilter(aiProperties, objectMapper),
+                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider, customUserDetailsService),
-                        AiApiKeyFilter.class);
+                        AiApiKeyFilter.class)
+                .addFilterBefore(authRateLimitFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 

--- a/apps/be/src/main/java/com/breadbread/global/exception/CustomException.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/CustomException.java
@@ -5,14 +5,23 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
+    private final Long retryAfterSeconds;
 
     public CustomException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+        this.retryAfterSeconds = null;
+    }
+
+    public CustomException(ErrorCode errorCode, long retryAfterSeconds) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 
     public CustomException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
+        this.retryAfterSeconds = null;
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/filter/AiApiKeyFilter.java
+++ b/apps/be/src/main/java/com/breadbread/global/filter/AiApiKeyFilter.java
@@ -13,10 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
 @RequiredArgsConstructor
 public class AiApiKeyFilter extends OncePerRequestFilter {
 

--- a/apps/be/src/main/java/com/breadbread/global/filter/AuthRateLimitFilter.java
+++ b/apps/be/src/main/java/com/breadbread/global/filter/AuthRateLimitFilter.java
@@ -1,0 +1,87 @@
+package com.breadbread.global.filter;
+
+import com.breadbread.global.config.RateLimitProperties;
+import com.breadbread.global.dto.ApiResponse;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.RateLimitRedisService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class AuthRateLimitFilter extends OncePerRequestFilter {
+    private final RateLimitRedisService rateLimitRedisService;
+    private final RateLimitProperties rateLimitProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        String method = request.getMethod();
+        String clientIp = getClientIp(request);
+
+        try {
+            for (RateLimitProperties.Rule rule : rateLimitProperties.getRules()) {
+                if (rule.getMethod().equalsIgnoreCase(method) && rule.getUris().contains(uri)) {
+                    String key =
+                            "rate-limit:"
+                                    + method.toLowerCase()
+                                    + ":"
+                                    + uri.replace("/", "-")
+                                    + ":"
+                                    + clientIp;
+                    rateLimitRedisService.checkLimit(
+                            key, rule.getTtlSeconds(), rule.getMaxRequests());
+                    break;
+                }
+            }
+
+            filterChain.doFilter(request, response);
+
+        } catch (CustomException e) {
+            if (e.getErrorCode() != ErrorCode.TOO_MANY_REQUESTS) {
+                throw e;
+            }
+
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            if (e.getRetryAfterSeconds() != null) {
+                response.setHeader("Retry-After", String.valueOf(e.getRetryAfterSeconds()));
+            }
+
+            String body =
+                    objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.TOO_MANY_REQUESTS));
+            response.getWriter().write(body);
+        }
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        // Cloud Run / Google LB: "client, google-lb-ip" 형태로 추가
+        // 끝에서 두 번째가 실제 클라이언트 IP (마지막은 LB 자신)
+        // X-Real-IP는 Cloud Run에서 LB가 설정하지 않으므로 신뢰하지 않음
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+            String[] parts = xForwardedFor.split(",");
+            if (parts.length >= 2) {
+                return parts[parts.length - 2].trim();
+            }
+            return parts[0].trim();
+        }
+
+        return request.getRemoteAddr();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/global/service/RateLimitRedisService.java
+++ b/apps/be/src/main/java/com/breadbread/global/service/RateLimitRedisService.java
@@ -1,0 +1,39 @@
+package com.breadbread.global.service;
+
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitRedisService {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void checkLimit(String key, long ttlSeconds, long maxRequests) {
+        Long count;
+        try {
+            count = stringRedisTemplate.opsForValue().increment(key);
+            if (count != null && count == 1L) {
+                stringRedisTemplate.expire(key, Duration.ofSeconds(ttlSeconds));
+            }
+        } catch (Exception e) {
+            log.warn("Rate limit Redis 오류 — fail-open으로 요청 통과: key={}", key, e);
+            return;
+        }
+
+        if (count != null && count > maxRequests) {
+            Long remainingMillis = stringRedisTemplate.getExpire(key, TimeUnit.MILLISECONDS);
+            long retryAfter =
+                    (remainingMillis != null && remainingMillis > 0)
+                            ? (long) Math.ceil(remainingMillis / 1000.0)
+                            : ttlSeconds;
+            throw new CustomException(ErrorCode.TOO_MANY_REQUESTS, retryAfter);
+        }
+    }
+}

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -150,6 +150,29 @@ kakao:
     base-url: https://apis-navi.kakaomobility.com
     timeout-seconds: ${KAKAO_MOBILITY_TIMEOUT_SECONDS:10}
 
+rate-limit:
+  rules:
+    - method: POST
+      uris: [ /auth/signup, /auth/find-id, /auth/find-pw, /auth/phone/send ]
+      ttl-seconds: 60
+      max-requests: 3
+    - method: POST
+      uris: [ /auth/phone/verify, /curator/chat, /courses/ai, /posts ]
+      ttl-seconds: 60
+      max-requests: 5
+    - method: POST
+      uris: [ /auth/login, /auth/naver/state, /images, /payments/prepare, /payments/complete ]
+      ttl-seconds: 60
+      max-requests: 10
+    - method: POST
+      uris: [ /auth/refresh ]
+      ttl-seconds: 60
+      max-requests: 20
+    - method: GET
+      uris: [ /courses, /bakeries, /bakeries/summary, /bakeries/ai, /trends/breads, /trends/bakeries ]
+      ttl-seconds: 60
+      max-requests: 50
+
 route:
   provider: kakao  # naver | kakao
 

--- a/apps/be/src/test/java/com/breadbread/global/filter/AuthRateLimitFilterTest.java
+++ b/apps/be/src/test/java/com/breadbread/global/filter/AuthRateLimitFilterTest.java
@@ -1,0 +1,179 @@
+package com.breadbread.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.breadbread.global.config.RateLimitProperties;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.service.RateLimitRedisService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AuthRateLimitFilterTest {
+
+    @Mock private RateLimitRedisService rateLimitRedisService;
+    @Mock private RateLimitProperties rateLimitProperties;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private AuthRateLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new AuthRateLimitFilter(rateLimitRedisService, rateLimitProperties, objectMapper);
+
+        RateLimitProperties.Rule rule = new RateLimitProperties.Rule();
+        rule.setMethod("POST");
+        rule.setUris(List.of("/auth/login", "/auth/signup"));
+        rule.setTtlSeconds(60);
+        rule.setMaxRequests(10);
+
+        org.mockito.Mockito.when(rateLimitProperties.getRules()).thenReturn(List.of(rule));
+    }
+
+    // ── checkLimit 호출 여부 ───────────────────────────────────────────────────
+
+    @Test
+    void configuredUri_callsCheckLimit() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.setRemoteAddr("1.2.3.4");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        doNothing().when(rateLimitRedisService).checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService).checkLimit(anyString(), anyLong(), anyLong());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void unconfiguredUri_skipsCheckLimit() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/courses");
+        request.setRemoteAddr("1.2.3.4");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService, never()).checkLimit(anyString(), anyLong(), anyLong());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void unconfiguredMethod_skipsCheckLimit() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/auth/login");
+        request.setRemoteAddr("1.2.3.4");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService, never()).checkLimit(anyString(), anyLong(), anyLong());
+    }
+
+    // ── 429 응답 ──────────────────────────────────────────────────────────────
+
+    @Test
+    void whenRateLimitExceeded_returns429WithRetryAfter() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.setRemoteAddr("1.2.3.4");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        doThrow(new CustomException(ErrorCode.TOO_MANY_REQUESTS, 30L))
+                .when(rateLimitRedisService)
+                .checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(429);
+        assertThat(response.getHeader("Retry-After")).isEqualTo("30");
+        assertThat(response.getContentAsString()).contains("E0007");
+    }
+
+    @Test
+    void whenRateLimitExceeded_doesNotCallFilterChain() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.setRemoteAddr("1.2.3.4");
+        MockFilterChain chain = new MockFilterChain();
+
+        doThrow(new CustomException(ErrorCode.TOO_MANY_REQUESTS, 30L))
+                .when(rateLimitRedisService)
+                .checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, new MockHttpServletResponse(), chain);
+
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    // ── IP 추출 ───────────────────────────────────────────────────────────────
+
+    @Test
+    void cloudRun_xForwardedFor_extractsClientIp() throws Exception {
+        // Cloud Run: "client, lb" 형태 → client를 rate limit 키에 사용
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.addHeader("X-Forwarded-For", "203.0.113.10, 35.191.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        doNothing().when(rateLimitRedisService).checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService)
+                .checkLimit(
+                        org.mockito.ArgumentMatchers.contains("203.0.113.10"),
+                        anyLong(),
+                        anyLong());
+    }
+
+    @Test
+    void singleIp_xForwardedFor_usesIt() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.addHeader("X-Forwarded-For", "203.0.113.10");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        doNothing().when(rateLimitRedisService).checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService)
+                .checkLimit(
+                        org.mockito.ArgumentMatchers.contains("203.0.113.10"),
+                        anyLong(),
+                        anyLong());
+    }
+
+    @Test
+    void noXForwardedFor_usesRemoteAddr() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/login");
+        request.setRemoteAddr("192.168.1.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        doNothing().when(rateLimitRedisService).checkLimit(anyString(), anyLong(), anyLong());
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(rateLimitRedisService)
+                .checkLimit(
+                        org.mockito.ArgumentMatchers.contains("192.168.1.1"), anyLong(), anyLong());
+    }
+}


### PR DESCRIPTION
## Task
- AuthRateLimitFilter: IP 추출, 429 응답, Retry-After 헤더 처리
- AuthRateLimitFilterTest 작성 (checkLimit 호출 여부, 429 응답, IP 추출)

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #240 
