### PR TITLE
feat: 구글 Places API 빵집 임포트 및 placeId 동기화

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/client/GooglePlacesClient.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/client/GooglePlacesClient.java
@@ -34,8 +34,48 @@ public class GooglePlacesClient {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PlaceResult {
         private String id;
+        private DisplayName displayName;
+        private String formattedAddress;
+        private Location location;
+        private String nationalPhoneNumber;
         private List<AddressComponent> addressComponents;
         private List<PlacePhoto> photos;
+        private RegularOpeningHours regularOpeningHours;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DisplayName {
+        private String text;
+        private String languageCode;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RegularOpeningHours {
+        private List<OpeningPeriod> periods;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Location {
+        private double latitude;
+        private double longitude;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OpeningPeriod {
+        private PeriodDetail open;
+        private PeriodDetail close;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PeriodDetail {
+        private int day; // 0=Sunday, 1=Monday, ...
+        private int hour;
+        private int minute;
     }
 
     @Getter
@@ -57,18 +97,33 @@ public class GooglePlacesClient {
         private String photoUri;
     }
 
-    /** 빵집 이름과 좌표로 Google Places Text Search를 수행하여 첫 번째 결과를 반환한다. */
-    public Optional<PlaceResult> searchBakeryPlace(String name, double lat, double lng) {
-        if (isApiKeyMissing()) return Optional.empty();
+    /** 키워드(지역 등) + bakery 타입으로 빵집 목록을 검색한다. */
+    public List<PlaceResult> searchBakeriesByKeyword(String keyword) {
+        if (isApiKeyMissing()) return List.of();
+
+        var requestBody = new TextSearchWithTypeRequest(keyword, "bakery", true, 20, "ko");
+        try {
+            PlacesSearchResponse response = doSearchTextWithDetails(requestBody);
+            if (response == null || response.getPlaces() == null) return List.of();
+            return response.getPlaces();
+        } catch (Exception e) {
+            log.error("[구글 Places] 키워드 검색 실패: keyword={}", keyword, e);
+            return List.of();
+        }
+    }
+
+    /** 빵집 이름과 좌표로 Google Places Text Search를 수행하여 후보 목록을 반환한다. */
+    public List<PlaceResult> searchBakeryPlace(String name, double lat, double lng) {
+        if (isApiKeyMissing()) return List.of();
 
         var requestBodyWithBias =
                 new TextSearchRequest(
-                        name, new LocationBias(new Circle(new LatLng(lat, lng), 200.0)), 1, "ko");
-        var requestBodyWithoutBias = new TextSearchRequestWithoutBias(name, 1, "ko");
+                        name, new LocationBias(new Circle(new LatLng(lat, lng), 200.0)), 5, "ko");
+        var requestBodyWithoutBias = new TextSearchRequestWithoutBias(name, 5, "ko");
 
         try {
             PlacesSearchResponse response = doSearchText(requestBodyWithBias);
-            return firstPlace(response, name);
+            return placesOrEmpty(response, name);
         } catch (WebClientResponseException.BadRequest e) {
             // locationBias가 데이터와 맞지 않아 400이 발생하는 케이스가 있어, 바이어스 없이 1회 재시도한다.
             log.warn(
@@ -78,18 +133,18 @@ public class GooglePlacesClient {
                     lng);
             try {
                 PlacesSearchResponse fallback = doSearchText(requestBodyWithoutBias);
-                return firstPlace(fallback, name);
+                return placesOrEmpty(fallback, name);
             } catch (WebClientResponseException ex) {
                 log.error(
                         "[구글 Places] 검색 재시도 실패: name={}, status={}", name, ex.getStatusCode(), ex);
-                return Optional.empty();
+                return List.of();
             } catch (Exception ex) {
                 log.error("[구글 Places] 검색 재시도 실패: name={}", name, ex);
-                return Optional.empty();
+                return List.of();
             }
         } catch (Exception e) {
             log.error("[구글 Places] 장소 검색 실패: name={}", name, e);
-            return Optional.empty();
+            return List.of();
         }
     }
 
@@ -98,7 +153,9 @@ public class GooglePlacesClient {
                 .post()
                 .uri(properties.getBaseUrl() + "/v1/places:searchText")
                 .header("X-Goog-Api-Key", properties.getApiKey())
-                .header("X-Goog-FieldMask", "places.id,places.addressComponents,places.photos")
+                .header(
+                        "X-Goog-FieldMask",
+                        "places.id,places.location,places.addressComponents,places.photos")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(requestBody)
                 .retrieve()
@@ -107,12 +164,28 @@ public class GooglePlacesClient {
                 .block();
     }
 
-    private Optional<PlaceResult> firstPlace(PlacesSearchResponse response, String name) {
+    private PlacesSearchResponse doSearchTextWithDetails(Object requestBody) {
+        return webClient
+                .post()
+                .uri(properties.getBaseUrl() + "/v1/places:searchText")
+                .header("X-Goog-Api-Key", properties.getApiKey())
+                .header(
+                        "X-Goog-FieldMask",
+                        "places.id,places.displayName,places.formattedAddress,places.location,places.nationalPhoneNumber,places.addressComponents,places.photos,places.regularOpeningHours")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(PlacesSearchResponse.class)
+                .timeout(Duration.ofSeconds(10))
+                .block();
+    }
+
+    private List<PlaceResult> placesOrEmpty(PlacesSearchResponse response, String name) {
         if (response == null || response.getPlaces() == null || response.getPlaces().isEmpty()) {
             log.info("[구글 Places] 검색 결과 없음: name={}", name);
-            return Optional.empty();
+            return List.of();
         }
-        return Optional.of(response.getPlaces().get(0));
+        return response.getPlaces();
     }
 
     /** placeId로 Place Details를 조회해 photos 목록을 반환한다. URL 해석 시 photoName을 런타임에 획득하기 위해 사용한다. */
@@ -182,6 +255,13 @@ public class GooglePlacesClient {
 
     record TextSearchRequestWithoutBias(
             String textQuery, int maxResultCount, String languageCode) {}
+
+    record TextSearchWithTypeRequest(
+            String textQuery,
+            String includedType,
+            boolean strictTypeFiltering,
+            int maxResultCount,
+            String languageCode) {}
 
     record LocationBias(Circle circle) {}
 

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
@@ -3,6 +3,7 @@ package com.breadbread.bakery.controller;
 import com.breadbread.bakery.dto.response.BakeryAdminListResponse;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.service.BakeryService;
+import com.breadbread.bakery.service.GooglePlacesImportService;
 import com.breadbread.bakery.service.GooglePlacesUpdateService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,16 @@ public class AdminBakeryController {
 
     private final BakeryService bakeryService;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
+    private final GooglePlacesImportService googlePlacesImportService;
+
+    @Operation(
+            summary = "구글 Places 키워드로 빵집 임포트",
+            description = "검색 결과를 PENDING 상태로 저장한다. 이미 존재하는 빵집은 스킵.")
+    @Parameter(name = "keyword", description = "검색 키워드", example = "대전 빵집")
+    @PostMapping("/import")
+    public ApiResponse<Integer> importBakeries(@RequestParam String keyword) {
+        return ApiResponse.ok(googlePlacesImportService.importByKeyword(keyword));
+    }
 
     @Operation(summary = "빵집 목록 조회 (상태 필터)")
     @Parameter(name = "status", description = "빵집 상태 필터 (PENDING / APPROVED / REJECTED, 미입력 시 전체)")
@@ -65,7 +76,7 @@ public class AdminBakeryController {
 
     @Operation(
             summary = "빵집 구글 Places 동기화",
-            description = "구글 Places API로 dong 및 이미지(placePhotoName)를 업데이트한다.")
+            description = "구글 Places API로 placeId를 동기화하고, GCS 이미지가 없으면 사진도 업데이트한다.")
     @PostMapping("/{id}/sync-places")
     public ApiResponse<Void> syncPlaces(@PathVariable Long id) {
         googlePlacesUpdateService.syncBakery(id);

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
@@ -27,7 +27,19 @@ public class AdminBakeryController {
 
     @Operation(
             summary = "구글 Places 키워드로 빵집 임포트",
-            description = "검색 결과를 PENDING 상태로 저장한다. 이미 존재하는 빵집은 스킵.")
+            description =
+                    "검색 결과를 PENDING 상태로 저장한다. 이미 존재하는 빵집은 스킵.\n\n"
+                            + "**임포트 시 채워지는 필드**\n"
+                            + "- `name` — 빵집 이름\n"
+                            + "- `address` — 주소\n"
+                            + "- `region` — 지역구\n"
+                            + "- `latitude` / `longitude` — 위경도\n"
+                            + "- `phone` — 전화번호\n"
+                            + "- `weekdayOpen` / `weekdayClose` — 평일 영업 시간\n"
+                            + "- `weekendOpen` / `weekendClose` — 주말 영업 시간\n"
+                            + "- `closedDays` — 정기 휴무일\n"
+                            + "- `placeId` — 구글 Places ID\n\n"
+                            + "나머지 필드(`region`, `bakeryType` 등)는 승인 전 직접 입력 필요.")
     @Parameter(name = "keyword", description = "검색 키워드", example = "대전 빵집")
     @PostMapping("/import")
     public ApiResponse<Integer> importBakeries(@RequestParam String keyword) {

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/Bakery.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/Bakery.java
@@ -48,10 +48,11 @@ public class Bakery extends BaseEntity {
     private int estimatedStayMinutes; // 예상 체류 시간 (분)
     private String note;
     private String dong; // 행정동 (구글 Places 동기화로 채워짐)
+    private String placeId; // Google Places ID (임포트 출처 식별 및 중복 방지)
     private boolean active = true;
 
     @Enumerated(EnumType.STRING)
-    private BakeryStatus status = BakeryStatus.APPROVED;
+    private BakeryStatus status = BakeryStatus.PENDING;
 
     @Embedded private BusinessHours businessHours; // • 운영 시간
 
@@ -183,6 +184,10 @@ public class Bakery extends BaseEntity {
         this.dong = dong;
     }
 
+    public void updatePlaceId(String placeId) {
+        this.placeId = placeId;
+    }
+
     public void updateAddress(String address) {
         this.address = address;
     }
@@ -224,7 +229,8 @@ public class Bakery extends BaseEntity {
             String note,
             LocalTime appearanceTime,
             Frequency frequency,
-            String dong) {
+            String dong,
+            String placeId) {
         this.name = name;
         this.address = address;
         this.region = region;
@@ -258,5 +264,6 @@ public class Bakery extends BaseEntity {
         this.appearanceTime = appearanceTime;
         this.frequency = frequency;
         this.dong = dong;
+        this.placeId = placeId;
     }
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryImage.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryImage.java
@@ -16,20 +16,15 @@ public class BakeryImage {
 
     private String imageUrl;
 
-    // imageUrl과 둘 중 하나만 설정. photoName은 만료되므로 저장하지 않고 런타임에 획득.
-    private String placeId;
-
     private int displayOrder;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bakery_id")
     private Bakery bakery;
 
-    // Builder 객체를 로그로 찍을 때 bakery 전체가 붙어서 출력되거나 순환 참조되므로 주의 필요
     @Builder
-    public BakeryImage(String imageUrl, String placeId, int displayOrder, Bakery bakery) {
+    public BakeryImage(String imageUrl, int displayOrder, Bakery bakery) {
         this.imageUrl = imageUrl;
-        this.placeId = placeId;
         this.displayOrder = displayOrder;
         this.bakery = bakery;
     }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRepositoryCustom {
     Optional<Bakery> findByIdAndActiveTrue(Long id);
@@ -17,15 +19,28 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRep
 
     List<Bakery> findAllByActiveTrueAndStatus(BakeryStatus status);
 
-    boolean existsByIdAndActiveTrue(Long id);
-
     boolean existsByIdAndActiveTrueAndStatus(Long id, BakeryStatus status);
 
-    List<Bakery> findAllByActiveTrue();
-
-    List<Bakery> findAllByIdInAndActiveTrue(List<Long> ids);
-
     boolean existsByNameAndAddress(String name, String address);
+
+    @Query(
+            value =
+                    """
+                    SELECT * FROM bakery
+                    WHERE active = true
+                      AND ST_DWithin(
+                          location::geography,
+                          ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+                          :radiusMeters
+                      )
+                    """,
+            nativeQuery = true)
+    List<Bakery> findAllNearby(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("radiusMeters") double radiusMeters);
+
+    boolean existsByPlaceId(String placeId);
 
     Optional<Bakery> findFirstByNameAndActiveTrue(String name);
 

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImageUrlResolver.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImageUrlResolver.java
@@ -1,5 +1,6 @@
 package com.breadbread.bakery.service;
 
+import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryImage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,9 +15,10 @@ public class BakeryImageUrlResolver {
         if (image.getImageUrl() != null) {
             return image.getImageUrl();
         }
-        if (image.getPlaceId() != null) {
+        Bakery bakery = image.getBakery();
+        if (bakery != null && bakery.getPlaceId() != null) {
             int photoIndex = Math.max(0, image.getDisplayOrder() - 1);
-            return placesPhotoRedisService.getOrFetchPhotoUrl(image.getPlaceId(), photoIndex);
+            return placesPhotoRedisService.getOrFetchPhotoUrl(bakery.getPlaceId(), photoIndex);
         }
         return null;
     }

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryReportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryReportService.java
@@ -109,7 +109,6 @@ public class BakeryReportService {
                             .dineInAvailable(false)
                             .parkingAvailable(false)
                             .build();
-            pendingBakery.markAsPending();
             bakeryRepository.save(pendingBakery);
         } else if (report.getType() == BakeryReportType.UPDATE_BAKERY) {
             applyUpdateReport(report);

--- a/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
@@ -147,16 +147,10 @@ public class GooglePlacesImportService {
 
         String city =
                 place.getAddressComponents().stream()
-                        .filter(
-                                c ->
-                                        c.getTypes() != null
-                                                && c.getTypes().contains("locality"))
+                        .filter(c -> c.getTypes() != null && c.getTypes().contains("locality"))
                         .findFirst()
                         .map(GooglePlacesClient.AddressComponent::getLongText)
-                        .map(
-                                s ->
-                                        s.replaceAll(
-                                                "(광역시|특별시|특별자치시|특별자치도|도|시)$", ""))
+                        .map(s -> s.replaceAll("(광역시|특별시|특별자치시|특별자치도|도|시)$", ""))
                         .orElse(null);
 
         return city != null ? city + " " + gu : gu;

--- a/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
@@ -1,0 +1,145 @@
+package com.breadbread.bakery.service;
+
+import com.breadbread.bakery.client.GooglePlacesClient;
+import com.breadbread.bakery.client.GooglePlacesClient.PlaceResult;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.repository.BakeryRepository;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GooglePlacesImportService {
+
+    private static final DayOfWeek[] GOOGLE_DAY_MAP = {
+        DayOfWeek.SUNDAY,
+        DayOfWeek.MONDAY,
+        DayOfWeek.TUESDAY,
+        DayOfWeek.WEDNESDAY,
+        DayOfWeek.THURSDAY,
+        DayOfWeek.FRIDAY,
+        DayOfWeek.SATURDAY
+    };
+
+    private static final Set<String> FRANCHISE_NAMES =
+            Set.of(
+                    "파리바게뜨", "뚜레쥬르", "던킨", "스타벅스", "투썸플레이스", "메가커피", "메가MGC커피", "이디야", "컴포즈커피",
+                    "빽다방", "공차", "할리스커피", "블루보틀", "더벤티", "아마스빈", "엔젤리너스", "탐앤탐스");
+
+    private final GooglePlacesClient googlePlacesClient;
+    private final BakeryRepository bakeryRepository;
+
+    @Transactional
+    public int importByKeyword(String keyword) {
+        List<PlaceResult> places = googlePlacesClient.searchBakeriesByKeyword(keyword);
+        int saved = 0;
+
+        for (PlaceResult place : places) {
+            if (place.getDisplayName() == null || place.getDisplayName().getText() == null)
+                continue;
+            if (place.getFormattedAddress() == null) continue;
+            if (place.getLocation() == null) continue;
+
+            String name = place.getDisplayName().getText();
+            String address = place.getFormattedAddress();
+
+            if (isFranchise(name)) continue;
+            if (bakeryRepository.existsByPlaceId(place.getId())) continue;
+            if (bakeryRepository.existsByNameAndAddress(name, address)) continue;
+            if (isDuplicateNearby(
+                    name, place.getLocation().getLatitude(), place.getLocation().getLongitude()))
+                continue;
+
+            LocalTime weekdayOpen = null;
+            LocalTime weekdayClose = null;
+            LocalTime weekendOpen = null;
+            LocalTime weekendClose = null;
+            Set<DayOfWeek> closedDays = new HashSet<>();
+
+            if (place.getRegularOpeningHours() != null
+                    && place.getRegularOpeningHours().getPeriods() != null) {
+                List<GooglePlacesClient.OpeningPeriod> periods =
+                        place.getRegularOpeningHours().getPeriods();
+
+                Set<Integer> openGoogleDays =
+                        periods.stream()
+                                .filter(p -> p.getOpen() != null)
+                                .map(p -> p.getOpen().getDay())
+                                .collect(Collectors.toSet());
+
+                for (int i = 0; i < 7; i++) {
+                    if (!openGoogleDays.contains(i)) closedDays.add(GOOGLE_DAY_MAP[i]);
+                }
+
+                for (GooglePlacesClient.OpeningPeriod period : periods) {
+                    if (period.getOpen() == null || period.getClose() == null) continue;
+                    int day = period.getOpen().getDay();
+                    LocalTime open =
+                            LocalTime.of(period.getOpen().getHour(), period.getOpen().getMinute());
+                    LocalTime close =
+                            LocalTime.of(
+                                    period.getClose().getHour(), period.getClose().getMinute());
+                    // 0=Sunday, 6=Saturday
+                    if (day == 0 || day == 6) {
+                        if (weekendOpen == null) {
+                            weekendOpen = open;
+                            weekendClose = close;
+                        }
+                    } else {
+                        if (weekdayOpen == null) {
+                            weekdayOpen = open;
+                            weekdayClose = close;
+                        }
+                    }
+                }
+            }
+
+            Bakery bakery =
+                    Bakery.builder()
+                            .name(name)
+                            .address(address)
+                            .latitude(place.getLocation().getLatitude())
+                            .longitude(place.getLocation().getLongitude())
+                            .phone(place.getNationalPhoneNumber())
+                            .weekdayOpen(weekdayOpen)
+                            .weekdayClose(weekdayClose)
+                            .weekendOpen(weekendOpen)
+                            .weekendClose(weekendClose)
+                            .closedDays(closedDays)
+                            .holidayClosed(false)
+                            .drinkAvailable(false)
+                            .dineInAvailable(false)
+                            .parkingAvailable(false)
+                            .placeId(place.getId())
+                            .build();
+            bakeryRepository.save(bakery);
+            saved++;
+        }
+
+        log.info("[Places 임포트] keyword={}, saved={}, total={}", keyword, saved, places.size());
+        return saved;
+    }
+
+    private boolean isDuplicateNearby(String name, double lat, double lng) {
+        String normalized = normalize(name);
+        return bakeryRepository.findAllNearby(lat, lng, 100).stream()
+                .anyMatch(b -> normalize(b.getName()).equals(normalized));
+    }
+
+    private String normalize(String name) {
+        return name.replaceAll("[\\s\\p{Punct}]", "").toLowerCase();
+    }
+
+    private boolean isFranchise(String name) {
+        return FRANCHISE_NAMES.stream().anyMatch(name::contains);
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
@@ -107,6 +107,7 @@ public class GooglePlacesImportService {
                     Bakery.builder()
                             .name(name)
                             .address(address)
+                            .region(extractRegion(place))
                             .latitude(place.getLocation().getLatitude())
                             .longitude(place.getLocation().getLongitude())
                             .phone(place.getNationalPhoneNumber())
@@ -127,6 +128,38 @@ public class GooglePlacesImportService {
 
         log.info("[Places 임포트] keyword={}, saved={}, total={}", keyword, saved, places.size());
         return saved;
+    }
+
+    private String extractRegion(GooglePlacesClient.PlaceResult place) {
+        if (place.getAddressComponents() == null) return null;
+
+        String gu =
+                place.getAddressComponents().stream()
+                        .filter(
+                                c ->
+                                        c.getTypes() != null
+                                                && c.getTypes().contains("sublocality_level_1"))
+                        .findFirst()
+                        .map(GooglePlacesClient.AddressComponent::getLongText)
+                        .orElse(null);
+
+        if (gu == null) return null;
+
+        String city =
+                place.getAddressComponents().stream()
+                        .filter(
+                                c ->
+                                        c.getTypes() != null
+                                                && c.getTypes().contains("locality"))
+                        .findFirst()
+                        .map(GooglePlacesClient.AddressComponent::getLongText)
+                        .map(
+                                s ->
+                                        s.replaceAll(
+                                                "(광역시|특별시|특별자치시|특별자치도|도|시)$", ""))
+                        .orElse(null);
+
+        return city != null ? city + " " + gu : gu;
     }
 
     private boolean isDuplicateNearby(String name, double lat, double lng) {

--- a/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesUpdateService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesUpdateService.java
@@ -10,9 +10,9 @@ import com.breadbread.bakery.repository.BakeryRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,20 +46,46 @@ public class GooglePlacesUpdateService {
                         .findByIdAndActiveTrue(bakeryId)
                         .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
 
-        Optional<PlaceResult> placeOpt =
+        List<PlaceResult> candidates =
                 googlePlacesClient.searchBakeryPlace(
                         bakery.getName(), bakery.getLatitude(), bakery.getLongitude());
 
-        if (placeOpt.isEmpty()) {
+        PlaceResult place =
+                candidates.stream()
+                        .filter(p -> p.getLocation() != null)
+                        .min(
+                                Comparator.comparingDouble(
+                                        p ->
+                                                distanceMeters(
+                                                        bakery.getLatitude(),
+                                                        bakery.getLongitude(),
+                                                        p.getLocation().getLatitude(),
+                                                        p.getLocation().getLongitude())))
+                        .orElse(null);
+
+        if (place == null) {
             log.warn("[Places 동기화] 장소 검색 결과 없음: bakeryId={}, name={}", bakeryId, bakery.getName());
             return false;
         }
 
-        PlaceResult place = placeOpt.get();
+        double distance =
+                distanceMeters(
+                        bakery.getLatitude(),
+                        bakery.getLongitude(),
+                        place.getLocation().getLatitude(),
+                        place.getLocation().getLongitude());
 
-        String dong = extractDong(place);
-        if (dong != null) {
-            bakery.updateDong(dong);
+        if (distance > 300) {
+            log.warn(
+                    "[Places 동기화] 가장 가까운 후보도 300m 초과, 스킵: bakeryId={}, name={}, distance={}m",
+                    bakeryId,
+                    bakery.getName(),
+                    (int) distance);
+            return false;
+        }
+
+        if (bakery.getPlaceId() == null) {
+            bakery.updatePlaceId(place.getId());
         }
 
         int photoCount =
@@ -76,12 +102,7 @@ public class GooglePlacesUpdateService {
 
             List<BakeryImage> newImages = new ArrayList<>();
             for (int i = 0; i < photoCount; i++) {
-                newImages.add(
-                        BakeryImage.builder()
-                                .placeId(place.getId())
-                                .displayOrder(i + 1)
-                                .bakery(bakery)
-                                .build());
+                newImages.add(BakeryImage.builder().displayOrder(i + 1).bakery(bakery).build());
             }
             bakeryImageRepository.saveAll(newImages);
 
@@ -96,7 +117,8 @@ public class GooglePlacesUpdateService {
     }
 
     public void syncAllBakeries() {
-        List<Bakery> bakeries = bakeryRepository.findAllByActiveTrue();
+        List<Bakery> bakeries =
+                bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.APPROVED);
         log.debug("[Places 동기화] 전체 동기화 시작: count={}", bakeries.size());
         int success = 0, skip = 0, fail = 0;
         for (Bakery bakery : bakeries) {
@@ -115,13 +137,17 @@ public class GooglePlacesUpdateService {
         }
     }
 
-    @Scheduled(cron = "0 0 4 */2 * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 4 */4 * *", zone = "Asia/Seoul")
     public void warmAllPhotoCaches() {
-        List<Long> bakeryIds =
-                bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.APPROVED).stream()
-                        .map(Bakery::getId)
-                        .toList();
-        if (bakeryIds.isEmpty()) return;
+        List<Bakery> bakeries =
+                bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.APPROVED);
+        if (bakeries.isEmpty()) return;
+
+        Map<Long, String> placeIdByBakeryId =
+                bakeries.stream()
+                        .filter(b -> b.getPlaceId() != null)
+                        .collect(Collectors.toMap(Bakery::getId, Bakery::getPlaceId));
+        List<Long> bakeryIds = bakeries.stream().map(Bakery::getId).toList();
 
         log.debug("[Places 캐시 워밍] 시작: count={}", bakeryIds.size());
         int success = 0, skip = 0, fail = 0;
@@ -148,12 +174,7 @@ public class GooglePlacesUpdateService {
                 skip++;
                 continue;
             }
-            String placeId =
-                    images.stream()
-                            .map(BakeryImage::getPlaceId)
-                            .filter(id -> id != null)
-                            .findFirst()
-                            .orElse(null);
+            String placeId = placeIdByBakeryId.get(bakeryId);
             if (placeId == null) {
                 skip++;
                 continue;
@@ -185,15 +206,16 @@ public class GooglePlacesUpdateService {
         }
     }
 
-    private String extractDong(PlaceResult place) {
-        if (place.getAddressComponents() == null) return null;
-        return place.getAddressComponents().stream()
-                .filter(
-                        comp ->
-                                comp.getTypes() != null
-                                        && comp.getTypes().contains("sublocality_level_2"))
-                .findFirst()
-                .map(GooglePlacesClient.AddressComponent::getLongText)
-                .orElse(null);
+    private double distanceMeters(double lat1, double lon1, double lat2, double lon2) {
+        final double R = 6371000;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a =
+                Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                        + Math.cos(Math.toRadians(lat1))
+                                * Math.cos(Math.toRadians(lat2))
+                                * Math.sin(dLon / 2)
+                                * Math.sin(dLon / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/config/GooglePlacesProperties.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/GooglePlacesProperties.java
@@ -12,5 +12,5 @@ import org.springframework.stereotype.Component;
 public class GooglePlacesProperties {
     private String apiKey = "";
     private String baseUrl = "https://places.googleapis.com";
-    private long photoUrlTtlSeconds = 3000;
+    private long photoUrlTtlSeconds = 345600; // 4일
 }

--- a/apps/be/src/main/java/com/breadbread/global/config/WebClientConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/WebClientConfig.java
@@ -2,6 +2,8 @@ package com.breadbread.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.codec.ClientCodecConfigurer;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -9,6 +11,12 @@ public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {
-        return WebClient.builder().build();
+        ExchangeStrategies strategies =
+                ExchangeStrategies.builder()
+                        .codecs(
+                                (ClientCodecConfigurer c) ->
+                                        c.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
+                        .build();
+        return WebClient.builder().exchangeStrategies(strategies).build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 @Slf4j
@@ -78,6 +80,13 @@ public class GlobalExceptionHandler {
                 .body(
                         ApiResponse.fail(
                                 ErrorCode.INVALID_INPUT_VALUE.getCode(), "올바르지 않은 요청 형식입니다."));
+    }
+
+    @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(Exception e) {
+        log.warn("Path not found: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail(ErrorCode.NOT_FOUND.getCode(), "존재하지 않는 경로입니다."));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -180,7 +180,7 @@ google:
   places:
     api-key: ${GOOGLE_PLACES_API_KEY}
     base-url: https://places.googleapis.com
-    photo-url-ttl-seconds: ${GOOGLE_PLACES_PHOTO_URL_TTL_SECONDS:172800}
+    photo-url-ttl-seconds: ${GOOGLE_PLACES_PHOTO_URL_TTL_SECONDS:345600}
 
 logging:
   pattern:

--- a/apps/be/src/main/resources/db/migration/V19__add_bakery_place_id.sql
+++ b/apps/be/src/main/resources/db/migration/V19__add_bakery_place_id.sql
@@ -1,0 +1,31 @@
+ALTER TABLE bakery ADD COLUMN place_id VARCHAR(255);
+
+UPDATE bakery b
+SET place_id = (
+    SELECT bi.place_id
+    FROM bakery_image bi
+    WHERE bi.bakery_id = b.id
+      AND bi.place_id IS NOT NULL
+    LIMIT 1
+)
+WHERE b.place_id IS NULL
+  AND EXISTS (
+      SELECT 1 FROM bakery_image bi
+      WHERE bi.bakery_id = b.id
+        AND bi.place_id IS NOT NULL
+  );
+
+-- 같은 place_id가 여러 bakery에 매핑된 경우 id가 작은 행만 남기고 나머지는 NULL 처리
+UPDATE bakery b
+SET place_id = NULL
+WHERE place_id IS NOT NULL
+  AND id NOT IN (
+      SELECT MIN(id)
+      FROM bakery
+      WHERE place_id IS NOT NULL
+      GROUP BY place_id
+  );
+
+CREATE UNIQUE INDEX idx_bakery_place_id ON bakery(place_id) WHERE place_id IS NOT NULL;
+
+ALTER TABLE bakery_image DROP COLUMN IF EXISTS place_id;

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryImageUrlResolverTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryImageUrlResolverTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryImage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +40,7 @@ class BakeryImageUrlResolverTest {
         BakeryImage image =
                 BakeryImage.builder()
                         .imageUrl("https://storage.googleapis.com/bucket/img.jpg")
-                        .placeId("ChIJ123")
+                        .bakery(bakeryWithPlaceId("ChIJ123"))
                         .displayOrder(1)
                         .build();
 
@@ -53,7 +54,8 @@ class BakeryImageUrlResolverTest {
 
     @Test
     void resolve_callsPlacesService_whenPlacesImage() {
-        BakeryImage image = BakeryImage.builder().placeId("ChIJ123").displayOrder(1).build();
+        BakeryImage image =
+                BakeryImage.builder().bakery(bakeryWithPlaceId("ChIJ123")).displayOrder(1).build();
         when(placesPhotoRedisService.getOrFetchPhotoUrl("ChIJ123", 0))
                 .thenReturn("https://places.googleapis.com/photo/abc");
 
@@ -65,7 +67,8 @@ class BakeryImageUrlResolverTest {
 
     @Test
     void resolve_usesCorrectPhotoIndex_basedOnDisplayOrder() {
-        BakeryImage image = BakeryImage.builder().placeId("ChIJ123").displayOrder(3).build();
+        BakeryImage image =
+                BakeryImage.builder().bakery(bakeryWithPlaceId("ChIJ123")).displayOrder(3).build();
         when(placesPhotoRedisService.getOrFetchPhotoUrl("ChIJ123", 2))
                 .thenReturn("https://places.googleapis.com/photo/abc");
 
@@ -76,7 +79,8 @@ class BakeryImageUrlResolverTest {
 
     @Test
     void resolve_usesZeroIndex_whenDisplayOrderIsZero() {
-        BakeryImage image = BakeryImage.builder().placeId("ChIJ123").displayOrder(0).build();
+        BakeryImage image =
+                BakeryImage.builder().bakery(bakeryWithPlaceId("ChIJ123")).displayOrder(0).build();
         when(placesPhotoRedisService.getOrFetchPhotoUrl("ChIJ123", 0)).thenReturn(null);
 
         resolver.resolve(image);
@@ -86,7 +90,8 @@ class BakeryImageUrlResolverTest {
 
     @Test
     void resolve_returnsNull_whenPlacesServiceReturnsNull() {
-        BakeryImage image = BakeryImage.builder().placeId("ChIJ123").displayOrder(1).build();
+        BakeryImage image =
+                BakeryImage.builder().bakery(bakeryWithPlaceId("ChIJ123")).displayOrder(1).build();
         when(placesPhotoRedisService.getOrFetchPhotoUrl("ChIJ123", 0)).thenReturn(null);
 
         String result = resolver.resolve(image);
@@ -104,5 +109,26 @@ class BakeryImageUrlResolverTest {
 
         assertThat(result).isNull();
         verifyNoInteractions(placesPhotoRedisService);
+    }
+
+    @Test
+    void resolve_returnsNull_whenBakeryHasNoPlaceId() {
+        BakeryImage image =
+                BakeryImage.builder().bakery(bakeryWithPlaceId(null)).displayOrder(1).build();
+
+        String result = resolver.resolve(image);
+
+        assertThat(result).isNull();
+        verifyNoInteractions(placesPhotoRedisService);
+    }
+
+    private Bakery bakeryWithPlaceId(String placeId) {
+        return Bakery.builder()
+                .name("test bakery")
+                .address("test address")
+                .latitude(36.327)
+                .longitude(127.427)
+                .placeId(placeId)
+                .build();
     }
 }

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -798,6 +798,7 @@ class BakeryServiceTest {
                         .note("")
                         .build();
         ReflectionTestUtils.setField(b, "id", id);
+        ReflectionTestUtils.setField(b, "status", BakeryStatus.APPROVED);
         return b;
     }
 


### PR DESCRIPTION
## Task
- Google Places 키워드 검색으로 PENDING 빵집 일괄 임포트
- placeId를 BakeryImage에서 Bakery로 이전 (V19 마이그레이션)
- 동기화 시 dong 제거, placeId만 업데이트
- 5개 후보 중 최근접 선택 + 300m 임계값으로 오매핑 방지
- 프랜차이즈 필터링, placeId/이름+주소/100m 근접 중복 방지
- 이미지 캐시 TTL 4일, 스케줄러 4일 주기로 변경
- Bakery 기본 status PENDING으로 변경

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #263 
