### PR TITLE
feat: 카카오 로컬 API 빵집 임포트 추가 및 어드민 기능 개선

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/client/GooglePlacesClient.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/client/GooglePlacesClient.java
@@ -41,6 +41,7 @@ public class GooglePlacesClient {
         private List<AddressComponent> addressComponents;
         private List<PlacePhoto> photos;
         private RegularOpeningHours regularOpeningHours;
+        private String googleMapsUri;
     }
 
     @Getter
@@ -171,7 +172,7 @@ public class GooglePlacesClient {
                 .header("X-Goog-Api-Key", properties.getApiKey())
                 .header(
                         "X-Goog-FieldMask",
-                        "places.id,places.displayName,places.formattedAddress,places.location,places.nationalPhoneNumber,places.addressComponents,places.photos,places.regularOpeningHours")
+                        "places.id,places.displayName,places.formattedAddress,places.location,places.nationalPhoneNumber,places.addressComponents,places.photos,places.regularOpeningHours,places.googleMapsUri")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(requestBody)
                 .retrieve()

--- a/apps/be/src/main/java/com/breadbread/bakery/client/KakaoLocalClient.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/client/KakaoLocalClient.java
@@ -1,0 +1,81 @@
+package com.breadbread.bakery.client;
+
+import com.breadbread.bakery.config.KakaoLocalProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+    private static final int MAX_SIZE = 15;
+
+    private final WebClient webClient;
+    private final KakaoLocalProperties properties;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KeywordSearchResponse {
+        private List<Place> documents;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Place {
+        @JsonProperty("place_name")
+        private String placeName;
+
+        @JsonProperty("road_address_name")
+        private String roadAddressName;
+
+        @JsonProperty("address_name")
+        private String addressName;
+
+        private String phone;
+        private String x; // longitude
+        private String y; // latitude
+
+        @JsonProperty("category_name")
+        private String categoryName;
+
+        @JsonProperty("place_url")
+        private String placeUrl;
+    }
+
+    public List<Place> searchBakeries(String keyword) {
+        if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
+            log.warn("[카카오 로컬] API 키가 설정되지 않아 요청을 건너뜁니다.");
+            return List.of();
+        }
+
+        try {
+            KeywordSearchResponse response =
+                    webClient
+                            .get()
+                            .uri(
+                                    properties.getBaseUrl()
+                                            + "/v2/local/search/keyword.json?query={query}&size={size}",
+                                    keyword,
+                                    MAX_SIZE)
+                            .header("Authorization", "KakaoAK " + properties.getApiKey())
+                            .retrieve()
+                            .bodyToMono(KeywordSearchResponse.class)
+                            .timeout(Duration.ofSeconds(10))
+                            .block();
+
+            if (response == null || response.getDocuments() == null) return List.of();
+            return response.getDocuments();
+        } catch (Exception e) {
+            log.error("[카카오 로컬] 키워드 검색 실패: keyword={}", keyword, e);
+            return List.of();
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/config/KakaoLocalProperties.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/config/KakaoLocalProperties.java
@@ -1,0 +1,15 @@
+package com.breadbread.bakery.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakao.local")
+public class KakaoLocalProperties {
+    private String apiKey = "";
+    private String baseUrl = "https://dapi.kakao.com";
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
@@ -5,10 +5,12 @@ import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.service.BakeryService;
 import com.breadbread.bakery.service.GooglePlacesImportService;
 import com.breadbread.bakery.service.GooglePlacesUpdateService;
+import com.breadbread.bakery.service.KakaoLocalImportService;
 import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -24,6 +26,7 @@ public class AdminBakeryController {
     private final BakeryService bakeryService;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
     private final GooglePlacesImportService googlePlacesImportService;
+    private final KakaoLocalImportService kakaoLocalImportService;
 
     @Operation(
             summary = "구글 Places 키워드로 빵집 임포트",
@@ -42,19 +45,38 @@ public class AdminBakeryController {
                             + "나머지 필드(`region`, `bakeryType` 등)는 승인 전 직접 입력 필요.")
     @Parameter(name = "keyword", description = "검색 키워드", example = "대전 빵집")
     @PostMapping("/import")
-    public ApiResponse<Integer> importBakeries(@RequestParam String keyword) {
+    public ApiResponse<List<String>> importBakeries(@RequestParam String keyword) {
         return ApiResponse.ok(googlePlacesImportService.importByKeyword(keyword));
+    }
+
+    @Operation(
+            summary = "카카오 로컬 키워드로 빵집 임포트",
+            description =
+                    "카카오 로컬 API 검색 결과를 PENDING 상태로 저장한다. 이미 존재하는 빵집은 스킵.\n\n"
+                            + "**임포트 시 채워지는 필드**\n"
+                            + "- `name` — 빵집 이름\n"
+                            + "- `address` — 도로명 주소 (없으면 지번 주소)\n"
+                            + "- `region` — 지역구\n"
+                            + "- `latitude` / `longitude` — 위경도\n"
+                            + "- `phone` — 전화번호\n\n"
+                            + "영업시간 등 나머지 필드는 승인 전 직접 입력 필요.")
+    @Parameter(name = "keyword", description = "검색 키워드", example = "대전 빵집")
+    @PostMapping("/import/kakao")
+    public ApiResponse<List<String>> importBakeriesFromKakao(@RequestParam String keyword) {
+        return ApiResponse.ok(kakaoLocalImportService.importByKeyword(keyword));
     }
 
     @Operation(summary = "빵집 목록 조회 (상태 필터)")
     @Parameter(name = "status", description = "빵집 상태 필터 (PENDING / APPROVED / REJECTED, 미입력 시 전체)")
+    @Parameter(name = "active", description = "활성 여부 (true: 정상, false: 소프트삭제된 빵집, 기본값 true)")
     @GetMapping
     public ApiResponse<BakeryAdminListResponse> getBakeries(
             @RequestParam(required = false) BakeryStatus status,
+            @RequestParam(defaultValue = "true") boolean active,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         return ApiResponse.ok(
-                bakeryService.getBakeriesByStatus(status, PageRequest.of(page, size)));
+                bakeryService.getBakeriesByStatus(status, active, PageRequest.of(page, size)));
     }
 
     @Operation(
@@ -83,6 +105,25 @@ public class AdminBakeryController {
     @PostMapping("/{id}/reject")
     public ApiResponse<Void> rejectBakery(@PathVariable Long id) {
         bakeryService.rejectBakery(id);
+        return ApiResponse.ok();
+    }
+
+    @Operation(
+            summary = "PENDING/REJECTED 빵집 전체 영구 삭제",
+            description = "PENDING 또는 REJECTED 상태의 빵집을 DB에서 완전히 삭제한다. APPROVED 상태는 삭제 불가.")
+    @Parameter(name = "status", description = "삭제할 상태 (PENDING 또는 REJECTED)")
+    @DeleteMapping
+    public ApiResponse<Integer> hardDeleteByStatus(@RequestParam BakeryStatus status) {
+        return ApiResponse.ok(bakeryService.hardDeleteByStatus(status));
+    }
+
+    @Operation(
+            summary = "특정 빵집 영구 삭제",
+            description =
+                    "PENDING 또는 REJECTED 상태의 특정 빵집을 DB에서 완전히 삭제한다. 소프트삭제된 빵집도 삭제 가능. APPROVED 상태는 삭제 불가.")
+    @DeleteMapping("/{id}/hard")
+    public ApiResponse<Void> hardDeleteBakery(@PathVariable Long id) {
+        bakeryService.hardDeleteBakery(id);
         return ApiResponse.ok();
     }
 

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryLikeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryLikeRepository.java
@@ -13,6 +13,8 @@ import org.springframework.data.repository.query.Param;
 public interface BakeryLikeRepository extends JpaRepository<BakeryLike, Long> {
     Optional<BakeryLike> findByBakeryIdAndUserId(Long bakeryId, Long userId);
 
+    void deleteAllByBakeryId(Long bakeryId);
+
     boolean existsByBakeryIdAndUserId(Long bakeryId, Long userId);
 
     long countByBakery(Bakery bakery);

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryRepository.java
@@ -19,6 +19,8 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRep
 
     List<Bakery> findAllByActiveTrueAndStatus(BakeryStatus status);
 
+    List<Bakery> findAllByActiveFalseAndStatus(BakeryStatus status);
+
     boolean existsByIdAndActiveTrueAndStatus(Long id, BakeryStatus status);
 
     boolean existsByNameAndAddress(String name, String address);
@@ -27,8 +29,7 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRep
             value =
                     """
                     SELECT * FROM bakery
-                    WHERE active = true
-                      AND ST_DWithin(
+                    WHERE ST_DWithin(
                           location::geography,
                           ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
                           :radiusMeters
@@ -47,4 +48,8 @@ public interface BakeryRepository extends JpaRepository<Bakery, Long>, BakeryRep
     Page<Bakery> findAllByActiveTrueAndStatus(BakeryStatus status, Pageable pageable);
 
     Page<Bakery> findAllByActiveTrue(Pageable pageable);
+
+    Page<Bakery> findAllByActiveFalseAndStatus(BakeryStatus status, Pageable pageable);
+
+    Page<Bakery> findAllByActiveFalse(Pageable pageable);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BreadRepository.java
@@ -10,4 +10,6 @@ public interface BreadRepository extends JpaRepository<Bread, Long> {
     List<Bread> findAllByBakeryIdIn(Collection<Long> bakeryIds);
 
     Optional<Bread> findByIdAndBakeryId(Long id, Long bakeryId);
+
+    void deleteAllByBakeryId(Long bakeryId);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/CrowdTimeRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/CrowdTimeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CrowdTimeRepository extends JpaRepository<CrowdTime, Long> {
     List<CrowdTime> findAllByBakeryIdIn(Collection<Long> bakeryIds);
+
+    void deleteAllByBakeryId(Long bakeryId);
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/ReviewRepository.java
@@ -32,6 +32,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
                     + "GROUP BY r.bakery.id")
     List<Object[]> averageRatingByBakeryIdIn(@Param("bakeryIds") List<Long> bakeryIds);
 
+    void deleteAllByBakeryId(Long bakeryId);
+
     List<Review> findAllByUserIdAndActiveTrueOrderByCreatedAtDesc(Long userId);
 
     @Query(

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImportConstants.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryImportConstants.java
@@ -1,0 +1,13 @@
+package com.breadbread.bakery.service;
+
+import java.util.Set;
+
+class BakeryImportConstants {
+
+    static final Set<String> FRANCHISE_NAMES =
+            Set.of(
+                    "파리바게뜨", "뚜레쥬르", "던킨", "스타벅스", "투썸플레이스", "메가커피", "메가MGC커피", "이디야", "컴포즈커피",
+                    "빽다방", "공차", "할리스커피", "블루보틀", "더벤티", "아마스빈", "엔젤리너스", "탐앤탐스");
+
+    private BakeryImportConstants() {}
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -374,11 +374,20 @@ public class BakeryService {
     }
 
     @Transactional(readOnly = true)
-    public BakeryAdminListResponse getBakeriesByStatus(BakeryStatus status, Pageable pageable) {
-        Page<Bakery> page =
-                status != null
-                        ? bakeryRepository.findAllByActiveTrueAndStatus(status, pageable)
-                        : bakeryRepository.findAllByActiveTrue(pageable);
+    public BakeryAdminListResponse getBakeriesByStatus(
+            BakeryStatus status, boolean active, Pageable pageable) {
+        Page<Bakery> page;
+        if (active) {
+            page =
+                    status != null
+                            ? bakeryRepository.findAllByActiveTrueAndStatus(status, pageable)
+                            : bakeryRepository.findAllByActiveTrue(pageable);
+        } else {
+            page =
+                    status != null
+                            ? bakeryRepository.findAllByActiveFalseAndStatus(status, pageable)
+                            : bakeryRepository.findAllByActiveFalse(pageable);
+        }
         return BakeryAdminListResponse.builder()
                 .bakeries(page.getContent().stream().map(BakeryAdminResponse::from).toList())
                 .total((int) page.getTotalElements())
@@ -421,6 +430,50 @@ public class BakeryService {
         }
         bakery.reject();
         log.info("빵집 거절: bakeryId={}", bakeryId);
+    }
+
+    @Transactional
+    public int hardDeleteByStatus(BakeryStatus status) {
+        if (status == BakeryStatus.APPROVED) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        List<Bakery> active = bakeryRepository.findAllByActiveTrueAndStatus(status);
+        List<Bakery> inactive = bakeryRepository.findAllByActiveFalseAndStatus(status);
+        List<Bakery> targets = new ArrayList<>();
+        targets.addAll(active);
+        targets.addAll(inactive);
+        targets.forEach(b -> deleteRelatedData(b.getId()));
+        targets.forEach(bakeryImageService::deleteAllImages);
+        bakeryRepository.deleteAll(targets);
+        log.info("빵집 전체 영구삭제: status={}, count={}", status, targets.size());
+        return targets.size();
+    }
+
+    @Transactional
+    public void hardDeleteBakery(Long bakeryId) {
+        Bakery bakery =
+                bakeryRepository
+                        .findById(bakeryId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+        if (bakery.getStatus() == BakeryStatus.APPROVED) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+        deleteRelatedData(bakeryId);
+        bakeryImageService.deleteAllImages(bakery);
+        bakeryRepository.delete(bakery);
+        log.info("빵집 영구삭제: bakeryId={}", bakeryId);
+    }
+
+    private void deleteRelatedData(Long bakeryId) {
+        List<Long> courseIds = courseBakeryRepository.findCourseIdsByBakeryId(bakeryId);
+        if (!courseIds.isEmpty()) {
+            courseDrivingRouteRepository.deleteAllByCourseIdIn(courseIds);
+        }
+        courseBakeryRepository.deleteAllByBakeryId(bakeryId);
+        breadRepository.deleteAllByBakeryId(bakeryId);
+        crowdTimeRepository.deleteAllByBakeryId(bakeryId);
+        reviewRepository.deleteAllByBakeryId(bakeryId);
+        bakeryLikeRepository.deleteAllByBakeryId(bakeryId);
     }
 
     private void checkAuthority(Bakery bakery, Long userId, UserRole role) {

--- a/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/GooglePlacesImportService.java
@@ -1,11 +1,14 @@
 package com.breadbread.bakery.service;
 
+import static com.breadbread.bakery.service.BakeryImportConstants.FRANCHISE_NAMES;
+
 import com.breadbread.bakery.client.GooglePlacesClient;
 import com.breadbread.bakery.client.GooglePlacesClient.PlaceResult;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.repository.BakeryRepository;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,18 +33,13 @@ public class GooglePlacesImportService {
         DayOfWeek.SATURDAY
     };
 
-    private static final Set<String> FRANCHISE_NAMES =
-            Set.of(
-                    "파리바게뜨", "뚜레쥬르", "던킨", "스타벅스", "투썸플레이스", "메가커피", "메가MGC커피", "이디야", "컴포즈커피",
-                    "빽다방", "공차", "할리스커피", "블루보틀", "더벤티", "아마스빈", "엔젤리너스", "탐앤탐스");
-
     private final GooglePlacesClient googlePlacesClient;
     private final BakeryRepository bakeryRepository;
 
     @Transactional
-    public int importByKeyword(String keyword) {
+    public List<String> importByKeyword(String keyword) {
         List<PlaceResult> places = googlePlacesClient.searchBakeriesByKeyword(keyword);
-        int saved = 0;
+        List<String> savedNames = new ArrayList<>();
 
         for (PlaceResult place : places) {
             if (place.getDisplayName() == null || place.getDisplayName().getText() == null)
@@ -108,6 +106,8 @@ public class GooglePlacesImportService {
                             .name(name)
                             .address(address)
                             .region(extractRegion(place))
+                            .dong(extractDong(place))
+                            .mapLink(place.getGoogleMapsUri())
                             .latitude(place.getLocation().getLatitude())
                             .longitude(place.getLocation().getLongitude())
                             .phone(place.getNationalPhoneNumber())
@@ -123,11 +123,26 @@ public class GooglePlacesImportService {
                             .placeId(place.getId())
                             .build();
             bakeryRepository.save(bakery);
-            saved++;
+            savedNames.add(name);
         }
 
-        log.info("[Places 임포트] keyword={}, saved={}, total={}", keyword, saved, places.size());
-        return saved;
+        log.info(
+                "[Places 임포트] keyword={}, saved={}, total={}",
+                keyword,
+                savedNames.size(),
+                places.size());
+        return savedNames;
+    }
+
+    private String extractDong(GooglePlacesClient.PlaceResult place) {
+        if (place.getAddressComponents() == null) return null;
+        return place.getAddressComponents().stream()
+                .filter(c -> c.getTypes() != null && c.getTypes().contains("sublocality_level_2"))
+                .findFirst()
+                .map(GooglePlacesClient.AddressComponent::getLongText)
+                .map(s -> s.replaceAll("[^가-힣]", ""))
+                .filter(s -> !s.isEmpty())
+                .orElse(null);
     }
 
     private String extractRegion(GooglePlacesClient.PlaceResult place) {

--- a/apps/be/src/main/java/com/breadbread/bakery/service/KakaoLocalImportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/KakaoLocalImportService.java
@@ -1,0 +1,125 @@
+package com.breadbread.bakery.service;
+
+import static com.breadbread.bakery.service.BakeryImportConstants.FRANCHISE_NAMES;
+
+import com.breadbread.bakery.client.KakaoLocalClient;
+import com.breadbread.bakery.client.KakaoLocalClient.Place;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.repository.BakeryRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLocalImportService {
+
+    private final KakaoLocalClient kakaoLocalClient;
+    private final BakeryRepository bakeryRepository;
+
+    @Transactional
+    public List<String> importByKeyword(String keyword) {
+        List<Place> places = kakaoLocalClient.searchBakeries(keyword);
+        List<String> savedNames = new ArrayList<>();
+
+        for (Place place : places) {
+            if (place.getPlaceName() == null) continue;
+            if (place.getX() == null || place.getY() == null) continue;
+
+            String name = place.getPlaceName();
+            String address =
+                    place.getRoadAddressName() != null
+                            ? place.getRoadAddressName()
+                            : place.getAddressName();
+            if (address == null) continue;
+
+            double lng, lat;
+            try {
+                lng = Double.parseDouble(place.getX());
+                lat = Double.parseDouble(place.getY());
+            } catch (NumberFormatException e) {
+                log.warn(
+                        "[카카오 임포트] 좌표 파싱 실패, 건너뜀: name={}, x={}, y={}",
+                        name,
+                        place.getX(),
+                        place.getY());
+                continue;
+            }
+
+            if (!isBakeryCategory(place.getCategoryName())) continue;
+            if (isFranchise(name)) continue;
+            if (bakeryRepository.existsByNameAndAddress(name, address)) continue;
+            if (isDuplicateNearby(name, lat, lng)) continue;
+
+            Bakery bakery =
+                    Bakery.builder()
+                            .name(name)
+                            .address(address)
+                            .region(extractRegion(place.getAddressName()))
+                            .dong(extractDong(place.getAddressName()))
+                            .mapLink(place.getPlaceUrl())
+                            .latitude(lat)
+                            .longitude(lng)
+                            .phone(place.getPhone())
+                            .holidayClosed(false)
+                            .drinkAvailable(false)
+                            .dineInAvailable(false)
+                            .parkingAvailable(false)
+                            .build();
+            bakeryRepository.save(bakery);
+            savedNames.add(name);
+        }
+
+        log.info(
+                "[카카오 임포트] keyword={}, saved={}, total={}",
+                keyword,
+                savedNames.size(),
+                places.size());
+        return savedNames;
+    }
+
+    private String extractDong(String addressName) {
+        if (addressName == null) return null;
+        return Arrays.stream(addressName.split(" "))
+                .filter(p -> p.endsWith("동"))
+                .findFirst()
+                .map(s -> s.replaceAll("[^가-힣]", ""))
+                .filter(s -> !s.isEmpty())
+                .orElse(null);
+    }
+
+    private String extractRegion(String addressName) {
+        if (addressName == null) return null;
+        String[] parts = addressName.split(" ");
+        if (parts.length < 2) return null;
+        String city = parts[0].replaceAll("(광역시|특별시|특별자치시|특별자치도|도|시)$", "");
+        String gu = Arrays.stream(parts).filter(p -> p.endsWith("구")).findFirst().orElse(null);
+        return gu != null ? city + " " + gu : null;
+    }
+
+    private boolean isDuplicateNearby(String name, double lat, double lng) {
+        String normalized = normalize(name);
+        return bakeryRepository.findAllNearby(lat, lng, 100).stream()
+                .anyMatch(b -> normalize(b.getName()).equals(normalized));
+    }
+
+    private String normalize(String name) {
+        return name.replaceAll("[\\s\\p{Punct}]", "").toLowerCase();
+    }
+
+    private boolean isBakeryCategory(String categoryName) {
+        if (categoryName == null) return false;
+        return categoryName.contains("베이커리")
+                || categoryName.contains("제과")
+                || categoryName.contains("빵");
+    }
+
+    private boolean isFranchise(String name) {
+        return FRANCHISE_NAMES.stream().anyMatch(name::contains);
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseBakeryRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseBakeryRepository.java
@@ -14,6 +14,8 @@ public interface CourseBakeryRepository extends JpaRepository<CourseBakery, Long
     @Query("SELECT cb.course.id FROM CourseBakery cb WHERE cb.bakery.id = :bakeryId")
     List<Long> findCourseIdsByBakeryId(@Param("bakeryId") Long bakeryId);
 
+    void deleteAllByBakeryId(Long bakeryId);
+
     /** 혼잡도 체크용 — bakery N+1 방지 */
     @Query(
             "SELECT cb FROM CourseBakery cb JOIN FETCH cb.bakery WHERE cb.course.id = :courseId"

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -145,6 +145,9 @@ naver:
     timeout-seconds: ${NAVER_MAPS_TIMEOUT_SECONDS:10}
 
 kakao:
+  local:
+    api-key: ${KAKAO_CLIENT_ID}
+    base-url: https://dapi.kakao.com
   mobility:
     app-key: ${KAKAO_MOBILITY_APP_KEY:}
     base-url: https://apis-navi.kakaomobility.com

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -3,6 +3,7 @@ package com.breadbread.bakery.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -13,6 +14,7 @@ import com.breadbread.bakery.dto.request.BakeryAiSearch;
 import com.breadbread.bakery.dto.request.BakerySearch;
 import com.breadbread.bakery.dto.request.CreateBakeryRequest;
 import com.breadbread.bakery.dto.request.UpdateBakeryRequest;
+import com.breadbread.bakery.dto.response.BakeryAdminListResponse;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryLike;
 import com.breadbread.bakery.entity.Bread;
@@ -759,6 +761,133 @@ class BakeryServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.BAKERY_NOT_PENDING);
+    }
+
+    // ── hardDeleteBakery ──────────────────────────────────────────────────────
+
+    @Test
+    void hardDeleteBakery_deletes_when_PENDING() {
+        Bakery bakery = pendingBakeryWithId(300L);
+        when(bakeryRepository.findById(300L)).thenReturn(Optional.of(bakery));
+        when(courseBakeryRepository.findCourseIdsByBakeryId(300L)).thenReturn(List.of());
+
+        bakeryService.hardDeleteBakery(300L);
+
+        verify(bakeryImageService).deleteAllImages(bakery);
+        verify(bakeryRepository).delete(bakery);
+    }
+
+    @Test
+    void hardDeleteBakery_deletes_when_REJECTED() {
+        Bakery bakery = pendingBakeryWithId(301L);
+        ReflectionTestUtils.setField(bakery, "status", BakeryStatus.REJECTED);
+        when(bakeryRepository.findById(301L)).thenReturn(Optional.of(bakery));
+        when(courseBakeryRepository.findCourseIdsByBakeryId(301L)).thenReturn(List.of());
+
+        bakeryService.hardDeleteBakery(301L);
+
+        verify(bakeryImageService).deleteAllImages(bakery);
+        verify(bakeryRepository).delete(bakery);
+    }
+
+    @Test
+    void hardDeleteBakery_deletes_related_data_before_delete() {
+        Bakery bakery = pendingBakeryWithId(303L);
+        when(bakeryRepository.findById(303L)).thenReturn(Optional.of(bakery));
+        when(courseBakeryRepository.findCourseIdsByBakeryId(303L)).thenReturn(List.of(10L));
+
+        bakeryService.hardDeleteBakery(303L);
+
+        verify(courseDrivingRouteRepository).deleteAllByCourseIdIn(List.of(10L));
+        verify(courseBakeryRepository).deleteAllByBakeryId(303L);
+        verify(breadRepository).deleteAllByBakeryId(303L);
+        verify(crowdTimeRepository).deleteAllByBakeryId(303L);
+        verify(reviewRepository).deleteAllByBakeryId(303L);
+        verify(bakeryLikeRepository).deleteAllByBakeryId(303L);
+        verify(bakeryRepository).delete(bakery);
+    }
+
+    @Test
+    void hardDeleteBakery_throws_FORBIDDEN_when_APPROVED() {
+        Bakery bakery = bakeryWithId(302L);
+        when(bakeryRepository.findById(302L)).thenReturn(Optional.of(bakery));
+
+        assertThatThrownBy(() -> bakeryService.hardDeleteBakery(302L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(bakeryRepository, never()).delete(any());
+    }
+
+    @Test
+    void hardDeleteBakery_throws_BAKERY_NOT_FOUND_when_missing() {
+        when(bakeryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bakeryService.hardDeleteBakery(999L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+    }
+
+    // ── hardDeleteByStatus ────────────────────────────────────────────────────
+
+    @Test
+    void hardDeleteByStatus_deletes_all_PENDING_including_inactive() {
+        List<Bakery> active = List.of(pendingBakeryWithId(1L));
+        List<Bakery> inactive = List.of(pendingBakeryWithId(2L));
+        when(bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.PENDING))
+                .thenReturn(active);
+        when(bakeryRepository.findAllByActiveFalseAndStatus(BakeryStatus.PENDING))
+                .thenReturn(inactive);
+        when(courseBakeryRepository.findCourseIdsByBakeryId(any())).thenReturn(List.of());
+
+        int count = bakeryService.hardDeleteByStatus(BakeryStatus.PENDING);
+
+        assertThat(count).isEqualTo(2);
+        verify(bakeryImageService).deleteAllImages(active.get(0));
+        verify(bakeryImageService).deleteAllImages(inactive.get(0));
+        verify(bakeryRepository).deleteAll(argThat(list -> ((List<?>) list).size() == 2));
+    }
+
+    @Test
+    void hardDeleteByStatus_throws_FORBIDDEN_when_APPROVED() {
+        assertThatThrownBy(() -> bakeryService.hardDeleteByStatus(BakeryStatus.APPROVED))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(bakeryRepository, never()).deleteAll(any());
+    }
+
+    // ── getBakeriesByStatus (active=false) ────────────────────────────────────
+
+    @Test
+    void getBakeriesByStatus_returns_soft_deleted_when_active_false() {
+        Bakery bakery = bakeryWithId(10L);
+        Pageable pageable = PageRequest.of(0, 10);
+        when(bakeryRepository.findAllByActiveFalse(pageable))
+                .thenReturn(new PageImpl<>(List.of(bakery), pageable, 1));
+
+        BakeryAdminListResponse response = bakeryService.getBakeriesByStatus(null, false, pageable);
+
+        assertThat(response.getTotal()).isEqualTo(1);
+        verify(bakeryRepository).findAllByActiveFalse(pageable);
+        verify(bakeryRepository, never()).findAllByActiveTrue(any());
+    }
+
+    @Test
+    void getBakeriesByStatus_filters_by_status_when_active_false() {
+        Bakery bakery = pendingBakeryWithId(11L);
+        Pageable pageable = PageRequest.of(0, 10);
+        when(bakeryRepository.findAllByActiveFalseAndStatus(BakeryStatus.PENDING, pageable))
+                .thenReturn(new PageImpl<>(List.of(bakery), pageable, 1));
+
+        BakeryAdminListResponse response =
+                bakeryService.getBakeriesByStatus(BakeryStatus.PENDING, false, pageable);
+
+        assertThat(response.getTotal()).isEqualTo(1);
+        verify(bakeryRepository).findAllByActiveFalseAndStatus(BakeryStatus.PENDING, pageable);
     }
 
     private static Bakery pendingBakeryWithId(long id) {

--- a/apps/be/src/test/java/com/breadbread/bakery/service/KakaoLocalImportServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/KakaoLocalImportServiceTest.java
@@ -1,0 +1,301 @@
+package com.breadbread.bakery.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.client.KakaoLocalClient;
+import com.breadbread.bakery.client.KakaoLocalClient.Place;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.repository.BakeryRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoLocalImportServiceTest {
+
+    @Mock private KakaoLocalClient kakaoLocalClient;
+    @Mock private BakeryRepository bakeryRepository;
+
+    @InjectMocks private KakaoLocalImportService kakaoLocalImportService;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Place place(
+            String name,
+            String roadAddress,
+            String address,
+            String x,
+            String y,
+            String categoryName) {
+        Place p = new Place();
+        ReflectionTestUtils.setField(p, "placeName", name);
+        ReflectionTestUtils.setField(p, "roadAddressName", roadAddress);
+        ReflectionTestUtils.setField(p, "addressName", address);
+        ReflectionTestUtils.setField(p, "x", x);
+        ReflectionTestUtils.setField(p, "y", y);
+        ReflectionTestUtils.setField(p, "phone", "042-000-0000");
+        ReflectionTestUtils.setField(p, "categoryName", categoryName);
+        return p;
+    }
+
+    private Place bakeryPlace(String name, String roadAddress, String address, String x, String y) {
+        return place(name, roadAddress, address, x, y, "카페 > 베이커리");
+    }
+
+    private Bakery bakeryNamed(String name) {
+        return Bakery.builder()
+                .name(name)
+                .address("대전광역시 유성구 대학로 1")
+                .latitude(36.3)
+                .longitude(127.3)
+                .holidayClosed(false)
+                .drinkAvailable(false)
+                .dineInAvailable(false)
+                .parkingAvailable(false)
+                .build();
+    }
+
+    // ── importByKeyword ───────────────────────────────────────────────────────
+
+    @Test
+    void importByKeyword_saves_valid_place_and_returns_name() {
+        Place place = bakeryPlace("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries("대전 빵집")).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).containsExactly("나무빵집");
+        verify(bakeryRepository).save(any(Bakery.class));
+    }
+
+    @Test
+    void importByKeyword_skips_non_bakery_category() {
+        Place place =
+                place(
+                        "나무커피",
+                        "대전광역시 유성구 대학로 99",
+                        "대전광역시 유성구 대학동 1",
+                        "127.35",
+                        "36.36",
+                        "카페 > 커피전문점");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_skips_null_category() {
+        Place place = place("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36", null);
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_accepts_jeogwa_category() {
+        Place place =
+                place(
+                        "나무빵집",
+                        "대전광역시 유성구 대학로 99",
+                        "대전광역시 유성구 대학동 1",
+                        "127.35",
+                        "36.36",
+                        "음식점 > 제과,베이커리");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).containsExactly("나무빵집");
+    }
+
+    @Test
+    void importByKeyword_skips_franchise() {
+        Place place =
+                bakeryPlace("파리바게뜨 유성점", "대전광역시 유성구 대학로 1", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_skips_existing_name_and_address() {
+        Place place = bakeryPlace("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress("나무빵집", "대전광역시 유성구 대학로 99")).thenReturn(true);
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_skips_nearby_duplicate() {
+        Place place = bakeryPlace("빵한모금", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        Bakery nearby = bakeryNamed("빵 한모금");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of(nearby));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_skips_place_with_null_name() {
+        Place place = bakeryPlace(null, "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_skips_place_with_invalid_coordinates() {
+        Place place = bakeryPlace("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "잘못된값", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
+    void importByKeyword_saves_valid_place_even_if_another_has_invalid_coordinates() {
+        Place invalid = bakeryPlace("이상한빵집", "대전광역시 유성구 대학로 1", "대전광역시 유성구 대학동 1", "N/A", "N/A");
+        Place valid = bakeryPlace("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 2", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(invalid, valid));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).containsExactly("나무빵집");
+        verify(bakeryRepository).save(any(Bakery.class));
+    }
+
+    @Test
+    void importByKeyword_uses_road_address_when_available() {
+        Place place = bakeryPlace("나무빵집", "대전광역시 유성구 대학로 99", "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        ArgumentCaptor<Bakery> captor = ArgumentCaptor.forClass(Bakery.class);
+        verify(bakeryRepository).save(captor.capture());
+        assertThat(captor.getValue().getAddress()).isEqualTo("대전광역시 유성구 대학로 99");
+    }
+
+    @Test
+    void importByKeyword_falls_back_to_address_name_when_no_road_address() {
+        Place place = bakeryPlace("나무빵집", null, "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        ArgumentCaptor<Bakery> captor = ArgumentCaptor.forClass(Bakery.class);
+        verify(bakeryRepository).save(captor.capture());
+        assertThat(captor.getValue().getAddress()).isEqualTo("대전광역시 유성구 대학동 1");
+    }
+
+    @Test
+    void importByKeyword_sets_region_from_address() {
+        Place place = bakeryPlace("나무빵집", null, "대전광역시 유성구 대학동 1", "127.35", "36.36");
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of(place));
+        when(bakeryRepository.existsByNameAndAddress(any(), any())).thenReturn(false);
+        when(bakeryRepository.findAllNearby(anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(List.of());
+
+        kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        ArgumentCaptor<Bakery> captor = ArgumentCaptor.forClass(Bakery.class);
+        verify(bakeryRepository).save(captor.capture());
+        assertThat(captor.getValue().getRegion()).isEqualTo("대전 유성구");
+    }
+
+    @Test
+    void importByKeyword_returns_empty_when_client_returns_empty() {
+        when(kakaoLocalClient.searchBakeries(any())).thenReturn(List.of());
+
+        List<String> result = kakaoLocalImportService.importByKeyword("대전 빵집");
+
+        assertThat(result).isEmpty();
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    // ── extractRegion (private, via ReflectionTestUtils) ─────────────────────
+
+    @Test
+    void extractRegion_returns_city_and_gu() {
+        String result =
+                (String)
+                        ReflectionTestUtils.invokeMethod(
+                                kakaoLocalImportService, "extractRegion", "대전광역시 유성구 대학동 99");
+        assertThat(result).isEqualTo("대전 유성구");
+    }
+
+    @Test
+    void extractRegion_returns_null_when_no_gu() {
+        String result =
+                (String)
+                        ReflectionTestUtils.invokeMethod(
+                                kakaoLocalImportService, "extractRegion", "대전광역시 대학동 99");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void extractRegion_returns_null_for_null_input() {
+        String result =
+                (String)
+                        ReflectionTestUtils.invokeMethod(
+                                kakaoLocalImportService, "extractRegion", (Object) null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void extractRegion_strips_gwangyeoksi_suffix() {
+        String result =
+                (String)
+                        ReflectionTestUtils.invokeMethod(
+                                kakaoLocalImportService, "extractRegion", "부산광역시 해운대구 중동 1");
+        assertThat(result).isEqualTo("부산 해운대구");
+    }
+}


### PR DESCRIPTION
## Task
카카오 로컬 API를 이용한 빵집 임포트 기능을 추가하고, 구글/카카오 임포트 공통 로직을 정리했습니다.
또한 PENDING/REJECTED 상태 빵집의 영구 삭제 API와 소프트삭제 항목 조회 기능을 추가했습니다.
- 카카오 로컬 API 임포트: categoryName 필터(베이커리/제과/빵), 좌표 파싱 실패 시 해당 항목만 skip, mapLink/dong/region 저장
- 구글/카카오 공통: 프랜차이즈 필터 목록 단일 관리(`BakeryImportConstants`), 임포트 반환값 저장된 빵집 이름 목록으로 변경, 중복 체크 시 PENDING/REJECTED 포함
- 영구 삭제: 상태별 일괄(`DELETE /admin/bakeries?status=`) 및 단건(`DELETE /admin/bakeries/{id}/hard`), 연관 데이터 선삭제
- 어드민 목록 조회에 `active=false` 필터 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #266 
