### PR TITLE
fix: AI 코스 상세 및 경로 조회 전체 공개 허용

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -8,7 +8,6 @@ import com.breadbread.course.service.CourseBakeryOrderService;
 import com.breadbread.course.service.CourseDrivingRouteService;
 import com.breadbread.course.service.CourseService;
 import com.breadbread.global.dto.ApiResponse;
-import com.breadbread.user.entity.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -55,8 +54,7 @@ public class CourseController {
     public ApiResponse<CourseDetailResponse> findOne(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails != null ? userDetails.getId() : null;
-        UserRole role = userDetails != null ? userDetails.getRole() : null;
-        return ApiResponse.ok(courseService.findOne(id, userId, role));
+        return ApiResponse.ok(courseService.findOne(id, userId));
     }
 
     @Operation(summary = "코스 좋아요", description = "이미 좋아요한 경우 409 반환")
@@ -106,8 +104,7 @@ public class CourseController {
     public ApiResponse<DrivingRouteResponse> getDrivingRoute(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails != null ? userDetails.getId() : null;
-        UserRole role = userDetails != null ? userDetails.getRole() : null;
-        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id, userId, role));
+        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id, userId));
     }
 
     @Operation(summary = "코스 내 빵집 방문 순서 변경")

--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -101,10 +101,8 @@ public class CourseController {
             summary = "코스 자동차 경로 조회",
             description = "코스에 포함된 빵집 순서대로 자동차 주행 경로의 vertex 좌표를 반환합니다. 비공개 AI 코스는 본인만 조회할 수 있습니다.")
     @GetMapping("/{id}/directions")
-    public ApiResponse<DrivingRouteResponse> getDrivingRoute(
-            @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails != null ? userDetails.getId() : null;
-        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id, userId));
+    public ApiResponse<DrivingRouteResponse> getDrivingRoute(@PathVariable Long id) {
+        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id));
     }
 
     @Operation(summary = "코스 내 빵집 방문 순서 변경")

