### PR TITLE
feat: 관리자 전용 데이터 목록 조회 API 및 빵 품절 상태 변경 API 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryOwnerController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryOwnerController.java
@@ -76,6 +76,18 @@ public class BakeryOwnerController {
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "빵집 메뉴 품절 상태 변경", description = "관리자 또는 빵집 사장님만 가능")
+    @PatchMapping("/{bakeryId}/breads/{breadId}/soldout")
+    public ApiResponse<Void> updateSoldOut(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long bakeryId,
+            @PathVariable Long breadId,
+            @RequestParam boolean soldOut) {
+        breadService.updateSoldOut(
+                userDetails.getId(), userDetails.getRole(), bakeryId, breadId, soldOut);
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "빵집 메뉴 삭제", description = "관리자 또는 빵집 사장님만 가능")
     @DeleteMapping("/{bakeryId}/breads/{breadId}")
     public ApiResponse<Void> deleteBread(

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BreadService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BreadService.java
@@ -108,6 +108,35 @@ public class BreadService {
         breadRepository.delete(bread);
     }
 
+    @Transactional
+    public void updateSoldOut(
+            Long userId, UserRole role, Long bakeryId, Long breadId, boolean soldOut) {
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrue(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        checkAuthority(bakery, userId, role);
+
+        Bread bread =
+                breadRepository
+                        .findByIdAndBakeryId(breadId, bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        if (soldOut) {
+            bread.markSoldOut();
+        } else {
+            bread.markAvailable();
+        }
+
+        log.info(
+                "빵 품절 상태 변경: breadId={}, bakeryId={}, soldOut={}, userId={}",
+                breadId,
+                bakeryId,
+                soldOut,
+                userId);
+    }
+
     private void checkAuthority(Bakery bakery, Long userId, UserRole role) {
         if (role == UserRole.ROLE_ADMIN) return;
         if (bakery.getOwner() == null || !bakery.getOwner().getId().equals(userId)) {

--- a/apps/be/src/main/java/com/breadbread/congestion/controller/AdminCongestionController.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/controller/AdminCongestionController.java
@@ -1,0 +1,53 @@
+package com.breadbread.congestion.controller;
+
+import com.breadbread.congestion.dto.BakeryCongestionSignalAdminListResponse;
+import com.breadbread.congestion.service.CongestionSignalService;
+import com.breadbread.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "혼잡도 - 관리자")
+@RestController
+@RequestMapping("/admin/congestions")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminCongestionController {
+
+    private final CongestionSignalService congestionSignalService;
+
+    @Operation(
+            summary = "혼잡도 신호 전체 목록 조회 (관리자)",
+            description = "수집된 BakeryCongestionSignal 전체 레코드를 최신순으로 조회합니다.")
+    @Parameters({
+        @Parameter(name = "page", description = "페이지 번호 (0부터 시작, 기본값: 0)"),
+        @Parameter(name = "size", description = "페이지 크기 (기본값: 20)"),
+        @Parameter(name = "from", description = "조회 시작 날짜 (형식: yyyy-MM-dd, 예: 2025-01-01)"),
+        @Parameter(name = "to", description = "조회 종료 날짜 (형식: yyyy-MM-dd, 예: 2025-12-31)")
+    })
+    @GetMapping
+    public ApiResponse<BakeryCongestionSignalAdminListResponse> findAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate to) {
+        return ApiResponse.ok(
+                congestionSignalService.findAllForAdmin(
+                        from != null ? from.atStartOfDay() : null,
+                        to != null ? to.atTime(LocalTime.MAX) : null,
+                        PageRequest.of(page, size)));
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/congestion/dto/BakeryCongestionSignalAdminListResponse.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/dto/BakeryCongestionSignalAdminListResponse.java
@@ -1,0 +1,15 @@
+package com.breadbread.congestion.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BakeryCongestionSignalAdminListResponse {
+    private List<BakeryCongestionSignalAdminResponse> signals;
+    private int total;
+    private int page;
+    private int size;
+    private boolean hasNext;
+}

--- a/apps/be/src/main/java/com/breadbread/congestion/dto/BakeryCongestionSignalAdminResponse.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/dto/BakeryCongestionSignalAdminResponse.java
@@ -1,27 +1,27 @@
 package com.breadbread.congestion.dto;
 
 import com.breadbread.congestion.entity.BakeryCongestionSignal;
+import com.breadbread.congestion.entity.CongestionLevel;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
 @Builder
-public class CongestionResponse {
-
+public class BakeryCongestionSignalAdminResponse {
+    private Long id;
     private Long bakeryId;
     private String bakeryName;
-    private String level;
     private Double congestionScore;
+    private CongestionLevel level;
     private Integer expectedWaitMin;
     private String reason;
     private Signals signals;
-    private LocalDateTime updatedAt;
+    private LocalDateTime collectedAt;
+    private LocalDateTime createdAt;
 
     @Getter
     @Builder
-    @ToString
     public static class Signals {
         private Integer waitingKeywordCount;
         private Integer openRunKeywordCount;
@@ -32,12 +32,13 @@ public class CongestionResponse {
         private Integer eveningMentions;
     }
 
-    public static CongestionResponse from(BakeryCongestionSignal signal) {
-        return CongestionResponse.builder()
+    public static BakeryCongestionSignalAdminResponse from(BakeryCongestionSignal signal) {
+        return BakeryCongestionSignalAdminResponse.builder()
+                .id(signal.getId())
                 .bakeryId(signal.getBakeryId())
                 .bakeryName(signal.getBakeryName())
-                .level(signal.getLevel() != null ? signal.getLevel().name() : null)
                 .congestionScore(signal.getCongestionScore())
+                .level(signal.getLevel())
                 .expectedWaitMin(signal.getExpectedWaitMin())
                 .reason(signal.getReason())
                 .signals(
@@ -50,7 +51,8 @@ public class CongestionResponse {
                                 .afternoonMentions(signal.getAfternoonMentions())
                                 .eveningMentions(signal.getEveningMentions())
                                 .build())
-                .updatedAt(signal.getUpdatedAt())
+                .collectedAt(signal.getCollectedAt())
+                .createdAt(signal.getCreatedAt())
                 .build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/congestion/repository/BakeryCongestionSignalRepository.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/repository/BakeryCongestionSignalRepository.java
@@ -1,8 +1,11 @@
 package com.breadbread.congestion.repository;
 
 import com.breadbread.congestion.entity.BakeryCongestionSignal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +27,11 @@ public interface BakeryCongestionSignalRepository
                             + " ORDER BY b.congestion_score ASC",
             nativeQuery = true)
     List<BakeryCongestionSignal> findLatestByBakeryIds(@Param("bakeryIds") List<Long> bakeryIds);
+
+    @Query(
+            "SELECT s FROM BakeryCongestionSignal s"
+                    + " WHERE s.createdAt >= :from AND s.createdAt <= :to"
+                    + " ORDER BY s.createdAt DESC")
+    Page<BakeryCongestionSignal> findAllByCreatedAtRange(
+            @Param("from") LocalDateTime from, @Param("to") LocalDateTime to, Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
@@ -3,6 +3,8 @@ package com.breadbread.congestion.service;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.congestion.dto.BakeryCongestionSignalAdminListResponse;
+import com.breadbread.congestion.dto.BakeryCongestionSignalAdminResponse;
 import com.breadbread.congestion.dto.CongestionResponse;
 import com.breadbread.congestion.dto.CongestionSignalRequest;
 import com.breadbread.congestion.entity.BakeryCongestionSignal;
@@ -10,12 +12,15 @@ import com.breadbread.congestion.entity.CongestionLevel;
 import com.breadbread.congestion.repository.BakeryCongestionSignalRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -144,5 +149,24 @@ public class CongestionSignalService {
             log.warn("[혼잡도 신호] 알 수 없는 level 값: {}", level);
             return null;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public BakeryCongestionSignalAdminListResponse findAllForAdmin(
+            LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        LocalDateTime start = from != null ? from : LocalDateTime.of(2000, 1, 1, 0, 0);
+        LocalDateTime end = to != null ? to : LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+        Page<BakeryCongestionSignal> page =
+                repository.findAllByCreatedAtRange(start, end, pageable);
+        return BakeryCongestionSignalAdminListResponse.builder()
+                .signals(
+                        page.getContent().stream()
+                                .map(BakeryCongestionSignalAdminResponse::from)
+                                .toList())
+                .total((int) page.getTotalElements())
+                .page(pageable.getPageNumber())
+                .size(pageable.getPageSize())
+                .hasNext(page.hasNext())
+                .build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/controller/AdminCourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/AdminCourseController.java
@@ -3,12 +3,19 @@ package com.breadbread.course.controller;
 import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.course.dto.request.ManualCourseRequest;
 import com.breadbread.course.dto.request.UpdateCourseRequest;
+import com.breadbread.course.dto.response.AiCourseAdminListResponse;
 import com.breadbread.course.service.CourseService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,6 +29,28 @@ import org.springframework.web.bind.annotation.*;
 public class AdminCourseController {
 
     private final CourseService courseService;
+
+    @Operation(summary = "AI 코스 전체 목록 조회 (관리자)")
+    @Parameters({
+        @Parameter(name = "page", description = "페이지 번호 (0부터 시작, 기본값: 0)"),
+        @Parameter(name = "size", description = "페이지 크기 (기본값: 10)"),
+        @Parameter(name = "from", description = "조회 시작 날짜 (형식: yyyy-MM-dd, 예: 2025-01-01)"),
+        @Parameter(name = "to", description = "조회 종료 날짜 (형식: yyyy-MM-dd, 예: 2025-12-31)")
+    })
+    @GetMapping("/ai")
+    public ApiResponse<AiCourseAdminListResponse> findAllAi(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate to) {
+        return ApiResponse.ok(
+                courseService.findAllAiForAdmin(
+                        from != null ? from.atStartOfDay() : null,
+                        to != null ? to.atTime(LocalTime.MAX) : null,
+                        PageRequest.of(page, size)));
+    }
 
     @Operation(summary = "운영자 코스 등록")
     @PostMapping("/manual")

--- a/apps/be/src/main/java/com/breadbread/course/dto/ai/RecommendedBakeryResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/ai/RecommendedBakeryResponse.java
@@ -1,5 +1,6 @@
 package com.breadbread.course.dto.ai;
 
+import com.breadbread.course.entity.CourseBakery;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,4 +12,14 @@ public class RecommendedBakeryResponse {
     private String name;
     private String recommendedBread;
     private String reason;
+
+    public static RecommendedBakeryResponse from(CourseBakery cb) {
+        RecommendedBakeryResponse r = new RecommendedBakeryResponse();
+        r.id = cb.getBakery().getId();
+        r.order = cb.getVisitOrder();
+        r.name = cb.getBakery().getName();
+        r.recommendedBread = cb.getRecommendedBread();
+        r.reason = cb.getReason();
+        return r;
+    }
 }

--- a/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminListResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminListResponse.java
@@ -1,0 +1,15 @@
+package com.breadbread.course.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCourseAdminListResponse {
+    private List<AiCourseAdminResponse> courses;
+    private int total;
+    private int page;
+    private int size;
+    private boolean hasNext;
+}

--- a/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminResponse.java
@@ -1,0 +1,125 @@
+package com.breadbread.course.dto.response;
+
+import com.breadbread.bakery.entity.enums.BakeryPersonality;
+import com.breadbread.bakery.entity.enums.BakeryType;
+import com.breadbread.bakery.entity.enums.BakeryUseType;
+import com.breadbread.bakery.entity.enums.BreadType;
+import com.breadbread.course.dto.ai.RecommendedBakeryResponse;
+import com.breadbread.course.entity.AiCourseInfo;
+import com.breadbread.course.entity.BudgetRange;
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.FlexibilityLevel;
+import com.breadbread.course.entity.TravelType;
+import com.breadbread.user.entity.UserPreference;
+import com.breadbread.user.entity.WaitingTolerance;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AiCourseAdminResponse {
+    private Long id;
+    private Long userId;
+    private String userNickname;
+
+    private Input input;
+    private Result result;
+
+    @Getter
+    @Builder
+    public static class Input {
+        private TravelType travelType;
+        private BudgetRange budgetRange;
+        private FlexibilityLevel flexibilityLevel;
+        private boolean minimizeRoute;
+        private boolean waitingPreference;
+        private boolean drinkPreference;
+        private int bakeryCount;
+        private double latitude;
+        private double longitude;
+        private Set<BreadType> preferredBreadTypes;
+        // 요청 시점 스냅샷 없음 — 현재 설정 참조
+        private CurrentUserPreference userPreference;
+
+        @Getter
+        @Builder
+        public static class CurrentUserPreference {
+            private List<BakeryType> bakeryTypes;
+            private List<BakeryPersonality> bakeryMoods;
+            private List<BakeryUseType> bakeryUseTypes;
+            private WaitingTolerance waitingTolerance;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Result {
+        private String name;
+        private String theme;
+        private String summary;
+        private String estimatedTime;
+        private Long estimatedCost;
+        private String recommendReason;
+        private List<RecommendedBakeryResponse> bakeries;
+    }
+
+    public static AiCourseAdminResponse from(Course course) {
+        AiCourseInfo ai = course.getAiCourseInfo();
+        UserPreference pref = course.getUserPreference();
+
+        Input input =
+                ai != null
+                        ? Input.builder()
+                                .travelType(ai.getTravelType())
+                                .budgetRange(ai.getBudgetRange())
+                                .flexibilityLevel(ai.getFlexibilityLevel())
+                                .minimizeRoute(ai.isMinimizeRoute())
+                                .waitingPreference(ai.isWaitingPreference())
+                                .drinkPreference(ai.isDrinkPreference())
+                                .bakeryCount(ai.getBakeryCount())
+                                .latitude(ai.getLatitude())
+                                .longitude(ai.getLongitude())
+                                .preferredBreadTypes(course.getPreferredBreadTypes())
+                                .userPreference(
+                                        pref != null
+                                                ? Input.CurrentUserPreference.builder()
+                                                        .bakeryTypes(pref.getBakeryTypes())
+                                                        .bakeryMoods(pref.getBakeryMoods())
+                                                        .bakeryUseTypes(pref.getBakeryUseTypes())
+                                                        .waitingTolerance(
+                                                                pref.getWaitingTolerance())
+                                                        .build()
+                                                : null)
+                                .build()
+                        : null;
+
+        List<RecommendedBakeryResponse> bakeries =
+                course.getCourseBakeries().stream()
+                        .sorted(Comparator.comparingInt(CourseBakery::getVisitOrder))
+                        .map(RecommendedBakeryResponse::from)
+                        .toList();
+
+        Result result =
+                Result.builder()
+                        .name(course.getName())
+                        .theme(course.getTheme())
+                        .summary(course.getSummary())
+                        .estimatedTime(course.getEstimatedTime())
+                        .estimatedCost(course.getEstimatedCost())
+                        .recommendReason(ai != null ? ai.getRecommendReason() : null)
+                        .bakeries(bakeries)
+                        .build();
+
+        return AiCourseAdminResponse.builder()
+                .id(course.getId())
+                .userId(course.getUser() != null ? course.getUser().getId() : null)
+                .userNickname(course.getUser() != null ? course.getUser().getNickname() : null)
+                .input(input)
+                .result(result)
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
@@ -1,8 +1,12 @@
 package com.breadbread.course.repository;
 
 import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,4 +35,37 @@ public interface CourseRepository extends JpaRepository<Course, Long>, CourseRep
                     + "LEFT JOIN FETCH cb.bakery "
                     + "WHERE c.id = :id AND c.active = true")
     Optional<Course> findActiveWithBakeriesById(@Param("id") Long id);
+
+    @Query(
+            value =
+                    "SELECT DISTINCT c FROM Course c "
+                            + "LEFT JOIN FETCH c.courseBakeries cb "
+                            + "LEFT JOIN FETCH cb.bakery "
+                            + "LEFT JOIN FETCH c.user "
+                            + "LEFT JOIN FETCH c.userPreference "
+                            + "WHERE c.courseType = :type AND c.active = true",
+            countQuery =
+                    "SELECT COUNT(c) FROM Course c "
+                            + "WHERE c.courseType = :type AND c.active = true")
+    Page<Course> findAllByActiveTrueAndCourseType(
+            @Param("type") CourseType type, Pageable pageable);
+
+    @Query(
+            value =
+                    "SELECT DISTINCT c FROM Course c "
+                            + "LEFT JOIN FETCH c.courseBakeries cb "
+                            + "LEFT JOIN FETCH cb.bakery "
+                            + "LEFT JOIN FETCH c.user "
+                            + "LEFT JOIN FETCH c.userPreference "
+                            + "WHERE c.courseType = :type AND c.active = true "
+                            + "AND c.createdAt >= :from AND c.createdAt <= :to",
+            countQuery =
+                    "SELECT COUNT(c) FROM Course c "
+                            + "WHERE c.courseType = :type AND c.active = true "
+                            + "AND c.createdAt >= :from AND c.createdAt <= :to")
+    Page<Course> findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+            @Param("type") CourseType type,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -8,6 +8,8 @@ import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.course.dto.request.CourseSearch;
 import com.breadbread.course.dto.request.ManualCourseRequest;
 import com.breadbread.course.dto.request.UpdateCourseRequest;
+import com.breadbread.course.dto.response.AiCourseAdminListResponse;
+import com.breadbread.course.dto.response.AiCourseAdminResponse;
 import com.breadbread.course.dto.response.CourseDetailResponse;
 import com.breadbread.course.dto.response.CourseListResponse;
 import com.breadbread.course.dto.response.CourseSummaryResponse;
@@ -15,6 +17,7 @@ import com.breadbread.course.dto.response.RouteResponse;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.entity.CourseLike;
+import com.breadbread.course.entity.CourseType;
 import com.breadbread.course.entity.ManualCourseInfo;
 import com.breadbread.course.entity.Route;
 import com.breadbread.course.repository.CourseBakeryRepository;
@@ -27,6 +30,7 @@ import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -310,7 +314,27 @@ public class CourseService {
         log.info("MANUAL 코스 수정: courseId={}", courseId);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
+    public AiCourseAdminListResponse findAllAiForAdmin(
+            LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        LocalDateTime start = from != null ? from : LocalDateTime.of(2000, 1, 1, 0, 0);
+        LocalDateTime end = to != null ? to : LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+        Page<Course> courses =
+                courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+                        CourseType.AI, start, end, pageable);
+
+        List<AiCourseAdminResponse> summaries =
+                courses.getContent().stream().map(AiCourseAdminResponse::from).toList();
+
+        return AiCourseAdminListResponse.builder()
+                .courses(summaries)
+                .total((int) courses.getTotalElements())
+                .page(pageable.getPageNumber())
+                .size(pageable.getPageSize())
+                .hasNext(courses.hasNext())
+                .build();
+    }
+
     public void delete(Long courseId) {
         Course course =
                 courseRepository

--- a/apps/be/src/main/java/com/breadbread/global/config/SwaggerConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/SwaggerConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
-        SecurityScheme securityScheme =
+        SecurityScheme bearerScheme =
                 new SecurityScheme()
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
@@ -19,7 +19,14 @@ public class SwaggerConfig {
                         .in(SecurityScheme.In.HEADER)
                         .name("Authorization");
 
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+        SecurityScheme apiKeyScheme =
+                new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name("X-AI-API-KEY");
+
+        SecurityRequirement securityRequirement =
+                new SecurityRequirement().addList("BearerAuth").addList("ApiKeyAuth");
 
         return new OpenAPI()
                 .info(
@@ -28,6 +35,7 @@ public class SwaggerConfig {
                                 .description("BreadBread 백엔드 API 명세서")
                                 .version("1.0.0"))
                 .addSecurityItem(securityRequirement)
-                .schemaRequirement("BearerAuth", securityScheme);
+                .schemaRequirement("BearerAuth", bearerScheme)
+                .schemaRequirement("ApiKeyAuth", apiKeyScheme);
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/filter/AiApiKeyFilter.java
+++ b/apps/be/src/main/java/com/breadbread/global/filter/AiApiKeyFilter.java
@@ -27,8 +27,8 @@ public class AiApiKeyFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String uri = request.getRequestURI();
         String method = request.getMethod();
-        return !(uri.startsWith("/admin/congestion")
-                || uri.startsWith("/admin/trends")
+        return !((uri.startsWith("/admin/congestion") && !"GET".equals(method))
+                || (uri.startsWith("/admin/trends") && !"GET".equals(method))
                 || uri.startsWith("/admin/tours/active")
                 || (uri.startsWith("/notifications/curator") && "POST".equals(method)));
     }

--- a/apps/be/src/main/java/com/breadbread/trend/controller/AdminTrendController.java
+++ b/apps/be/src/main/java/com/breadbread/trend/controller/AdminTrendController.java
@@ -1,0 +1,53 @@
+package com.breadbread.trend.controller;
+
+import com.breadbread.global.dto.ApiResponse;
+import com.breadbread.trend.dto.BakeryTrendTagAdminListResponse;
+import com.breadbread.trend.service.TrendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "트렌드 - 관리자")
+@RestController
+@RequestMapping("/admin/trends")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminTrendController {
+
+    private final TrendService trendService;
+
+    @Operation(
+            summary = "트렌드 태그 전체 목록 조회 (관리자)",
+            description = "수집된 BakeryTrendTag 전체 레코드를 최신순으로 조회합니다.")
+    @Parameters({
+        @Parameter(name = "page", description = "페이지 번호 (0부터 시작, 기본값: 0)"),
+        @Parameter(name = "size", description = "페이지 크기 (기본값: 20)"),
+        @Parameter(name = "from", description = "조회 시작 날짜 (형식: yyyy-MM-dd, 예: 2025-01-01)"),
+        @Parameter(name = "to", description = "조회 종료 날짜 (형식: yyyy-MM-dd, 예: 2025-12-31)")
+    })
+    @GetMapping
+    public ApiResponse<BakeryTrendTagAdminListResponse> findAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate to) {
+        return ApiResponse.ok(
+                trendService.findAllForAdmin(
+                        from != null ? from.atStartOfDay() : null,
+                        to != null ? to.atTime(LocalTime.MAX) : null,
+                        PageRequest.of(page, size)));
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/trend/dto/BakeryTrendTagAdminListResponse.java
+++ b/apps/be/src/main/java/com/breadbread/trend/dto/BakeryTrendTagAdminListResponse.java
@@ -1,0 +1,15 @@
+package com.breadbread.trend.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BakeryTrendTagAdminListResponse {
+    private List<BakeryTrendTagAdminResponse> tags;
+    private int total;
+    private int page;
+    private int size;
+    private boolean hasNext;
+}

--- a/apps/be/src/main/java/com/breadbread/trend/dto/BakeryTrendTagAdminResponse.java
+++ b/apps/be/src/main/java/com/breadbread/trend/dto/BakeryTrendTagAdminResponse.java
@@ -1,0 +1,53 @@
+package com.breadbread.trend.dto;
+
+import com.breadbread.trend.entity.BakeryTrendTag;
+import com.breadbread.trend.entity.TrendStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BakeryTrendTagAdminResponse {
+    private Long id;
+    private String keyword;
+    private Double trendScore;
+    private TrendStatus trendStatus;
+    private Double growthRate;
+    private Long bakeryId;
+    private String bakeryName;
+    private List<String> matchedMenus;
+    private List<String> sources;
+    private LocalDateTime collectedAt;
+    private LocalDateTime createdAt;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static List<String> parseJsonArray(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return MAPPER.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    public static BakeryTrendTagAdminResponse from(BakeryTrendTag tag) {
+        return BakeryTrendTagAdminResponse.builder()
+                .id(tag.getId())
+                .keyword(tag.getKeyword())
+                .trendScore(tag.getTrendScore())
+                .trendStatus(tag.getTrendStatus())
+                .growthRate(tag.getGrowthRate())
+                .bakeryId(tag.getBakeryId())
+                .bakeryName(tag.getBakeryName())
+                .matchedMenus(parseJsonArray(tag.getMatchedMenus()))
+                .sources(parseJsonArray(tag.getSources()))
+                .collectedAt(tag.getCollectedAt())
+                .createdAt(tag.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/trend/repository/BakeryTrendTagRepository.java
+++ b/apps/be/src/main/java/com/breadbread/trend/repository/BakeryTrendTagRepository.java
@@ -2,6 +2,7 @@ package com.breadbread.trend.repository;
 
 import com.breadbread.trend.entity.BakeryTrendTag;
 import com.breadbread.trend.entity.TrendStatus;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -80,4 +81,11 @@ public interface BakeryTrendTagRepository extends JpaRepository<BakeryTrendTag, 
             nativeQuery = true)
     Page<BakeryTrendTag> findLatestByBakeryAndKeyword(
             @Param("keyword") String keyword, Pageable pageable);
+
+    @Query(
+            "SELECT t FROM BakeryTrendTag t"
+                    + " WHERE t.createdAt >= :from AND t.createdAt <= :to"
+                    + " ORDER BY t.createdAt DESC")
+    Page<BakeryTrendTag> findAllByCreatedAtRange(
+            @Param("from") LocalDateTime from, @Param("to") LocalDateTime to, Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/trend/service/TrendService.java
+++ b/apps/be/src/main/java/com/breadbread/trend/service/TrendService.java
@@ -1,5 +1,7 @@
 package com.breadbread.trend.service;
 
+import com.breadbread.trend.dto.BakeryTrendTagAdminListResponse;
+import com.breadbread.trend.dto.BakeryTrendTagAdminResponse;
 import com.breadbread.trend.dto.TrendBakeryResponse;
 import com.breadbread.trend.dto.TrendBreadResponse;
 import com.breadbread.trend.dto.TrendDiscoverRequest;
@@ -8,11 +10,13 @@ import com.breadbread.trend.entity.TrendStatus;
 import com.breadbread.trend.repository.BakeryTrendTagRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,5 +89,20 @@ public class TrendService {
             log.warn("[트렌드] JSON 직렬화 실패: {}", list);
             return null;
         }
+    }
+
+    @Transactional(readOnly = true)
+    public BakeryTrendTagAdminListResponse findAllForAdmin(
+            LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        LocalDateTime start = from != null ? from : LocalDateTime.of(2000, 1, 1, 0, 0);
+        LocalDateTime end = to != null ? to : LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+        Page<BakeryTrendTag> page = repository.findAllByCreatedAtRange(start, end, pageable);
+        return BakeryTrendTagAdminListResponse.builder()
+                .tags(page.getContent().stream().map(BakeryTrendTagAdminResponse::from).toList())
+                .total((int) page.getTotalElements())
+                .page(pageable.getPageNumber())
+                .size(pageable.getPageSize())
+                .hasNext(page.hasNext())
+                .build();
     }
 }

--- a/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -203,6 +206,56 @@ class CongestionSignalServiceTest {
         CongestionResponse response = CongestionResponse.from(signal);
 
         assertThat(response.getLevel()).isNull();
+    }
+
+    // ── findAllForAdmin ───────────────────────────────────────────────────────
+
+    @Test
+    void findAllForAdmin_returnsPagedSignals() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        BakeryCongestionSignal s1 = signal(1L, "파리바게뜨", CongestionLevel.HIGH);
+        BakeryCongestionSignal s2 = signal(2L, "뚜레쥬르", CongestionLevel.LOW);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(s1, s2), pageable, 2));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.getSignals()).hasSize(2);
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getSignals().get(0).getBakeryId()).isEqualTo(1L);
+        assertThat(result.getSignals().get(0).getLevel()).isEqualTo(CongestionLevel.HIGH);
+    }
+
+    @Test
+    void findAllForAdmin_returnsEmptyPage_whenNoData() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.getSignals()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(0);
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void findAllForAdmin_hasNext_whenMorePagesExist() {
+        PageRequest pageable = PageRequest.of(0, 1);
+        BakeryCongestionSignal s = signal(1L, "파리바게뜨", CongestionLevel.MEDIUM);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(s), pageable, 5));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(5);
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -17,6 +17,7 @@ import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.course.dto.request.CourseSearch;
 import com.breadbread.course.dto.request.ManualCourseRequest;
 import com.breadbread.course.dto.request.UpdateCourseRequest;
+import com.breadbread.course.dto.response.AiCourseAdminListResponse;
 import com.breadbread.course.dto.response.CourseListResponse;
 import com.breadbread.course.dto.response.RouteResponse;
 import com.breadbread.course.entity.AiCourseInfo;
@@ -24,6 +25,7 @@ import com.breadbread.course.entity.BudgetRange;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.entity.CourseLike;
+import com.breadbread.course.entity.CourseType;
 import com.breadbread.course.entity.FlexibilityLevel;
 import com.breadbread.course.entity.ManualCourseInfo;
 import com.breadbread.course.entity.Route;
@@ -38,6 +40,7 @@ import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -551,6 +554,69 @@ class CourseServiceTest {
         courseService.updateManual(1L, request);
 
         verify(courseDrivingRouteRepository, never()).deleteAllByCourseIdIn(any());
+    }
+
+    // ── findAllAiForAdmin ─────────────────────────────────────────────────────
+
+    @Test
+    void findAllAiForAdmin_returnsPagedAiCourses() {
+        User u = owner(1L);
+        Course c1 = aiPrivateCourse(10L, u);
+        Course c2 = aiPrivateCourse(11L, u);
+        Bakery bakery = bakery(20L, "A빵집");
+        c1.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(bakery).build());
+
+        Pageable pageable = PageRequest.of(0, 10);
+        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+                        eq(CourseType.AI),
+                        any(LocalDateTime.class),
+                        any(LocalDateTime.class),
+                        eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(c1, c2), pageable, 2));
+
+        AiCourseAdminListResponse result = courseService.findAllAiForAdmin(null, null, pageable);
+
+        assertThat(result.getCourses()).hasSize(2);
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getCourses().get(0).getUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    void findAllAiForAdmin_returnsEmptyPage_whenNoData() {
+        Pageable pageable = PageRequest.of(0, 10);
+        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+                        eq(CourseType.AI),
+                        any(LocalDateTime.class),
+                        any(LocalDateTime.class),
+                        eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        AiCourseAdminListResponse result = courseService.findAllAiForAdmin(null, null, pageable);
+
+        assertThat(result.getCourses()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(0);
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void findAllAiForAdmin_hasNext_whenMorePagesExist() {
+        User u = owner(1L);
+        Course c = aiPrivateCourse(10L, u);
+        Pageable pageable = PageRequest.of(0, 1);
+        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+                        eq(CourseType.AI),
+                        any(LocalDateTime.class),
+                        any(LocalDateTime.class),
+                        eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(c), pageable, 5));
+
+        AiCourseAdminListResponse result = courseService.findAllAiForAdmin(null, null, pageable);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(5);
     }
 
     // ── 헬퍼 ─────────────────────────────────────────────────────────────

--- a/apps/be/src/test/java/com/breadbread/trend/service/TrendServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/trend/service/TrendServiceTest.java
@@ -194,6 +194,56 @@ class TrendServiceTest {
         assertThat(result.getContent().get(0).getMatchedMenus()).containsExactly("소금빵", "버터소금빵");
     }
 
+    // ── findAllForAdmin ───────────────────────────────────────────────────────
+
+    @Test
+    void findAllForAdmin_returnsPagedTags() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        BakeryTrendTag t1 = tag("소금빵", TrendStatus.RISING, 50.0, null, null);
+        BakeryTrendTag t2 = tag("휘낭시에", TrendStatus.STABLE, 30.0, null, null);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(t1, t2), pageable, 2));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.getTags()).hasSize(2);
+        assertThat(result.getTotal()).isEqualTo(2);
+        assertThat(result.getPage()).isEqualTo(0);
+        assertThat(result.getSize()).isEqualTo(20);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getTags().get(0).getKeyword()).isEqualTo("소금빵");
+        assertThat(result.getTags().get(1).getKeyword()).isEqualTo("휘낭시에");
+    }
+
+    @Test
+    void findAllForAdmin_returnsEmptyPage_whenNoData() {
+        PageRequest pageable = PageRequest.of(0, 20);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.getTags()).isEmpty();
+        assertThat(result.getTotal()).isEqualTo(0);
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    @Test
+    void findAllForAdmin_hasNext_whenMorePagesExist() {
+        PageRequest pageable = PageRequest.of(0, 1);
+        BakeryTrendTag t = tag("소금빵", TrendStatus.RISING, 50.0, null, null);
+        when(repository.findAllByCreatedAtRange(
+                        any(LocalDateTime.class), any(LocalDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(t), pageable, 5));
+
+        var result = service.findAllForAdmin(null, null, pageable);
+
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(5);
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private static TrendDiscoverRequest request(


### PR DESCRIPTION
## Task
- AI 코스, 트렌드 태그, 혼잡도 신호 전체 목록 조회 (페이징, createdAt 날짜 범위 필터)
- 빵 품절 상태 변경 API 추가
- GET /admin/trends, /admin/congestions API 키 필터 제외

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #252 
