### PR TITLE
fix: 선호도 미등록 유저 조회 시 예외 대신 null 반환

### DIFF
--- a/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
+++ b/apps/be/src/main/java/com/breadbread/user/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
         return ApiResponse.ok(userService.getUserProfile(userDetails.getId()));
     }
 
-    @Operation(summary = "닉네임 중복 확인")
+    @Operation(summary = "닉네임 중복 확인", description = "사용 가능하면 true, 중복이면 false를 반환합니다.")
     @GetMapping("/check-nickname")
     public ApiResponse<Boolean> checkNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -74,7 +74,9 @@ public class UserController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "비밀번호 수정")
+    @Operation(
+            summary = "비밀번호 수정",
+            description = "현재 비밀번호를 확인한 뒤 새 비밀번호로 변경합니다. 소셜 전용 계정은 사용할 수 없습니다.")
     @PatchMapping("/me/password")
     public ApiResponse<Void> changePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -83,7 +85,9 @@ public class UserController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "선호도 조사 등록")
+    @Operation(
+            summary = "선호도 조사 등록",
+            description = "빵집 유형, 분위기, 이용 목적, 대기 허용 시간을 등록합니다. 선호도는 1회만 등록 가능합니다.")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/preference")
     public ApiResponse<Void> savePreference(
@@ -96,14 +100,14 @@ public class UserController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "내 선호도 조회")
+    @Operation(summary = "내 선호도 조회", description = "등록된 선호도가 없으면 null을 반환합니다.")
     @GetMapping("/preference")
     public ApiResponse<PreferenceResponse> getPreference(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.ok(userService.getPreference(userDetails.getId()));
     }
 
-    @Operation(summary = "내가 쓴 리뷰 목록 조회")
+    @Operation(summary = "내가 쓴 리뷰 목록 조회", description = "페이지 단위로 조회합니다. page는 0부터 시작합니다.")
     @GetMapping("/me/reviews")
     public ApiResponse<MyReviewListResponse> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -112,7 +116,7 @@ public class UserController {
         return ApiResponse.ok(userService.getMyReviews(userDetails.getId(), page, size));
     }
 
-    @Operation(summary = "좋아요한 빵집 목록 조회")
+    @Operation(summary = "좋아요한 빵집 목록 조회", description = "페이지 단위로 조회합니다. page는 0부터 시작합니다.")
     @GetMapping("/me/liked/bakeries")
     public ApiResponse<BakeryListResponse> getLikedBakeries(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -121,7 +125,7 @@ public class UserController {
         return ApiResponse.ok(userService.getLikedBakeries(userDetails.getId(), page, size));
     }
 
-    @Operation(summary = "좋아요한 코스 목록 조회")
+    @Operation(summary = "좋아요한 코스 목록 조회", description = "페이지 단위로 조회합니다. page는 0부터 시작합니다.")
     @GetMapping("/me/liked/courses")
     public ApiResponse<CourseListResponse> getLikedCourses(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -130,7 +134,7 @@ public class UserController {
         return ApiResponse.ok(userService.getLikedCourses(userDetails.getId(), page, size));
     }
 
-    @Operation(summary = "내가 쓴 게시글 목록 조회")
+    @Operation(summary = "내가 쓴 게시글 목록 조회", description = "페이지 단위로 조회합니다. page는 0부터 시작합니다.")
     @GetMapping("/me/posts")
     public ApiResponse<PostListResponse> getMyPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -139,7 +143,7 @@ public class UserController {
         return ApiResponse.ok(userService.getMyPosts(userDetails.getId(), page, size));
     }
 
-    @Operation(summary = "좋아요한 게시글 목록 조회")
+    @Operation(summary = "좋아요한 게시글 목록 조회", description = "페이지 단위로 조회합니다. page는 0부터 시작합니다.")
     @GetMapping("/me/liked/posts")
     public ApiResponse<PostListResponse> getLikedPosts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -155,7 +159,7 @@ public class UserController {
         return ApiResponse.ok();
     }
 
-    @Operation(summary = "선호도 수정")
+    @Operation(summary = "선호도 수정", description = "기존 선호도를 수정합니다. 선호도가 등록되지 않은 경우 에러가 반환됩니다.")
     @PatchMapping("/preference")
     public ApiResponse<Void> updatePreference(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/apps/be/src/main/java/com/breadbread/user/service/UserService.java
+++ b/apps/be/src/main/java/com/breadbread/user/service/UserService.java
@@ -123,11 +123,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public PreferenceResponse getPreference(Long userId) {
-        UserPreference preference =
-                userPreferenceRepository
-                        .findByUserId(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.PREFERENCE_NOT_FOUND));
-        return PreferenceResponse.from(preference);
+        return userPreferenceRepository
+                .findByUserId(userId)
+                .map(PreferenceResponse::from)
+                .orElse(null);
     }
 
     @Transactional

--- a/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/user/service/UserServiceTest.java
@@ -48,6 +48,7 @@ import com.breadbread.reservation.repository.ReservationRepository;
 import com.breadbread.user.dto.ChangePasswordRequest;
 import com.breadbread.user.dto.ChangePhoneRequest;
 import com.breadbread.user.dto.CreatePreferenceRequest;
+import com.breadbread.user.dto.PreferenceResponse;
 import com.breadbread.user.dto.UpdatePreferenceRequest;
 import com.breadbread.user.dto.UpdateProfileRequest;
 import com.breadbread.user.entity.User;
@@ -626,13 +627,30 @@ class UserServiceTest {
     // ───────────────────────────── getPreference / updatePreference ─────────────────────────────
 
     @Test
-    void getPreference_throws_whenMissing() {
+    void getPreference_returnsNull_whenMissing() {
         when(userPreferenceRepository.findByUserId(3L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> userService.getPreference(3L))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.PREFERENCE_NOT_FOUND);
+        assertThat(userService.getPreference(3L)).isNull();
+    }
+
+    @Test
+    void getPreference_returnsResponse_whenExists() {
+        User user = user(3L);
+        UserPreference pref =
+                UserPreference.builder()
+                        .user(user)
+                        .bakeryTypes(List.of(BakeryType.CLASSIC))
+                        .bakeryPersonalities(List.of(BakeryPersonality.HIDDEN_GEM))
+                        .bakeryUseTypes(List.of(BakeryUseType.TAKEOUT))
+                        .waitingTolerance(WaitingTolerance.UNDER_20)
+                        .build();
+        when(userPreferenceRepository.findByUserId(3L)).thenReturn(Optional.of(pref));
+
+        PreferenceResponse result = userService.getPreference(3L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBakeryTypes()).containsExactly(BakeryType.CLASSIC);
+        assertThat(result.getWaitingTolerance()).isEqualTo(WaitingTolerance.UNDER_20);
     }
 
     @Test


### PR DESCRIPTION
## Task
- 선호도 미등록 유저 조회 시 예외 대신 null 반환

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue

