### PR TITLE
feat: 회원 탈퇴 기능 구현 (소프트삭제)

### DIFF
--- a/apps/be/src/main/java/com/breadbread/auth/dto/CustomUserDetails.java
+++ b/apps/be/src/main/java/com/breadbread/auth/dto/CustomUserDetails.java
@@ -47,7 +47,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return user.isActive();
+        return !user.isWithdrawn();
     }
 
     @Override

--- a/apps/be/src/main/java/com/breadbread/auth/repository/SsoAccountRepository.java
+++ b/apps/be/src/main/java/com/breadbread/auth/repository/SsoAccountRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SsoAccountRepository extends JpaRepository<SsoAccount, Long> {
     Optional<SsoAccount> findByProviderAndProviderUserId(
             SsoProvider provider, String providerUserId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/auth/service/CustomUserDetailsService.java
+++ b/apps/be/src/main/java/com/breadbread/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,8 @@
 package com.breadbread.auth.service;
 
 import com.breadbread.auth.dto.CustomUserDetails;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,9 @@ public class CustomUserDetailsService implements UserDetailsService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
+        if (user.isWithdrawn()) {
+            throw new CustomException(ErrorCode.WITHDRAWN_USER);
+        }
         return new CustomUserDetails(user);
     }
 }

--- a/apps/be/src/main/java/com/breadbread/auth/service/SsoService.java
+++ b/apps/be/src/main/java/com/breadbread/auth/service/SsoService.java
@@ -38,6 +38,9 @@ public class SsoService {
         SocialUserInfo userInfo = getUserInfo(provider, accessToken);
         SsoAccount ssoAccount = ssoAccountService.findOrCreateSsoAccount(provider, userInfo);
         User user = ssoAccount.getUser();
+        if (user.isWithdrawn()) {
+            throw new CustomException(ErrorCode.WITHDRAWN_USER);
+        }
         log.info("소셜 로그인 성공: provider={}, userId={}", provider, user.getId());
         return tokenService.issueTokens(user);
     }

