### PR TITLE
feat: 빵집 승인 시 혼잡도 자동 초기화 및 리뷰 작성자 프로필 이미지 반환

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
@@ -1,5 +1,6 @@
 package com.breadbread.bakery.controller;
 
+import com.breadbread.auth.dto.CustomUserDetails;
 import com.breadbread.bakery.dto.request.ApproveBakeriesRequest;
 import com.breadbread.bakery.dto.response.ApproveBakeriesResponse;
 import com.breadbread.bakery.dto.response.BakeryAdminListResponse;
@@ -21,6 +22,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "관리자 - 빵집")
@@ -121,16 +123,18 @@ public class AdminBakeryController {
                             + "승인 후 일반 사용자에게 노출되며 AI 코스 추천 대상에도 포함됩니다.")
     @PostMapping("/approve")
     public ApiResponse<ApproveBakeriesResponse> approveBakeries(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid ApproveBakeriesRequest request) {
-        return ApiResponse.ok(bakeryService.approveBakeries(request.getIds()));
+        return ApiResponse.ok(bakeryService.approveBakeries(userDetails.getId(), request.getIds()));
     }
 
     @Operation(
             summary = "빵집 전체 일괄 승인 (PENDING → APPROVED)",
             description = "현재 PENDING 상태인 빵집을 모두 승인합니다. " + "필수 항목 미충족 빵집은 스킵되며 응답에 포함됩니다.")
     @PostMapping("/approve-all")