--- a/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/response/AiCourseAdminResponse.java
@@ -24,7 +24,6 @@ import lombok.Getter;
 public class AiCourseAdminResponse {
     private Long id;
     private Long userId;
-    private String userNickname;
 
     private Input input;
     private Result result;
@@ -117,7 +116,6 @@ public class AiCourseAdminResponse {
         return AiCourseAdminResponse.builder()
                 .id(course.getId())
                 .userId(course.getUser() != null ? course.getUser().getId() : null)
-                .userNickname(course.getUser() != null ? course.getUser().getNickname() : null)
                 .input(input)
                 .result(result)
                 .build();

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseRepository.java
@@ -50,22 +50,25 @@ public interface CourseRepository extends JpaRepository<Course, Long>, CourseRep
     Page<Course> findAllByActiveTrueAndCourseType(
             @Param("type") CourseType type, Pageable pageable);
 
+    // 1단계: ID + 페이징만 (컬렉션 fetch join 없음 → DB 레벨 페이징 보장)
     @Query(
-            value =
-                    "SELECT DISTINCT c FROM Course c "
-                            + "LEFT JOIN FETCH c.courseBakeries cb "
-                            + "LEFT JOIN FETCH cb.bakery "
-                            + "LEFT JOIN FETCH c.user "
-                            + "LEFT JOIN FETCH c.userPreference "
-                            + "WHERE c.courseType = :type AND c.active = true "
-                            + "AND c.createdAt >= :from AND c.createdAt <= :to",
-            countQuery =
-                    "SELECT COUNT(c) FROM Course c "
-                            + "WHERE c.courseType = :type AND c.active = true "
-                            + "AND c.createdAt >= :from AND c.createdAt <= :to")
-    Page<Course> findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+            "SELECT c.id FROM Course c "
+                    + "WHERE c.courseType = :type AND c.active = true "
+                    + "AND c.createdAt >= :from AND c.createdAt <= :to "
+                    + "ORDER BY c.createdAt DESC")
+    Page<Long> findIdsByActiveTrueAndCourseTypeAndCreatedAtRange(
             @Param("type") CourseType type,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
             Pageable pageable);
+
+    // 2단계: ID 목록으로 상세 fetch (컬렉션 fetch join, 페이징 없음)
+    @Query(
+            "SELECT DISTINCT c FROM Course c "
+                    + "LEFT JOIN FETCH c.courseBakeries cb "
+                    + "LEFT JOIN FETCH cb.bakery "
+                    + "LEFT JOIN FETCH c.user "
+                    + "LEFT JOIN FETCH c.userPreference "
+                    + "WHERE c.id IN :ids")
+    List<Course> findAllWithDetailsByIdIn(@Param("ids") List<Long> ids);
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
@@ -14,7 +14,6 @@ import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
-import com.breadbread.user.entity.UserRole;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -35,12 +34,11 @@ public class CourseDrivingRouteService {
     private final DrivingRouteClient drivingRouteClient;
 
     @Transactional
-    public DrivingRouteResponse getDrivingRoute(Long courseId, Long userId, UserRole role) {
+    public DrivingRouteResponse getDrivingRoute(Long courseId, Long userId) {
         Course course =
                 courseRepository
                         .findActiveWithBakeriesById(courseId)
                         .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
-        validateDrivingRouteAccess(course, userId, role);
 
         List<Bakery> orderedBakeries =
                 course.getCourseBakeries().stream()
@@ -154,17 +152,6 @@ public class CourseDrivingRouteService {
                 .totalStayMinutes(totalStayMinutes)
                 .totalMinutes(totalTravelMinutes + totalStayMinutes)
                 .build();
-    }
-
-    private void validateDrivingRouteAccess(Course course, Long userId, UserRole role) {
-        if (!course.isShared() && role != UserRole.ROLE_ADMIN) {
-            if (userId == null) {
-                throw new CustomException(ErrorCode.UNAUTHORIZED);
-            }
-            if (course.getUser() == null || !course.getUser().getId().equals(userId)) {
-                throw new CustomException(ErrorCode.FORBIDDEN);
-            }
-        }
     }
 
     private int secondsToMinutesCeil(int seconds) {

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
@@ -34,7 +34,7 @@ public class CourseDrivingRouteService {
     private final DrivingRouteClient drivingRouteClient;
 
     @Transactional
-    public DrivingRouteResponse getDrivingRoute(Long courseId, Long userId) {
+    public DrivingRouteResponse getDrivingRoute(Long courseId) {
         Course course =
                 courseRepository
                         .findActiveWithBakeriesById(courseId)

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -28,7 +28,6 @@ import com.breadbread.course.repository.RouteRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
-import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -134,20 +133,11 @@ public class CourseService {
     }
 
     @Transactional(readOnly = true)
-    public CourseDetailResponse findOne(Long id, Long userId, UserRole role) {
+    public CourseDetailResponse findOne(Long id, Long userId) {
         Course course =
                 courseRepository
                         .findByIdAndActiveTrue(id)
                         .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
-
-        if (!course.isShared() && role != UserRole.ROLE_ADMIN) {
-            if (userId == null) {
-                throw new CustomException(ErrorCode.UNAUTHORIZED);
-            }
-            if (course.getUser() == null || !course.getUser().getId().equals(userId)) {
-                throw new CustomException(ErrorCode.FORBIDDEN);
-            }
-        }
 
         List<CourseBakery> courseBakeries =
                 courseBakeryRepository.findAllByCourseIdOrderByVisitOrder(id);
@@ -319,19 +309,32 @@ public class CourseService {
             LocalDateTime from, LocalDateTime to, Pageable pageable) {
         LocalDateTime start = from != null ? from : LocalDateTime.of(2000, 1, 1, 0, 0);
         LocalDateTime end = to != null ? to : LocalDateTime.of(9999, 12, 31, 23, 59, 59);
-        Page<Course> courses =
-                courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+
+        // 1단계: ID만 페이지 조회 (DB 레벨 페이징)
+        Page<Long> idPage =
+                courseRepository.findIdsByActiveTrueAndCourseTypeAndCreatedAtRange(
                         CourseType.AI, start, end, pageable);
 
+        // 2단계: ID 목록으로 상세 fetch
+        List<Long> ids = idPage.getContent();
+        List<Course> courses =
+                ids.isEmpty() ? List.of() : courseRepository.findAllWithDetailsByIdIn(ids);
+
+        // ID 순서 보장 (1단계 정렬 기준 유지)
+        Map<Long, Course> courseMap =
+                courses.stream().collect(Collectors.toMap(Course::getId, c -> c));
         List<AiCourseAdminResponse> summaries =
-                courses.getContent().stream().map(AiCourseAdminResponse::from).toList();
+                ids.stream()
+                        .filter(courseMap::containsKey)
+                        .map(id -> AiCourseAdminResponse.from(courseMap.get(id)))
+                        .toList();
 
         return AiCourseAdminListResponse.builder()
                 .courses(summaries)
-                .total((int) courses.getTotalElements())
+                .total((int) idPage.getTotalElements())
                 .page(pageable.getPageNumber())
                 .size(pageable.getPageSize())
-                .hasNext(courses.hasNext())
+                .hasNext(idPage.hasNext())
                 .build();
     }
 
@@ -351,8 +354,6 @@ public class CourseService {
                 courseRepository
                         .findByIdAndActiveTrue(courseId)
                         .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
-
-        validateCourseActionAccess(course, userId);
 
         User user =
                 userRepository
@@ -394,8 +395,6 @@ public class CourseService {
                         .findByIdAndActiveTrue(courseId)
                         .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
 
-        validateCourseActionAccess(course, userId);
-
         User user =
                 userRepository
                         .findById(userId)
@@ -420,12 +419,5 @@ public class CourseService {
                         .findByCourseIdAndUserId(courseId, userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.NOT_ROUTED));
         routeRepository.delete(route);
-    }
-
-    private void validateCourseActionAccess(Course course, Long userId) {
-        if (!course.isShared()
-                && (course.getUser() == null || !course.getUser().getId().equals(userId))) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
     }
 }

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
@@ -55,52 +55,10 @@ class CourseDrivingRouteServiceTest {
     void getDrivingRoute_throws_whenCourseNotFound() {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(
-                        () -> courseDrivingRouteService.getDrivingRoute(1L, 1L, UserRole.ROLE_USER))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, 1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
-    }
-
-    @Test
-    void getDrivingRoute_throws_unauthorized_whenPrivateCourseAndAnonymous() {
-        Course course = aiPrivateCourse(1L, owner(1L));
-        when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null, null))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.UNAUTHORIZED);
-    }
-
-    @Test
-    void getDrivingRoute_throws_forbidden_whenPrivateCourseAndNotOwner() {
-        Course course = aiPrivateCourse(1L, owner(1L));
-        when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(
-                        () -> courseDrivingRouteService.getDrivingRoute(1L, 2L, UserRole.ROLE_USER))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-    }
-
-    @Test
-    void getDrivingRoute_allows_admin_to_access_private_course() {
-        Course course = aiPrivateCourse(1L, owner(1L));
-        List<Coordinate> cachedPath =
-                List.of(new Coordinate(36.0, 127.0), new Coordinate(36.1, 127.1));
-        CourseDrivingRoute cached =
-                CourseDrivingRoute.builder().courseId(1L).path(cachedPath).build();
-
-        when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.of(cached));
-
-        DrivingRouteResponse response =
-                courseDrivingRouteService.getDrivingRoute(1L, 999L, UserRole.ROLE_ADMIN);
-
-        assertThat(response.getPath()).isEqualTo(cachedPath);
-        verify(drivingRouteClient, never()).getPath(any());
     }
 
     @Test
@@ -114,7 +72,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.of(cached));
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
 
         assertThat(response.getPath()).isEqualTo(cachedPath);
         verify(drivingRouteClient, never()).getPath(any());
@@ -136,11 +94,10 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
 
         assertThat(response.getPath()).isEqualTo(path);
 
-        // MANUAL 코스는 사용자 위치 미포함 — 빵집만 좌표로 전달
         ArgumentCaptor<List<Coordinate>> coordCaptor = ArgumentCaptor.forClass(List.class);
         verify(drivingRouteClient).getPath(coordCaptor.capture());
         List<Coordinate> coords = coordCaptor.getValue();
@@ -166,13 +123,12 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        courseDrivingRouteService.getDrivingRoute(2L, 1L, UserRole.ROLE_USER);
+        courseDrivingRouteService.getDrivingRoute(2L, 1L);
 
-        // AI 코스는 AiCourseInfo의 유저 위치가 첫 번째 좌표로 추가되어야 함
         ArgumentCaptor<List<Coordinate>> coordCaptor = ArgumentCaptor.forClass(List.class);
         verify(drivingRouteClient).getPath(coordCaptor.capture());
         List<Coordinate> coords = coordCaptor.getValue();
-        assertThat(coords).hasSize(2); // 유저위치 + 빵집 1개
+        assertThat(coords).hasSize(2);
         assertThat(coords.get(0).getLat()).isEqualTo(35.5);
         assertThat(coords.get(0).getLng()).isEqualTo(126.5);
         assertThat(coords.get(1).getLat()).isEqualTo(36.0);
@@ -192,8 +148,7 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response =
-                courseDrivingRouteService.getDrivingRoute(2L, 1L, UserRole.ROLE_USER);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L, 1L);
 
         assertThat(response.getPath()).isEqualTo(path);
         verify(drivingRouteClient).getPath(any());
@@ -208,7 +163,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null, null))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_INSUFFICIENT_WAYPOINTS);
@@ -218,7 +173,6 @@ class CourseDrivingRouteServiceTest {
 
     @Test
     void getDrivingRoute_throws_whenManualCourseExceedsWaypointLimit() {
-        // 수동 코스: 빵집 8개 → coordinates 8개 > 7
         Course course = manualCourse(1L, "공유코스");
         for (int i = 0; i < 8; i++) {
             course.addCourseBakery(
@@ -231,7 +185,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null, null))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -241,7 +195,6 @@ class CourseDrivingRouteServiceTest {
 
     @Test
     void getDrivingRoute_throws_whenAiCourseExceedsWaypointLimit() {
-        // AI 코스: 빵집 7개 + 출발 위치 1개 → coordinates 8개 > 7
         User owner = owner(1L);
         Course course = aiCourseWithLocation(2L, owner, 35.5, 126.5);
         for (int i = 0; i < 7; i++) {
@@ -255,8 +208,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(2L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(
-                        () -> courseDrivingRouteService.getDrivingRoute(2L, 1L, UserRole.ROLE_USER))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(2L, 1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -275,8 +227,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(
-                        () -> courseDrivingRouteService.getDrivingRoute(1L, 1L, UserRole.ROLE_USER))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, 1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_NOT_FOUND);
@@ -302,8 +253,7 @@ class CourseDrivingRouteServiceTest {
                 .when(courseDrivingRouteSaver)
                 .save(eq(1L), any(RouteResult.class));
 
-        // PK 충돌이 나도 경로는 정상 반환
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
 
         assertThat(response.getPath()).isEqualTo(path);
     }

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
@@ -55,7 +55,7 @@ class CourseDrivingRouteServiceTest {
     void getDrivingRoute_throws_whenCourseNotFound() {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, 1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
@@ -72,7 +72,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.of(cached));
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
 
         assertThat(response.getPath()).isEqualTo(cachedPath);
         verify(drivingRouteClient, never()).getPath(any());
@@ -94,7 +94,7 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
 
         assertThat(response.getPath()).isEqualTo(path);
 
@@ -123,7 +123,7 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        courseDrivingRouteService.getDrivingRoute(2L, 1L);
+        courseDrivingRouteService.getDrivingRoute(2L);
 
         ArgumentCaptor<List<Coordinate>> coordCaptor = ArgumentCaptor.forClass(List.class);
         verify(drivingRouteClient).getPath(coordCaptor.capture());
@@ -148,7 +148,7 @@ class CourseDrivingRouteServiceTest {
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L, 1L);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L);
 
         assertThat(response.getPath()).isEqualTo(path);
         verify(drivingRouteClient).getPath(any());
@@ -163,7 +163,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_INSUFFICIENT_WAYPOINTS);
@@ -185,7 +185,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, null))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -208,7 +208,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(2L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(2L, 1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(2L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -227,7 +227,7 @@ class CourseDrivingRouteServiceTest {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
         when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, 1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_NOT_FOUND);
@@ -253,7 +253,7 @@ class CourseDrivingRouteServiceTest {
                 .when(courseDrivingRouteSaver)
                 .save(eq(1L), any(RouteResult.class));
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L, null);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
 
         assertThat(response.getPath()).isEqualTo(path);
     }

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -124,36 +124,14 @@ class CourseServiceTest {
     void findOne_throws_whenCourseMissing() {
         when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseService.findOne(1L, 1L, UserRole.ROLE_USER))
+        assertThatThrownBy(() -> courseService.findOne(1L, 1L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
     }
 
     @Test
-    void findOne_privateCourse_throwsUnauthorized_whenUserMissing() {
-        Course course = aiPrivateCourse(5L, owner(1L));
-        when(courseRepository.findByIdAndActiveTrue(5L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(() -> courseService.findOne(5L, null, null))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.UNAUTHORIZED);
-    }
-
-    @Test
-    void findOne_privateCourse_throwsForbidden_whenNotOwner() {
-        Course course = aiPrivateCourse(5L, owner(1L));
-        when(courseRepository.findByIdAndActiveTrue(5L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(() -> courseService.findOne(5L, 2L, UserRole.ROLE_USER))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-    }
-
-    @Test
-    void findOne_returns_private_course_when_owner() {
+    void findOne_returns_course_for_any_user() {
         User owner = owner(1L);
         Course course = aiPrivateCourse(7L, owner);
         syncCourseBakeriesForDetail(course);
@@ -166,7 +144,7 @@ class CourseServiceTest {
         when(courseLikeRepository.existsByCourseIdAndUserId(7L, 1L)).thenReturn(false);
         when(routeRepository.existsByCourseIdAndUserId(7L, 1L)).thenReturn(true);
 
-        var detail = courseService.findOne(7L, 1L, UserRole.ROLE_USER);
+        var detail = courseService.findOne(7L, 1L);
 
         assertThat(detail.getId()).isEqualTo(7L);
         assertThat(detail.getBakeries()).hasSize(1);
@@ -174,7 +152,7 @@ class CourseServiceTest {
     }
 
     @Test
-    void findOne_returns_private_course_when_admin() {
+    void findOne_returns_course_for_anonymous() {
         Course course = aiPrivateCourse(8L, owner(3L));
         syncCourseBakeriesForDetail(course);
 
@@ -183,13 +161,12 @@ class CourseServiceTest {
                 .thenReturn(new ArrayList<>(course.getCourseBakeries()));
         when(courseSummaryAssembler.buildThumbnailMap(anyList())).thenReturn(Map.of());
         when(courseLikeRepository.countByCourse(course)).thenReturn(1L);
-        when(courseLikeRepository.existsByCourseIdAndUserId(8L, 999L)).thenReturn(false);
-        when(routeRepository.existsByCourseIdAndUserId(8L, 999L)).thenReturn(false);
 
-        var detail = courseService.findOne(8L, 999L, UserRole.ROLE_ADMIN);
+        var detail = courseService.findOne(8L, null);
 
         assertThat(detail.getLikeCount()).isEqualTo(1);
         assertThat(detail.isSaved()).isFalse();
+        assertThat(detail.isLiked()).isFalse();
     }
 
     @Test
@@ -342,17 +319,6 @@ class CourseServiceTest {
         courseService.delete(4L);
 
         assertThat(course.isActive()).isFalse();
-    }
-
-    @Test
-    void like_throws_whenPrivateAndNotOwner() {
-        Course course = aiPrivateCourse(1L, owner(1L));
-        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(() -> courseService.like(1L, 2L))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
     }
 
     @Test
@@ -511,17 +477,6 @@ class CourseServiceTest {
     }
 
     @Test
-    void saveRoute_throws_when_private_course_and_requester_not_owner() {
-        Course course = aiPrivateCourse(1L, owner(1L));
-        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
-
-        assertThatThrownBy(() -> courseService.saveRoute(1L, 2L))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
-    }
-
-    @Test
     void removeRoute_throws_when_not_routed() {
         when(routeRepository.findByCourseIdAndUserId(1L, 2L)).thenReturn(Optional.empty());
 
@@ -567,12 +522,14 @@ class CourseServiceTest {
         c1.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(bakery).build());
 
         Pageable pageable = PageRequest.of(0, 10);
-        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+        when(courseRepository.findIdsByActiveTrueAndCourseTypeAndCreatedAtRange(
                         eq(CourseType.AI),
                         any(LocalDateTime.class),
                         any(LocalDateTime.class),
                         eq(pageable)))
-                .thenReturn(new PageImpl<>(List.of(c1, c2), pageable, 2));
+                .thenReturn(new PageImpl<>(List.of(10L, 11L), pageable, 2));
+        when(courseRepository.findAllWithDetailsByIdIn(List.of(10L, 11L)))
+                .thenReturn(List.of(c1, c2));
 
         AiCourseAdminListResponse result = courseService.findAllAiForAdmin(null, null, pageable);
 
@@ -587,7 +544,7 @@ class CourseServiceTest {
     @Test
     void findAllAiForAdmin_returnsEmptyPage_whenNoData() {
         Pageable pageable = PageRequest.of(0, 10);
-        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+        when(courseRepository.findIdsByActiveTrueAndCourseTypeAndCreatedAtRange(
                         eq(CourseType.AI),
                         any(LocalDateTime.class),
                         any(LocalDateTime.class),
@@ -606,12 +563,13 @@ class CourseServiceTest {
         User u = owner(1L);
         Course c = aiPrivateCourse(10L, u);
         Pageable pageable = PageRequest.of(0, 1);
-        when(courseRepository.findAllByActiveTrueAndCourseTypeAndCreatedAtRange(
+        when(courseRepository.findIdsByActiveTrueAndCourseTypeAndCreatedAtRange(
                         eq(CourseType.AI),
                         any(LocalDateTime.class),
                         any(LocalDateTime.class),
                         eq(pageable)))
-                .thenReturn(new PageImpl<>(List.of(c), pageable, 5));
+                .thenReturn(new PageImpl<>(List.of(10L), pageable, 5));
+        when(courseRepository.findAllWithDetailsByIdIn(List.of(10L))).thenReturn(List.of(c));
 
         AiCourseAdminListResponse result = courseService.findAllAiForAdmin(null, null, pageable);
 


### PR DESCRIPTION
## Task
- AI 코스 상세 및 경로 조회 전체 공개 허용
- 좋아요 / 좋아요 취소 / 루트 저장 / 루트 해제 — `shared` 여부 무관하게 허용 

## What's Changed
- [] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #259 