--- a/apps/be/src/main/java/com/breadbread/community/dto/CommentResponse.java
+++ b/apps/be/src/main/java/com/breadbread/community/dto/CommentResponse.java
@@ -32,7 +32,10 @@ public class CommentResponse {
     public static CommentResponse from(Comment comment, Long userId) {
         return CommentResponse.builder()
                 .id(comment.getId())
-                .nickname(comment.getUser().getNickname())
+                .nickname(
+                        comment.getUser().getNickname() != null
+                                ? comment.getUser().getNickname()
+                                : "탈퇴한 사용자")
                 .profileImageUrl(comment.getUser().getProfileImageUrl())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())

--- a/apps/be/src/main/java/com/breadbread/community/dto/PostDetailResponse.java
+++ b/apps/be/src/main/java/com/breadbread/community/dto/PostDetailResponse.java
@@ -55,7 +55,10 @@ public class PostDetailResponse {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .nickname(post.getUser().getNickname())
+                .nickname(
+                        post.getUser().getNickname() != null
+                                ? post.getUser().getNickname()
+                                : "탈퇴한 사용자")
                 .profileImageUrl(post.getUser().getProfileImageUrl())
                 .createdAt(post.getCreatedAt())
                 .content(post.getContent())

--- a/apps/be/src/main/java/com/breadbread/course/service/AiCourseSaveService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/AiCourseSaveService.java
@@ -54,6 +54,12 @@ public class AiCourseSaveService {
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
 
     public String createAi(Long userId, AiCourseRequest request) {
+        if (!userRepository.existsById(userId)) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        if (!userPreferenceRepository.findByUserId(userId).isPresent()) {
+            throw new CustomException(ErrorCode.PREFERENCE_NOT_FOUND);
+        }
         String jobId = UUID.randomUUID().toString();
         aiCourseRedisService.savePending(jobId, userId);
         try {

--- a/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
@@ -133,7 +133,7 @@ public class SecurityConfig {
                         new AiApiKeyFilter(aiProperties, objectMapper),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider, customUserDetailsService),
+                        new JwtAuthenticationFilter(jwtProvider, customUserDetailsService, objectMapper),
                         AiApiKeyFilter.class)
                 .addFilterBefore(authRateLimitFilter, JwtAuthenticationFilter.class);
         return http.build();

--- a/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
+++ b/apps/be/src/main/java/com/breadbread/global/config/SecurityConfig.java
@@ -133,7 +133,8 @@ public class SecurityConfig {
                         new AiApiKeyFilter(aiProperties, objectMapper),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider, customUserDetailsService, objectMapper),
+                        new JwtAuthenticationFilter(
+                                jwtProvider, customUserDetailsService, objectMapper),
                         AiApiKeyFilter.class)
                 .addFilterBefore(authRateLimitFilter, JwtAuthenticationFilter.class);
         return http.build();

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
     INVALID_SOCIAL_STATE(HttpStatus.BAD_REQUEST, "E0115", "유효하지 않은 소셜 로그인 state입니다."),
     SOCIAL_ACCOUNT_NO_PASSWORD(HttpStatus.BAD_REQUEST, "E0116", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "E0117", "이미 사용 중인 닉네임입니다."),
+    WITHDRAWN_USER(HttpStatus.UNAUTHORIZED, "E0118", "탈퇴한 사용자입니다."),
+    WITHDRAW_BLOCKED_BY_RESERVATION(HttpStatus.CONFLICT, "E0119", "진행 중인 예약이 있어 탈퇴할 수 없습니다."),
 
     // 토큰 E02xx
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E0201", "유효하지 않은 토큰입니다."),

--- a/apps/be/src/main/java/com/breadbread/global/filter/JwtAuthenticationFilter.java
+++ b/apps/be/src/main/java/com/breadbread/global/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,10 @@
 package com.breadbread.global.filter;
 
 import com.breadbread.auth.service.CustomUserDetailsService;
+import com.breadbread.global.dto.ApiResponse;
+import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,6 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService userDetailsService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(
@@ -28,12 +33,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtProvider.validateAccessToken(token)) {
             String userId = jwtProvider.getUserIdFromAccessToken(token);
             MDC.put("userId", userId);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            userDetails, null, userDetails.getAuthorities());
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            try {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (CustomException e) {
+                response.setStatus(e.getErrorCode().getStatus().value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.setCharacterEncoding("UTF-8");
+                response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(e.getErrorCode())));
+                return;
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/apps/be/src/main/java/com/breadbread/global/filter/JwtAuthenticationFilter.java
+++ b/apps/be/src/main/java/com/breadbread/global/filter/JwtAuthenticationFilter.java
@@ -45,7 +45,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 response.setStatus(e.getErrorCode().getStatus().value());
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 response.setCharacterEncoding("UTF-8");
-                response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(e.getErrorCode())));
+                response.getWriter()
+                        .write(objectMapper.writeValueAsString(ApiResponse.fail(e.getErrorCode())));
                 return;
             }
         }