-    public ApiResponse<ApproveBakeriesResponse> approveAllBakeries() {
-        return ApiResponse.ok(bakeryService.approveAllPendingBakeries());
+    public ApiResponse<ApproveBakeriesResponse> approveAllBakeries(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(bakeryService.approveAllPendingBakeries(userDetails.getId()));
     }
 
     @Operation(summary = "빵집 등록 거절 (PENDING → REJECTED)")

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/response/ReviewResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/response/ReviewResponse.java
@@ -16,6 +16,7 @@ public class ReviewResponse {
     private Long authorUserId;
 
     private String authorNickname;
+    private String authorProfileImageUrl;
     private int rating;
     private String content;
     private List<String> imageUrls;
@@ -31,6 +32,8 @@ public class ReviewResponse {
                 .id(review.getId())
                 .authorUserId(review.getUser() != null ? review.getUser().getId() : null)
                 .authorNickname(authorDisplayName(review.getUser()))
+                .authorProfileImageUrl(
+                        review.getUser() != null ? review.getUser().getProfileImageUrl() : null)
                 .rating(review.getRating())
                 .content(review.getContent())
                 .imageUrls(review.getImageUrls())

--- a/apps/be/src/main/java/com/breadbread/bakery/event/BakeriesApprovedEvent.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/event/BakeriesApprovedEvent.java
@@ -1,0 +1,12 @@
+package com.breadbread.bakery.event;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BakeriesApprovedEvent {
+    private final Long adminUserId;
+    private final List<Long> approvedBakeryIds;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/event/BakeryApprovalEventListener.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/event/BakeryApprovalEventListener.java
@@ -1,0 +1,35 @@
+package com.breadbread.bakery.event;
+
+import com.breadbread.congestion.service.CongestionSignalService;
+import com.breadbread.tour.client.CongestionInstantCheckClient;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BakeryApprovalEventListener {
+
+    private final CongestionInstantCheckClient congestionInstantCheckClient;
+    private final CongestionSignalService congestionSignalService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onBakeriesApproved(BakeriesApprovedEvent event) {
+        try {
+            Map<String, Object> body = new HashMap<>();
+            body.put("userId", event.getAdminUserId());
+            body.put("bakeryIds", event.getApprovedBakeryIds());
+            congestionSignalService.saveAllFromInstantCheck(
+                    congestionInstantCheckClient.check(body).getData(),
+                    new HashSet<>(event.getApprovedBakeryIds()));
+        } catch (Exception e) {
+            log.warn("빵집 승인 후 혼잡도 초기화 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -11,6 +11,7 @@ import com.breadbread.bakery.entity.enums.AdminBakerySortType;
 import com.breadbread.bakery.entity.enums.BakerySortType;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.entity.enums.DayType;
+import com.breadbread.bakery.event.BakeriesApprovedEvent;
 import com.breadbread.bakery.repository.*;
 import com.breadbread.bakery.service.BakeryImageService.PreviewBatch;
 import com.breadbread.course.repository.CourseBakeryRepository;
@@ -27,6 +28,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -48,6 +50,7 @@ public class BakeryService {
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
     private final BakeryImageService bakeryImageService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<BakeryAiResponse> findAllForAi(BakeryAiSearch search) {
@@ -433,18 +436,18 @@ public class BakeryService {
     }
 
     @Transactional
-    public ApproveBakeriesResponse approveAllPendingBakeries() {
+    public ApproveBakeriesResponse approveAllPendingBakeries(Long adminUserId) {
         List<Long> ids =
                 bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.PENDING).stream()
                         .map(Bakery::getId)
                         .toList();
-        return approveBakeries(ids);
+        return approveBakeries(adminUserId, ids);
     }
 
     @Transactional
-    public ApproveBakeriesResponse approveBakeries(List<Long> bakeryIds) {
+    public ApproveBakeriesResponse approveBakeries(Long adminUserId, List<Long> bakeryIds) {
         List<ApproveBakeriesResponse.SkippedBakery> skipped = new ArrayList<>();
-        int successCount = 0;
+        List<Long> approvedIds = new ArrayList<>();
         for (Long id : bakeryIds) {
             Bakery bakery =
                     bakeryRepository
@@ -466,11 +469,16 @@ public class BakeryService {
                 continue;
             }
             bakery.approve();
-            successCount++;
+            approvedIds.add(id);
         }
-        log.info("빵집 일괄 승인: 성공={}, 스킵={}", successCount, skipped.size());
+        log.info("빵집 일괄 승인: 성공={}, 스킵={}", approvedIds.size(), skipped.size());
+
+        if (!approvedIds.isEmpty()) {
+            eventPublisher.publishEvent(new BakeriesApprovedEvent(adminUserId, approvedIds));
+        }
+
         return ApproveBakeriesResponse.builder()
-                .successCount(successCount)
+                .successCount(approvedIds.size())
                 .skipCount(skipped.size())
                 .skippedBakeries(skipped)
                 .build();

--- a/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -109,13 +110,48 @@ public class CongestionSignalService {
     @Transactional
     public void saveAllFromInstantCheck(
             List<CongestionInstantCheckResponse.CongestionResult> results) {
+        saveAllFromInstantCheck(results, null);
+    }
+
+    @Transactional
+    public void saveAllFromInstantCheck(
+            List<CongestionInstantCheckResponse.CongestionResult> results,
+            Set<Long> allowedBakeryIds) {
         if (results == null || results.isEmpty()) {
             log.warn("[혼잡도 신호] 저장 가능한 데이터가 없습니다.");
             return;
         }
-        List<BakeryCongestionSignal> entities = results.stream().map(this::toEntity).toList();
+        List<Long> bakeryIds =
+                results.stream()
+                        .map(CongestionInstantCheckResponse.CongestionResult::getBakeryId)
+                        .filter(id -> id != null)
+                        .toList();
+        Set<Long> approvedIds =
+                bakeryRepository
+                        .findAllByIdInAndActiveTrueAndStatus(bakeryIds, BakeryStatus.APPROVED)
+                        .stream()
+                        .map(Bakery::getId)
+                        .collect(Collectors.toSet());
+
+        List<BakeryCongestionSignal> entities =
+                results.stream()
+                        .filter(
+                                r ->
+                                        r.getBakeryId() != null
+                                                && approvedIds.contains(r.getBakeryId()))
+                        .filter(
+                                r ->
+                                        allowedBakeryIds == null
+                                                || allowedBakeryIds.contains(r.getBakeryId()))
+                        .map(this::toEntity)
+                        .toList();
+
+        if (entities.isEmpty()) {
+            log.warn("[혼잡도 신호] 저장 가능한 데이터가 없습니다.");
+            return;
+        }
         repository.saveAll(entities);
-        log.info("[혼잡도 신호] {}건 저장 완료", entities.size());
+        log.info("[혼잡도 신호] {}건 저장 완료 (응답 {}건 중)", entities.size(), results.size());
     }
 
     private BakeryCongestionSignal toEntity(

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
@@ -23,7 +23,9 @@ import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -150,9 +152,13 @@ public class TourService {
         if (request.getTargetBakeryId() != null) {
             body.put("targetBakeryId", request.getTargetBakeryId());
         }
+        Set<Long> allowedIds = new HashSet<>(request.getBakeryIds());
+        if (request.getTargetBakeryId() != null) {
+            allowedIds.add(request.getTargetBakeryId());
+        }
         CongestionInstantCheckResponse response = congestionInstantCheckClient.check(body);
         if (response.getData() != null && !response.getData().isEmpty()) {
-            congestionSignalService.saveAllFromInstantCheck(response.getData());
+            congestionSignalService.saveAllFromInstantCheck(response.getData(), allowedIds);
         }
         return response;
     }

--- a/apps/be/src/test/java/com/breadbread/bakery/event/BakeryApprovalEventListenerTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/event/BakeryApprovalEventListenerTest.java
@@ -1,0 +1,70 @@
+package com.breadbread.bakery.event;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.congestion.service.CongestionSignalService;
+import com.breadbread.tour.client.CongestionInstantCheckClient;
+import com.breadbread.tour.dto.CongestionInstantCheckResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BakeryApprovalEventListenerTest {
+
+    @Mock private CongestionInstantCheckClient congestionInstantCheckClient;
+    @Mock private CongestionSignalService congestionSignalService;
+
+    @InjectMocks private BakeryApprovalEventListener listener;
+
+    @Test
+    void onBakeriesApproved_sends_userId_and_bakeryIds_to_n8n() {
+        CongestionInstantCheckResponse response = new CongestionInstantCheckResponse();
+        ReflectionTestUtils.setField(response, "success", true);
+        ReflectionTestUtils.setField(response, "data", List.of());
+        when(congestionInstantCheckClient.check(any())).thenReturn(response);
+
+        listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L, 2L)));
+
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(congestionInstantCheckClient).check(bodyCaptor.capture());
+        Map<?, ?> body = bodyCaptor.getValue();
+        assert body.get("userId").equals(99L);
+        assert body.get("bakeryIds").equals(List.of(1L, 2L));
+    }
+
+    @Test
+    void onBakeriesApproved_saves_with_allowed_ids() {
+        CongestionInstantCheckResponse.CongestionResult result =
+                new CongestionInstantCheckResponse.CongestionResult();
+        ReflectionTestUtils.setField(result, "bakeryId", 1L);
+
+        CongestionInstantCheckResponse response = new CongestionInstantCheckResponse();
+        ReflectionTestUtils.setField(response, "success", true);
+        ReflectionTestUtils.setField(response, "data", List.of(result));
+        when(congestionInstantCheckClient.check(any())).thenReturn(response);
+
+        listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L, 2L)));
+
+        verify(congestionSignalService).saveAllFromInstantCheck(List.of(result), Set.of(1L, 2L));
+    }
+
+    @Test
+    void onBakeriesApproved_does_not_propagate_exception() {
+        when(congestionInstantCheckClient.check(any())).thenThrow(new RuntimeException("n8n 오류"));
+
+        listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L)));
+
+        verify(congestionSignalService, never()).saveAllFromInstantCheck(any(), any());
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -74,6 +74,7 @@ class BakeryServiceTest {
     @Mock private CourseDrivingRouteRepository courseDrivingRouteRepository;
     @Mock private GooglePlacesUpdateService googlePlacesUpdateService;
     @Mock private BakeryImageService bakeryImageService;
+    @Mock private org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @InjectMocks private BakeryService bakeryService;
 
@@ -678,7 +679,7 @@ class BakeryServiceTest {
         Bakery bakery = pendingBakeryWithId(100L);
         when(bakeryRepository.findByIdAndActiveTrue(100L)).thenReturn(Optional.of(bakery));
 
-        ApproveBakeriesResponse result = bakeryService.approveBakeries(List.of(100L));
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(100L));
 
         assertThat(bakery.getStatus()).isEqualTo(BakeryStatus.APPROVED);
         assertThat(result.getSuccessCount()).isEqualTo(1);
@@ -705,7 +706,7 @@ class BakeryServiceTest {
         ReflectionTestUtils.setField(bakery, "status", BakeryStatus.PENDING);
         when(bakeryRepository.findByIdAndActiveTrue(100L)).thenReturn(Optional.of(bakery));
 
-        ApproveBakeriesResponse result = bakeryService.approveBakeries(List.of(100L));
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(100L));
 
         assertThat(bakery.getStatus()).isEqualTo(BakeryStatus.PENDING);
         assertThat(result.getSuccessCount()).isZero();
@@ -730,7 +731,7 @@ class BakeryServiceTest {
         ReflectionTestUtils.setField(bakery, "status", BakeryStatus.PENDING);
         when(bakeryRepository.findByIdAndActiveTrue(101L)).thenReturn(Optional.of(bakery));
 
-        ApproveBakeriesResponse result = bakeryService.approveBakeries(List.of(101L));
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(101L));
 
         assertThat(result.getSuccessCount()).isZero();
         assertThat(result.getSkipCount()).isEqualTo(1);
@@ -741,7 +742,7 @@ class BakeryServiceTest {
         Bakery bakery = bakeryWithId(100L);
         when(bakeryRepository.findByIdAndActiveTrue(100L)).thenReturn(Optional.of(bakery));
 
-        ApproveBakeriesResponse result = bakeryService.approveBakeries(List.of(100L));
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(100L));
 
         assertThat(result.getSuccessCount()).isZero();
         assertThat(result.getSkipCount()).isEqualTo(1);
@@ -754,7 +755,7 @@ class BakeryServiceTest {
         when(bakeryRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(good));
         when(bakeryRepository.findByIdAndActiveTrue(2L)).thenReturn(Optional.of(bad));
 
-        ApproveBakeriesResponse result = bakeryService.approveBakeries(List.of(1L, 2L));
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(1L, 2L));
 
         assertThat(good.getStatus()).isEqualTo(BakeryStatus.APPROVED);
         assertThat(result.getSuccessCount()).isEqualTo(1);

--- a/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
@@ -136,6 +136,10 @@ class CongestionSignalServiceTest {
 
     @Test
     void saveAllFromInstantCheck_saves_entities_when_data_present() {
+        Bakery bakery = bakery(1L, "파리바게뜨");
+        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
+                        List.of(1L), BakeryStatus.APPROVED))
+                .thenReturn(List.of(bakery));
         CongestionInstantCheckResponse.CongestionResult result =
                 instantCheckResult(1L, "파리바게뜨", "HIGH");
 
@@ -149,6 +153,19 @@ class CongestionSignalServiceTest {
     }
 
     @Test
+    void saveAllFromInstantCheck_skips_unapproved_bakery() {
+        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
+                        List.of(1L), BakeryStatus.APPROVED))
+                .thenReturn(List.of());
+        CongestionInstantCheckResponse.CongestionResult result =
+                instantCheckResult(1L, "파리바게뜨", "HIGH");
+
+        service.saveAllFromInstantCheck(List.of(result));
+
+        verify(repository, never()).saveAll(anyList());
+    }
+
+    @Test
     void saveAllFromInstantCheck_skips_save_when_empty() {
         service.saveAllFromInstantCheck(List.of());
 
@@ -157,6 +174,10 @@ class CongestionSignalServiceTest {
 
     @Test
     void saveAllFromInstantCheck_handles_unknown_level_gracefully() {
+        Bakery bakery = bakery(1L, "파리바게뜨");
+        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
+                        List.of(1L), BakeryStatus.APPROVED))
+                .thenReturn(List.of(bakery));
         CongestionInstantCheckResponse.CongestionResult result =
                 instantCheckResult(1L, "파리바게뜨", "UNKNOWN_LEVEL");
 

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
@@ -33,6 +33,7 @@ import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -411,7 +412,25 @@ class TourServiceTest {
 
         tourService.checkCongestionInstant(1L, request);
 
-        verify(congestionSignalService).saveAllFromInstantCheck(List.of(result));
+        verify(congestionSignalService).saveAllFromInstantCheck(List.of(result), Set.of(1L));
+    }
+
+    @Test
+    void checkCongestionInstant_includes_targetBakeryId_in_allowed_ids() {
+        CongestionInstantCheckRequest request = mock(CongestionInstantCheckRequest.class);
+        CongestionInstantCheckResponse response = mock(CongestionInstantCheckResponse.class);
+        CongestionInstantCheckResponse.CongestionResult result =
+                mock(CongestionInstantCheckResponse.CongestionResult.class);
+        when(request.getCourseId()).thenReturn(10L);
+        when(request.getBakeryIds()).thenReturn(List.of(1L, 2L));
+        when(request.getTargetBakeryId()).thenReturn(3L);
+        when(congestionInstantCheckClient.check(any())).thenReturn(response);
+        when(response.getData()).thenReturn(List.of(result));
+
+        tourService.checkCongestionInstant(1L, request);
+
+        verify(congestionSignalService)
+                .saveAllFromInstantCheck(List.of(result), Set.of(1L, 2L, 3L));
     }
 
     @Test
@@ -426,7 +445,7 @@ class TourServiceTest {
 
         tourService.checkCongestionInstant(1L, request);
 
-        verify(congestionSignalService, never()).saveAllFromInstantCheck(any());
+        verify(congestionSignalService, never()).saveAllFromInstantCheck(any(), any());
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Task
- 빵집 승인 후 AFTER_COMMIT 이벤트로 n8n 혼잡도 즉시 체크 호출 및 DB 저장
- 혼잡도 저장 시 APPROVED 빵집 여부 검증 추가
- 리뷰 조회 응답에 authorProfileImageUrl 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #295 