--- a/apps/be/src/main/java/com/breadbread/image/repository/TempImageRepository.java
+++ b/apps/be/src/main/java/com/breadbread/image/repository/TempImageRepository.java
@@ -14,4 +14,6 @@ public interface TempImageRepository extends JpaRepository<TempImage, Long> {
     List<TempImage> findAllByUrlIn(Collection<String> urls);
 
     List<TempImage> findAllByUploadedAtBefore(LocalDateTime threshold);
+
+    List<TempImage> findAllByUserId(Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/image/service/GcsService.java
+++ b/apps/be/src/main/java/com/breadbread/image/service/GcsService.java
@@ -143,20 +143,12 @@ public class GcsService {
         }
     }
 
+    /** 공개 URL을 검증한 뒤 객체 키로만 삭제합니다. (CodeQL 경로/URL taint 완화) */
     public void deleteQuietly(String url) {
         try {
-            delete(url);
+            deleteByObjectKey(extractObjectKey(url));
         } catch (Exception e) {
             log.warn("GCS 파일 삭제 실패 (무시됨): {}", url, e);
-        }
-    }
-
-    /** 공개 URL을 검증한 뒤 객체 키로만 삭제합니다. (CodeQL 경로/URL taint 완화) */
-    public void deleteVerifiedQuietly(String fileUrl) {
-        try {
-            deleteByObjectKey(extractObjectKey(fileUrl));
-        } catch (Exception e) {
-            log.warn("GCS verified delete failed", e);
         }
     }
 

--- a/apps/be/src/main/java/com/breadbread/image/service/TempImageService.java
+++ b/apps/be/src/main/java/com/breadbread/image/service/TempImageService.java
@@ -121,6 +121,23 @@ public class TempImageService {
         log.info("만료 임시 이미지 정리 완료: threshold={}, deletedCount={}", threshold, deletedCount);
     }
 
+    @Transactional
+    public void cleanupByUserId(Long userId) {
+        List<TempImage> images = tempImageRepository.findAllByUserId(userId);
+        if (images.isEmpty()) {
+            return;
+        }
+        for (TempImage image : images) {
+            try {
+                gcsService.deleteByObjectKey(image.getObjectKey());
+            } catch (Exception e) {
+                log.warn("탈퇴 임시 이미지 GCS 삭제 실패 (무시됨): objectKey={}", image.getObjectKey(), e);
+            }
+        }
+        tempImageRepository.deleteAll(images);
+        log.info("탈퇴 임시 이미지 정리 완료: userId={}, count={}", userId, images.size());
+    }
+
     private void validateAllRequestedImagesExist(
             Set<String> requestedUrls, List<TempImage> tempImages) {
         Set<String> foundUrls =

--- a/apps/be/src/main/java/com/breadbread/notification/repository/FcmTokenRepository.java
+++ b/apps/be/src/main/java/com/breadbread/notification/repository/FcmTokenRepository.java
@@ -10,4 +10,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     boolean existsByUserIdAndToken(Long userId, String token);
 
     void deleteByToken(String token);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
+++ b/apps/be/src/main/java/com/breadbread/reservation/repository/ReservationRepository.java
@@ -57,6 +57,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("today") LocalDate today,
             @Param("statuses") Collection<ReservationStatus> statuses);
 
+    boolean existsByUserIdAndStatusInAndActiveTrue(
+            Long userId, Collection<ReservationStatus> statuses);
+
     Optional<Reservation> findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
             Long userId, Long courseId, LocalDate departureDate, ReservationStatus status);
 

--- a/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
@@ -148,6 +148,13 @@ public class UserController {
         return ApiResponse.ok(userService.getLikedPosts(userDetails.getId(), page, size));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "탈퇴 즉시 로그인 불가. 게시글·댓글은 유지되며 작성자 정보는 익명 처리됩니다.")
+    @DeleteMapping("/me")
+    public ApiResponse<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.withdraw(userDetails.getId());
+        return ApiResponse.ok();
+    }
+
     @Operation(summary = "선호도 수정")
     @PatchMapping("/preference")
     public ApiResponse<Void> updatePreference(

--- a/apps/be/src/main/java/com/breadbread/user/entity/User.java
+++ b/apps/be/src/main/java/com/breadbread/user/entity/User.java
@@ -3,6 +3,7 @@ package com.breadbread.user.entity;
 import com.breadbread.global.entity.BaseEntity;
 import com.breadbread.user.dto.UpdateProfileRequest;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,7 +50,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private boolean privacyAgreed;
 
-    private boolean active = true;
+    private LocalDateTime deletedAt;
 
     private String profileImageUrl;
 
@@ -100,5 +101,20 @@ public class User extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public boolean isWithdrawn() {
+        return this.deletedAt != null;
+    }
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+        this.name = "탈퇴한 사용자";
+        this.loginId = null;
+        this.password = null;
+        this.nickname = null;
+        this.email = null;
+        this.phone = null;
+        this.profileImageUrl = null;
     }
 }

--- a/apps/be/src/main/java/com/breadbread/user/repository/UserPreferenceRepository.java
+++ b/apps/be/src/main/java/com/breadbread/user/repository/UserPreferenceRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
     Optional<UserPreference> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/apps/be/src/main/java/com/breadbread/user/service/UserService.java
+++ b/apps/be/src/main/java/com/breadbread/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.breadbread.user.service;
 
 import com.breadbread.auth.entity.VerificationPurpose;
 import com.breadbread.auth.redis.PhoneVerificationCache;
+import com.breadbread.auth.repository.SsoAccountRepository;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
 import com.breadbread.bakery.dto.response.BakeryCourseSummaryResponse;
@@ -37,6 +38,9 @@ import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.global.validator.PaginationValidator;
 import com.breadbread.image.service.GcsService;
 import com.breadbread.image.service.TempImageService;
+import com.breadbread.notification.repository.FcmTokenRepository;
+import com.breadbread.reservation.entity.ReservationStatus;
+import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.user.dto.ChangePasswordRequest;
 import com.breadbread.user.dto.ChangePhoneRequest;
 import com.breadbread.user.dto.CreatePreferenceRequest;
@@ -86,6 +90,9 @@ public class UserService {
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final SsoAccountRepository ssoAccountRepository;
+    private final ReservationRepository reservationRepository;
 
     @Transactional
     public void savePreference(Long userId, CreatePreferenceRequest request) {
@@ -198,7 +205,7 @@ public class UserService {
                     && !Objects.equals(newProfileImageUrl, oldProfileImageUrl)
                     && oldProfileImageUrl != null
                     && !oldProfileImageUrl.isBlank()) {
-                gcsService.deleteVerifiedQuietly(oldProfileImageUrl);
+                gcsService.deleteQuietly(oldProfileImageUrl);
             }
         } catch (DataIntegrityViolationException e) {
             log.warn("[프로필 수정 중복 또는 무결성 위반] userId={}, msg={}", userId, e.getMessage());
@@ -253,6 +260,28 @@ public class UserService {
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
         tokenService.invalidateByUserId(userId);
         log.info("비밀번호 변경: userId={}", userId);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (reservationRepository.existsByUserIdAndStatusInAndActiveTrue(
+                userId, List.of(ReservationStatus.CONFIRMED, ReservationStatus.IN_PROGRESS))) {
+            throw new CustomException(ErrorCode.WITHDRAW_BLOCKED_BY_RESERVATION);
+        }
+        String profileImageUrl = user.getProfileImageUrl();
+        user.withdraw();
+        tempImageService.cleanupByUserId(userId);
+        tokenService.invalidateByUserId(userId);
+        fcmTokenRepository.deleteAllByUserId(userId);
+        ssoAccountRepository.deleteAllByUserId(userId);
+        if (profileImageUrl != null) {
+            gcsService.deleteQuietly(profileImageUrl);
+        }
+        log.info("회원 탈퇴: userId={}", userId);
     }
 
     @Transactional(readOnly = true)

--- a/apps/be/src/main/resources/db/migration/V21__user_soft_delete.sql
+++ b/apps/be/src/main/resources/db/migration/V21__user_soft_delete.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.users
+    ADD COLUMN deleted_at timestamp(6) without time zone;
+
+ALTER TABLE public.users
+    DROP COLUMN active;

--- a/apps/be/src/test/java/com/breadbread/auth/service/CustomUserDetailsServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/auth/service/CustomUserDetailsServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.breadbread.auth.dto.CustomUserDetails;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
@@ -55,15 +57,15 @@ class CustomUserDetailsServiceTest {
     }
 
     @Test
-    void loadUserByUsername_reflects_disabled_when_user_inactive() {
+    void loadUserByUsername_throws_when_user_withdrawn() {
         User user = user(3L);
-        ReflectionTestUtils.setField(user, "active", false);
+        user.withdraw();
         when(userRepository.findById(3L)).thenReturn(Optional.of(user));
 
-        CustomUserDetails details =
-                (CustomUserDetails) customUserDetailsService.loadUserByUsername("3");
-
-        assertThat(details.isEnabled()).isFalse();
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername("3"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.WITHDRAWN_USER);
     }
 
     private static User user(long id) {

--- a/apps/be/src/test/java/com/breadbread/auth/service/SsoServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/auth/service/SsoServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -188,6 +189,39 @@ class SsoServiceTest {
 
         assertThat(result).isSameAs(tokens);
         verify(tokenService).issueTokens(user);
+    }
+
+    @Test
+    void socialLogin_throws_WITHDRAWN_USER_whenUserWithdrawn() {
+        SocialLoginRequest request =
+                socialRequest("code", "https://app/oauth/kakao/callback", null, null);
+        stubWebClientPostReturns(Mono.just(Map.of("access_token", "kakao-at")));
+        Map<String, Object> kakaoAccount = new HashMap<>();
+        kakaoAccount.put("email", "k@example.com");
+        kakaoAccount.put("name", "카카오이름");
+        kakaoAccount.put("profile", Map.of("nickname", "카카오닉"));
+        Map<String, Object> userBody = new HashMap<>();
+        userBody.put("id", 12345L);
+        userBody.put("kakao_account", kakaoAccount);
+        stubWebClientGetReturns(kakaoConfig.getUserInfoUri(), Mono.just(userBody));
+
+        User withdrawnUser = user(10L);
+        withdrawnUser.withdraw();
+        SsoAccount account =
+                SsoAccount.builder()
+                        .provider(SsoProvider.KAKAO)
+                        .providerUserId("12345")
+                        .user(withdrawnUser)
+                        .build();
+        when(ssoAccountService.findOrCreateSsoAccount(eq(SsoProvider.KAKAO), any()))
+                .thenReturn(account);
+
+        assertThatThrownBy(() -> ssoService.socialLogin(SsoProvider.KAKAO, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.WITHDRAWN_USER);
+
+        verify(tokenService, never()).issueTokens(any());
     }
 
     @Test

--- a/apps/be/src/test/java/com/breadbread/course/service/AiCourseSaveServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/AiCourseSaveServiceTest.java
@@ -72,6 +72,9 @@ class AiCourseSaveServiceTest {
     @Test
     void createAi_returns_job_id_when_async_submit_ok() {
         AiCourseRequest request = new AiCourseRequest();
+        when(userRepository.existsById(2L)).thenReturn(true);
+        when(userPreferenceRepository.findByUserId(2L))
+                .thenReturn(Optional.of(preference(user(2L))));
         when(aiCourseAsyncService.processAiCourse(anyString(), eq(2L), eq(request)))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
@@ -85,6 +88,9 @@ class AiCourseSaveServiceTest {
     @Test
     void createAi_throws_whenAsyncSubmitFails() {
         AiCourseRequest request = new AiCourseRequest();
+        when(userRepository.existsById(2L)).thenReturn(true);
+        when(userPreferenceRepository.findByUserId(2L))
+                .thenReturn(Optional.of(preference(user(2L))));
         when(aiCourseAsyncService.processAiCourse(anyString(), eq(2L), eq(request)))
                 .thenThrow(new IllegalStateException("submit"));
 

--- a/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.breadbread.auth.entity.VerificationPurpose;
 import com.breadbread.auth.redis.PhoneVerificationCache;
+import com.breadbread.auth.repository.SsoAccountRepository;
 import com.breadbread.auth.service.PhoneVerificationRedisService;
 import com.breadbread.auth.service.TokenService;
 import com.breadbread.bakery.entity.Bakery;
@@ -42,6 +43,8 @@ import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.image.service.GcsService;
 import com.breadbread.image.service.TempImageService;
+import com.breadbread.notification.repository.FcmTokenRepository;
+import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.user.dto.ChangePasswordRequest;
 import com.breadbread.user.dto.ChangePhoneRequest;
 import com.breadbread.user.dto.CreatePreferenceRequest;
@@ -89,6 +92,9 @@ class UserServiceTest {
     @Mock private PostRepository postRepository;
     @Mock private PostLikeRepository postLikeRepository;
     @Mock private CommentRepository commentRepository;
+    @Mock private FcmTokenRepository fcmTokenRepository;
+    @Mock private SsoAccountRepository ssoAccountRepository;
+    @Mock private ReservationRepository reservationRepository;
 
     @InjectMocks private UserService userService;
 
@@ -253,7 +259,7 @@ class UserServiceTest {
         userService.updateProfile(1L, request);
 
         assertThat(user.getProfileImageUrl()).isNull();
-        verify(gcsService).deleteVerifiedQuietly("https://gcs/old.jpg");
+        verify(gcsService).deleteQuietly("https://gcs/old.jpg");
         verify(tempImageService, never()).consumeOwnedImages(any(), any(), any());
     }
 
@@ -269,7 +275,6 @@ class UserServiceTest {
         userService.updateProfile(1L, request);
 
         assertThat(user.getProfileImageUrl()).isEqualTo("https://gcs/old.jpg");
-        verify(gcsService, never()).deleteVerifiedQuietly(any());
         verify(gcsService, never()).deleteQuietly(any());
         verify(tempImageService, never()).consumeOwnedImages(any(), any(), any());
     }
@@ -486,6 +491,92 @@ class UserServiceTest {
 
         assertThat(user.getPassword()).isEqualTo("encodedNew");
         verify(tokenService).invalidateByUserId(1L);
+    }
+
+    // ───────────────────────────── withdraw ─────────────────────────────
+
+    @Test
+    void withdraw_throws_whenUserNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.withdraw(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    void withdraw_throws_whenActiveReservationExists() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(reservationRepository.existsByUserIdAndStatusInAndActiveTrue(eq(1L), any()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> userService.withdraw(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.WITHDRAW_BLOCKED_BY_RESERVATION);
+
+        verify(tokenService, never()).invalidateByUserId(any());
+    }
+
+    @Test
+    void withdraw_masksAllPiiFields() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(reservationRepository.existsByUserIdAndStatusInAndActiveTrue(eq(1L), any()))
+                .thenReturn(false);
+
+        userService.withdraw(1L);
+
+        assertThat(user.isWithdrawn()).isTrue();
+        assertThat(user.getName()).isEqualTo("탈퇴한 사용자");
+        assertThat(user.getLoginId()).isNull();
+        assertThat(user.getPassword()).isNull();
+        assertThat(user.getNickname()).isNull();
+        assertThat(user.getEmail()).isNull();
+        assertThat(user.getPhone()).isNull();
+        assertThat(user.getProfileImageUrl()).isNull();
+    }
+
+    @Test
+    void withdraw_deletesProfileImageFromGcs_whenExists() {
+        User user = user(1L);
+        ReflectionTestUtils.setField(user, "profileImageUrl", "https://gcs/profiles/img.jpg");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(reservationRepository.existsByUserIdAndStatusInAndActiveTrue(eq(1L), any()))
+                .thenReturn(false);
+
+        userService.withdraw(1L);
+
+        verify(gcsService).deleteQuietly("https://gcs/profiles/img.jpg");
+    }
+
+    @Test
+    void withdraw_doesNotTouchGcs_whenNoProfileImage() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(reservationRepository.existsByUserIdAndStatusInAndActiveTrue(eq(1L), any()))
+                .thenReturn(false);
+
+        userService.withdraw(1L);
+
+        verify(gcsService, never()).deleteQuietly(any());
+    }
+
+    @Test
+    void withdraw_cleansUpAllSideData() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(reservationRepository.existsByUserIdAndStatusInAndActiveTrue(eq(1L), any()))
+                .thenReturn(false);
+
+        userService.withdraw(1L);
+
+        verify(tempImageService).cleanupByUserId(1L);
+        verify(tokenService).invalidateByUserId(1L);
+        verify(fcmTokenRepository).deleteAllByUserId(1L);
+        verify(ssoAccountRepository).deleteAllByUserId(1L);
     }
 
     // ───────────────────────────── savePreference ─────────────────────────────


### PR DESCRIPTION
## Task
- DELETE /users/me 엔드포인트 추가
- 탈퇴 시 PII 마스킹(name/loginId/password/nickname/email/phone/profileImageUrl)
- CONFIRMED/IN_PROGRESS 예약 있으면 탈퇴 거부(409)
- 탈퇴 시 refresh token, FCM token, SSO 계정, 임시 이미지 일괄 정리
- 탈퇴 유저 소셜 재로그인 차단
- 탈퇴 유저 JWT 재사용 차단 (CustomUserDetailsService)
- 게시글/댓글 닉네임 null 시 '탈퇴한 사용자' 표시
- V21 마이그레이션: users.active → deleted_at

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #282 
