### PR TITLE
feat: 리뷰/게시글 태그 시스템 구현

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/dto/request/CreateReviewRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/request/CreateReviewRequest.java
@@ -1,5 +1,7 @@
 package com.breadbread.bakery.dto.request;
 
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import java.util.List;
 import lombok.Getter;
@@ -19,4 +21,10 @@ public class CreateReviewRequest {
 
     @Size(max = 2)
     private List<String> imageUrls;
+
+    @Size(max = 2)
+    private List<@NotNull BakeryTagType> bakeryTags;
+
+    @Size(max = 5)
+    private List<@NotNull @Valid MenuTagRequest> menuTags;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/request/MenuTagRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/request/MenuTagRequest.java
@@ -1,0 +1,19 @@
+package com.breadbread.bakery.dto.request;
+
+import com.breadbread.bakery.entity.enums.BreadTagType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuTagRequest {
+
+    @NotNull private Long breadId;
+
+    @NotNull
+    @Size(max = 2)
+    private List<@NotNull BreadTagType> tags;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/request/UpdateReviewRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/request/UpdateReviewRequest.java
@@ -1,8 +1,11 @@
 package com.breadbread.bakery.dto.request;
 
+import com.breadbread.bakery.entity.enums.BakeryTagType;
 import com.breadbread.global.validation.NotBlankIfPresent;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
@@ -22,4 +25,10 @@ public class UpdateReviewRequest {
 
     @Size(max = 2)
     private List<String> imageUrls;
+
+    @Size(max = 2)
+    private List<@NotNull BakeryTagType> bakeryTags;
+
+    @Size(max = 5)
+    private List<@NotNull @Valid MenuTagRequest> menuTags;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/response/MenuTagResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/response/MenuTagResponse.java
@@ -1,0 +1,14 @@
+package com.breadbread.bakery.dto.response;
+
+import com.breadbread.bakery.entity.enums.BreadTagType;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MenuTagResponse {
+    private Long breadId;
+    private String breadName;
+    private List<BreadTagType> tags;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/response/ReviewResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/response/ReviewResponse.java
@@ -1,6 +1,7 @@
 package com.breadbread.bakery.dto.response;
 
 import com.breadbread.bakery.entity.Review;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
 import com.breadbread.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,8 +23,22 @@ public class ReviewResponse {
     private List<String> imageUrls;
     private LocalDateTime createdAt;
     private boolean isAuthor;
+    private List<BakeryTagType> bakeryTags;
+    private List<MenuTagResponse> menuTags;
 
-    public static ReviewResponse from(Review review, Long currentUserId) {
+    public record TagBundle(List<BakeryTagType> bakeryTags, List<MenuTagResponse> menuTags) {}
+
+    public static ReviewResponse from(Review review, Long currentUserId, TagBundle tags) {
+        List<BakeryTagType> bakeryTags = tags != null ? tags.bakeryTags() : List.of();
+        List<MenuTagResponse> menuTags = tags != null ? tags.menuTags() : List.of();
+        return from(review, currentUserId, bakeryTags, menuTags);
+    }
+
+    private static ReviewResponse from(
+            Review review,
+            Long currentUserId,
+            List<BakeryTagType> bakeryTags,
+            List<MenuTagResponse> menuTags) {
         boolean isAuthor =
                 currentUserId != null
                         && review.getUser() != null
@@ -39,6 +54,8 @@ public class ReviewResponse {
                 .imageUrls(review.getImageUrls())
                 .createdAt(review.getCreatedAt())
                 .isAuthor(isAuthor)
+                .bakeryTags(bakeryTags)
+                .menuTags(menuTags)
                 .build();
     }
 

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryTag.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryTag.java
@@ -1,0 +1,42 @@
+package com.breadbread.bakery.entity;
+
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import com.breadbread.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "bakery_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BakeryTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bakery_id", nullable = false)
+    private Bakery bakery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BakeryTagType tag;
+
+    @Column(nullable = false)
+    private String sourceType; // POST or REVIEW
+
+    @Column(nullable = false)
+    private Long sourceId;
+
+    @Builder
+    public BakeryTag(Bakery bakery, BakeryTagType tag, String sourceType, Long sourceId) {
+        this.bakery = bakery;
+        this.tag = tag;
+        this.sourceType = sourceType;
+        this.sourceId = sourceId;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BreadTag.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BreadTag.java
@@ -1,0 +1,39 @@
+package com.breadbread.bakery.entity;
+
+import com.breadbread.bakery.entity.enums.BreadTagType;
+import com.breadbread.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "bread_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BreadTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bread_id", nullable = false)
+    private Bread bread;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BreadTagType tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @Builder
+    public BreadTag(Bread bread, BreadTagType tag, Review review) {
+        this.bread = bread;
+        this.tag = tag;
+        this.review = review;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BakeryTagType.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BakeryTagType.java
@@ -1,0 +1,14 @@
+package com.breadbread.bakery.entity.enums;
+
+public enum BakeryTagType {
+    COZY,
+    QUIET,
+    LIVELY,
+    EMOTIONAL,
+    LOCAL_VIBE,
+    SWEET,
+    SAVORY,
+    CRISPY,
+    SOFT,
+    NUTTY
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BreadTagType.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BreadTagType.java
@@ -1,0 +1,12 @@
+package com.breadbread.bakery.entity.enums;
+
+public enum BreadTagType {
+    SWEET,
+    SAVORY,
+    CRISPY,
+    SOFT,
+    NUTTY,
+    SPICY,
+    CHEWY,
+    RICH
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryTagRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BakeryTagRepository.java
@@ -1,0 +1,26 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.entity.BakeryTag;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BakeryTagRepository extends JpaRepository<BakeryTag, Long> {
+
+    @Query(
+            "SELECT bt.tag FROM BakeryTag bt "
+                    + "WHERE bt.bakery.id = :bakeryId "
+                    + "AND ("
+                    + "  (bt.sourceType = 'REVIEW' AND EXISTS (SELECT 1 FROM Review r WHERE r.id = bt.sourceId AND r.active = true)) "
+                    + "  OR (bt.sourceType = 'POST' AND EXISTS (SELECT 1 FROM Post p WHERE p.id = bt.sourceId AND p.active = true))"
+                    + ") "
+                    + "GROUP BY bt.tag HAVING COUNT(bt.tag) >= :minCount")
+    List<BakeryTagType> findPopularTagsByBakeryId(
+            @Param("bakeryId") Long bakeryId, @Param("minCount") long minCount);
+
+    List<BakeryTag> findAllBySourceTypeAndSourceId(String sourceType, Long sourceId);
+
+    List<BakeryTag> findAllBySourceTypeAndSourceIdIn(String sourceType, List<Long> sourceIds);
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/repository/BreadTagRepository.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/repository/BreadTagRepository.java
@@ -1,0 +1,22 @@
+package com.breadbread.bakery.repository;
+
+import com.breadbread.bakery.entity.BreadTag;
+import com.breadbread.bakery.entity.enums.BreadTagType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BreadTagRepository extends JpaRepository<BreadTag, Long> {
+
+    @Query(
+            "SELECT bt.tag FROM BreadTag bt "
+                    + "WHERE bt.bread.id = :breadId AND bt.review.active = true "
+                    + "GROUP BY bt.tag HAVING COUNT(bt.tag) >= :minCount")
+    List<BreadTagType> findPopularTagsByBreadId(
+            @Param("breadId") Long breadId, @Param("minCount") long minCount);
+
+    List<BreadTag> findAllByReviewId(Long reviewId);
+
+    List<BreadTag> findAllByReviewIdIn(List<Long> reviewIds);
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/service/ReviewService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/ReviewService.java
@@ -1,14 +1,24 @@
 package com.breadbread.bakery.service;
 
 import com.breadbread.bakery.dto.request.CreateReviewRequest;
+import com.breadbread.bakery.dto.request.MenuTagRequest;
 import com.breadbread.bakery.dto.request.UpdateReviewRequest;
+import com.breadbread.bakery.dto.response.MenuTagResponse;
 import com.breadbread.bakery.dto.response.ReviewListResponse;
 import com.breadbread.bakery.dto.response.ReviewResponse;
 import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryTag;
+import com.breadbread.bakery.entity.Bread;
+import com.breadbread.bakery.entity.BreadTag;
 import com.breadbread.bakery.entity.Review;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import com.breadbread.bakery.entity.enums.BreadTagType;
 import com.breadbread.bakery.entity.enums.ReviewSortType;
 import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BakeryTagRepository;
+import com.breadbread.bakery.repository.BreadRepository;
+import com.breadbread.bakery.repository.BreadTagRepository;
 import com.breadbread.bakery.repository.ReviewRepository;
 import com.breadbread.global.dto.UploadFolder;
 import com.breadbread.global.exception.CustomException;
@@ -18,7 +28,10 @@ import com.breadbread.image.service.TempImageService;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -33,8 +46,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final BakeryRepository bakeryRepository;
+    private final BreadRepository breadRepository;
     private final UserRepository userRepository;
     private final ReviewRepository reviewRepository;
+    private final BakeryTagRepository bakeryTagRepository;
+    private final BreadTagRepository breadTagRepository;
     private final GcsService gcsService;
     private final TempImageService tempImageService;
 
@@ -58,9 +74,59 @@ public class ReviewService {
                         .user(user)
                         .build();
         reviewRepository.save(review);
+
+        if (request.getBakeryTags() != null) {
+            bakeryTagRepository.saveAll(
+                    request.getBakeryTags().stream()
+                            .distinct()
+                            .map(
+                                    tag ->
+                                            BakeryTag.builder()
+                                                    .bakery(bakery)
+                                                    .tag(tag)
+                                                    .sourceType("REVIEW")
+                                                    .sourceId(review.getId())
+                                                    .build())
+                            .toList());
+        }
+
+        if (request.getMenuTags() != null) {
+            // 같은 breadId가 여러 번 올 경우 tags를 합쳐서 처리
+            Map<Long, List<BreadTagType>> tagsByBreadId =
+                    request.getMenuTags().stream()
+                            .collect(
+                                    Collectors.groupingBy(
+                                            MenuTagRequest::getBreadId,
+                                            Collectors.flatMapping(
+                                                    m -> m.getTags().stream(),
+                                                    Collectors.toList())));
+
+            List<BreadTag> breadTagsToSave = new ArrayList<>();
+            for (var entry : tagsByBreadId.entrySet()) {
+                List<BreadTagType> dedupedTags = entry.getValue().stream().distinct().toList();
+                if (dedupedTags.size() > 2) {
+                    throw new CustomException(ErrorCode.MENU_TAG_LIMIT_EXCEEDED);
+                }
+                Bread bread =
+                        breadRepository
+                                .findByIdAndBakeryId(entry.getKey(), bakeryId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+                dedupedTags.stream()
+                        .map(tag -> BreadTag.builder().bread(bread).tag(tag).review(review).build())
+                        .forEach(breadTagsToSave::add);
+            }
+            breadTagRepository.saveAll(breadTagsToSave);
+        }
+
         tempImageService.consumeOwnedImages(userId, request.getImageUrls(), UploadFolder.reviews);
         bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
-        log.info("리뷰 작성: reviewId={}, bakeryId={}, userId={}", review.getId(), bakeryId, userId);
+        log.info(
+                "리뷰 작성: reviewId={}, bakeryId={}, userId={}, bakeryTags={}, menuTagCount={}",
+                review.getId(),
+                bakeryId,
+                userId,
+                request.getBakeryTags(),
+                request.getMenuTags() != null ? request.getMenuTags().size() : 0);
         return review.getId();
     }
 
@@ -79,10 +145,44 @@ public class ReviewService {
         Page<Review> result =
                 reviewRepository.findAllByBakeryIdAndActiveTrue(
                         bakeryId, PageRequest.of(page, size, sorting));
+
+        List<Long> reviewIds = result.getContent().stream().map(Review::getId).toList();
+        Map<Long, List<BakeryTagType>> bakeryTagsByReviewId =
+                bakeryTagRepository.findAllBySourceTypeAndSourceIdIn("REVIEW", reviewIds).stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        BakeryTag::getSourceId,
+                                        Collectors.mapping(
+                                                BakeryTag::getTag, Collectors.toList())));
+
+        List<BreadTag> allBreadTags = breadTagRepository.findAllByReviewIdIn(reviewIds);
+        List<Long> breadIds =
+                allBreadTags.stream().map(bt -> bt.getBread().getId()).distinct().toList();
+        Map<Long, String> breadNameById =
+                breadRepository.findAllById(breadIds).stream()
+                        .collect(Collectors.toMap(b -> b.getId(), b -> b.getName()));
+        Map<Long, List<BreadTag>> breadTagsByReviewId =
+                allBreadTags.stream().collect(Collectors.groupingBy(bt -> bt.getReview().getId()));
+
         return ReviewListResponse.builder()
                 .reviews(
                         result.getContent().stream()
-                                .map(r -> ReviewResponse.from(r, userId))
+                                .map(
+                                        r -> {
+                                            List<BakeryTagType> bakeryTags =
+                                                    bakeryTagsByReviewId.getOrDefault(
+                                                            r.getId(), List.of());
+                                            List<MenuTagResponse> menuTags =
+                                                    toMenuTagResponses(
+                                                            breadTagsByReviewId.getOrDefault(
+                                                                    r.getId(), List.of()),
+                                                            breadNameById);
+                                            return ReviewResponse.from(
+                                                    r,
+                                                    userId,
+                                                    new ReviewResponse.TagBundle(
+                                                            bakeryTags, menuTags));
+                                        })
                                 .toList())
                 .total((int) result.getTotalElements())
                 .page(page)
@@ -123,8 +223,21 @@ public class ReviewService {
                     .forEach(gcsService::deleteQuietly);
         }
 
+        if (request.getBakeryTags() != null) {
+            syncBakeryTags(bakery, reviewId, request.getBakeryTags());
+        }
+        if (request.getMenuTags() != null) {
+            syncMenuTags(bakeryId, reviewId, review, request.getMenuTags());
+        }
+
         bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
-        log.info("리뷰 수정: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
+        log.info(
+                "리뷰 수정: reviewId={}, bakeryId={}, userId={}, bakeryTags={}, menuTagCount={}",
+                reviewId,
+                bakeryId,
+                userId,
+                request.getBakeryTags(),
+                request.getMenuTags() != null ? request.getMenuTags().size() : 0);
     }
 
     @Transactional
@@ -144,8 +257,114 @@ public class ReviewService {
         }
 
         review.getImageUrls().forEach(gcsService::deleteQuietly);
+        bakeryTagRepository.deleteAll(
+                bakeryTagRepository.findAllBySourceTypeAndSourceId("REVIEW", reviewId));
+        breadTagRepository.deleteAll(breadTagRepository.findAllByReviewId(reviewId));
         review.deactivate();
         bakery.updateRating(reviewRepository.findAverageRatingByBakeryId(bakeryId).orElse(null));
         log.info("리뷰 삭제: reviewId={}, bakeryId={}, userId={}", reviewId, bakeryId, userId);
+    }
+
+    private void syncBakeryTags(Bakery bakery, Long reviewId, List<BakeryTagType> requested) {
+        List<BakeryTag> existing =
+                bakeryTagRepository.findAllBySourceTypeAndSourceId("REVIEW", reviewId);
+        List<BakeryTagType> existingTypes = existing.stream().map(BakeryTag::getTag).toList();
+
+        List<BakeryTagType> toAdd =
+                requested.stream().distinct().filter(t -> !existingTypes.contains(t)).toList();
+        List<BakeryTag> toRemove =
+                existing.stream().filter(t -> !requested.contains(t.getTag())).toList();
+
+        bakeryTagRepository.deleteAll(toRemove);
+        bakeryTagRepository.saveAll(
+                toAdd.stream()
+                        .map(
+                                tag ->
+                                        BakeryTag.builder()
+                                                .bakery(bakery)
+                                                .tag(tag)
+                                                .sourceType("REVIEW")
+                                                .sourceId(reviewId)
+                                                .build())
+                        .toList());
+    }
+
+    private void syncMenuTags(
+            Long bakeryId, Long reviewId, Review review, List<MenuTagRequest> requested) {
+        List<BreadTag> existing = breadTagRepository.findAllByReviewId(reviewId);
+
+        Map<Long, List<BreadTag>> existingByBreadId =
+                existing.stream().collect(Collectors.groupingBy(bt -> bt.getBread().getId()));
+        Map<Long, List<BreadTagType>> requestedByBreadId =
+                requested.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        MenuTagRequest::getBreadId,
+                                        Collectors.flatMapping(
+                                                m -> m.getTags().stream(), Collectors.toList())))
+                        .entrySet()
+                        .stream()
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        e -> {
+                                            List<BreadTagType> deduped =
+                                                    e.getValue().stream().distinct().toList();
+                                            if (deduped.size() > 2) {
+                                                throw new CustomException(
+                                                        ErrorCode.MENU_TAG_LIMIT_EXCEEDED);
+                                            }
+                                            return deduped;
+                                        }));
+
+        // 요청에 없는 빵의 태그 전체 삭제
+        existingByBreadId.forEach(
+                (breadId, tags) -> {
+                    if (!requestedByBreadId.containsKey(breadId)) {
+                        breadTagRepository.deleteAll(tags);
+                    }
+                });
+
+        // 요청된 빵별로 diff 처리
+        List<BreadTag> breadTagsToSave = new ArrayList<>();
+        for (var entry : requestedByBreadId.entrySet()) {
+            Long breadId = entry.getKey();
+            List<BreadTagType> requestedTags = entry.getValue();
+            Bread bread =
+                    breadRepository
+                            .findByIdAndBakeryId(breadId, bakeryId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+            List<BreadTag> existingTags = existingByBreadId.getOrDefault(breadId, List.of());
+            List<BreadTagType> existingTypes = existingTags.stream().map(BreadTag::getTag).toList();
+
+            List<BreadTag> toRemove =
+                    existingTags.stream().filter(t -> !requestedTags.contains(t.getTag())).toList();
+            breadTagRepository.deleteAll(toRemove);
+
+            requestedTags.stream()
+                    .filter(t -> !existingTypes.contains(t))
+                    .map(tag -> BreadTag.builder().bread(bread).tag(tag).review(review).build())
+                    .forEach(breadTagsToSave::add);
+        }
+        breadTagRepository.saveAll(breadTagsToSave);
+    }
+
+    private List<MenuTagResponse> toMenuTagResponses(
+            List<BreadTag> breadTags, Map<Long, String> breadNameById) {
+        Map<Long, List<BreadTagType>> tagsByBreadId =
+                breadTags.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        bt -> bt.getBread().getId(),
+                                        Collectors.mapping(BreadTag::getTag, Collectors.toList())));
+        return tagsByBreadId.entrySet().stream()
+                .map(
+                        e ->
+                                MenuTagResponse.builder()
+                                        .breadId(e.getKey())
+                                        .breadName(breadNameById.get(e.getKey()))
+                                        .tags(e.getValue())
+                                        .build())
+                .toList();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/community/dto/CreatePostRequest.java
+++ b/apps/be/src/main/java/com/breadbread/community/dto/CreatePostRequest.java
@@ -1,5 +1,6 @@
 package com.breadbread.community.dto;
 
+import com.breadbread.bakery.entity.enums.BakeryTagType;
 import com.breadbread.community.entity.PostType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -31,4 +32,11 @@ public class CreatePostRequest {
     @Schema(description = "이미지 URL 목록 (최대 5개)")
     @Size(max = 5)
     private List<String> imageUrls;
+
+    @Schema(description = "연결할 빵집 ID (자유게시판 전용, optional)")
+    private Long bakeryId;
+
+    @Schema(description = "빵집 선택형 태그 최대 2개 (bakeryId 있을 때만 유효)")
+    @Size(max = 2)
+    private List<@NotNull BakeryTagType> bakeryTags;
 }

--- a/apps/be/src/main/java/com/breadbread/community/dto/PostDetailResponse.java
+++ b/apps/be/src/main/java/com/breadbread/community/dto/PostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.breadbread.community.dto;
 
+import com.breadbread.bakery.entity.enums.BakeryTagType;
 import com.breadbread.community.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -46,12 +47,22 @@ public class PostDetailResponse {
     @Schema(description = "댓글 목록")
     private CommentListResponse commentListResponse;
 
+    @Schema(description = "연결된 빵집 ID")
+    private Long bakeryId;
+
+    @Schema(description = "연결된 빵집 이름")
+    private String bakeryName;
+
+    @Schema(description = "빵집 선택형 태그 목록")
+    private List<BakeryTagType> bakeryTags;
+
     public static PostDetailResponse from(
             Post post,
             Long userId,
             boolean liked,
             int likeCount,
-            CommentListResponse commentListResponse) {
+            CommentListResponse commentListResponse,
+            List<BakeryTagType> bakeryTags) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -67,6 +78,9 @@ public class PostDetailResponse {
                 .isAuthor(userId != null && userId.equals(post.getUser().getId()))
                 .likeCount(likeCount)
                 .commentListResponse(commentListResponse)
+                .bakeryId(post.getBakery() != null ? post.getBakery().getId() : null)
+                .bakeryName(post.getBakery() != null ? post.getBakery().getName() : null)
+                .bakeryTags(bakeryTags)
                 .build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/community/dto/UpdatePostRequest.java
+++ b/apps/be/src/main/java/com/breadbread/community/dto/UpdatePostRequest.java
@@ -1,7 +1,9 @@
 package com.breadbread.community.dto;
 
+import com.breadbread.bakery.entity.enums.BakeryTagType;
 import com.breadbread.global.validation.NotBlankIfPresent;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
@@ -25,4 +27,8 @@ public class UpdatePostRequest {
     @Schema(description = "수정할 이미지 URL 목록 (최대 5개, null 전송 시 변경 없음)")
     @Size(max = 5)
     private List<String> imageUrls;
+
+    @Schema(description = "빵집 선택형 태그 (null 전송 시 변경 없음, 빈 배열 전송 시 전체 삭제, 최대 2개)")
+    @Size(max = 2)
+    private List<@NotNull BakeryTagType> bakeryTags;
 }

--- a/apps/be/src/main/java/com/breadbread/community/entity/Post.java
+++ b/apps/be/src/main/java/com/breadbread/community/entity/Post.java
@@ -1,5 +1,6 @@
 package com.breadbread.community.entity;
 
+import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.global.entity.BaseEntity;
 import com.breadbread.user.entity.User;
 import jakarta.persistence.*;
@@ -32,6 +33,10 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bakery_id")
+    private Bakery bakery;
+
     @ElementCollection
     @CollectionTable(name = "post_image_urls", joinColumns = @JoinColumn(name = "post_id"))
     @Column(name = "image_url", nullable = false)
@@ -56,12 +61,18 @@ public class Post extends BaseEntity {
 
     @Builder
     public Post(
-            String title, String content, PostType postType, List<String> imageUrls, User user) {
+            String title,
+            String content,
+            PostType postType,
+            List<String> imageUrls,
+            User user,
+            Bakery bakery) {
         this.title = title;
         this.content = content;
         this.postType = postType;
         this.imageUrls = imageUrls != null ? new ArrayList<>(imageUrls) : new ArrayList<>();
         this.user = user;
+        this.bakery = bakery;
     }
 
     public void update(String title, String content, List<String> imageUrls) {

--- a/apps/be/src/main/java/com/breadbread/community/service/CommunityService.java
+++ b/apps/be/src/main/java/com/breadbread/community/service/CommunityService.java
@@ -1,5 +1,11 @@
 package com.breadbread.community.service;
 
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryTag;
+import com.breadbread.bakery.entity.enums.BakeryStatus;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BakeryTagRepository;
 import com.breadbread.community.dto.CommentListResponse;
 import com.breadbread.community.dto.CommentResponse;
 import com.breadbread.community.dto.CreateCommentRequest;
@@ -47,6 +53,8 @@ public class CommunityService {
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
     private final UserRepository userRepository;
+    private final BakeryRepository bakeryRepository;
+    private final BakeryTagRepository bakeryTagRepository;
     private final GcsService gcsService;
     private final TempImageService tempImageService;
 
@@ -97,6 +105,28 @@ public class CommunityService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (request.getBakeryId() == null
+                && request.getBakeryTags() != null
+                && !request.getBakeryTags().isEmpty()) {
+            throw new CustomException(ErrorCode.TAG_REQUIRES_BAKERY);
+        }
+
+        Bakery bakery =
+                request.getBakeryId() == null
+                        ? null
+                        : bakeryRepository
+                                .findByIdAndActiveTrueAndStatus(
+                                        request.getBakeryId(), BakeryStatus.APPROVED)
+                                .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        if (bakery != null
+                && request.getPostType() != PostType.FREE
+                && request.getBakeryTags() != null
+                && !request.getBakeryTags().isEmpty()) {
+            throw new CustomException(ErrorCode.BAKERY_TAG_NOT_ALLOWED_POST_TYPE);
+        }
+
         Post post =
                 postRepository.save(
                         Post.builder()
@@ -105,14 +135,33 @@ public class CommunityService {
                                 .postType(request.getPostType())
                                 .imageUrls(request.getImageUrls())
                                 .user(user)
+                                .bakery(bakery)
                                 .build());
+
+        if (bakery != null && request.getBakeryTags() != null) {
+            bakeryTagRepository.saveAll(
+                    request.getBakeryTags().stream()
+                            .distinct()
+                            .map(
+                                    tag ->
+                                            BakeryTag.builder()
+                                                    .bakery(bakery)
+                                                    .tag(tag)
+                                                    .sourceType("POST")
+                                                    .sourceId(post.getId())
+                                                    .build())
+                            .toList());
+        }
+
         tempImageService.consumeOwnedImages(userId, request.getImageUrls(), UploadFolder.posts);
 
         log.info(
-                "게시글 작성: postId={}, userId={}, postType={}",
+                "게시글 작성: postId={}, userId={}, postType={}, bakeryId={}, bakeryTags={}",
                 post.getId(),
                 userId,
-                post.getPostType());
+                post.getPostType(),
+                request.getBakeryId(),
+                request.getBakeryTags());
         return post.getId();
     }
 
@@ -130,7 +179,11 @@ public class CommunityService {
                 CommentListResponse.from(
                         commentRepository.findAllByPostIdWithUserOrderByCreatedAtAsc(post.getId()),
                         userId);
-        return PostDetailResponse.from(post, userId, liked, likeCount, comments);
+        List<BakeryTagType> bakeryTags =
+                bakeryTagRepository.findAllBySourceTypeAndSourceId("POST", post.getId()).stream()
+                        .map(BakeryTag::getTag)
+                        .toList();
+        return PostDetailResponse.from(post, userId, liked, likeCount, comments, bakeryTags);
     }
 
     @Transactional
@@ -155,7 +208,18 @@ public class CommunityService {
                     .forEach(gcsService::deleteQuietly);
         }
 
-        log.info("게시글 수정: postId={}, userId={}", postId, userId);
+        if (request.getBakeryTags() != null) {
+            if (post.getBakery() == null && !request.getBakeryTags().isEmpty()) {
+                throw new CustomException(ErrorCode.TAG_REQUIRES_BAKERY);
+            }
+            syncBakeryTags("POST", postId, request.getBakeryTags(), post.getBakery());
+        }
+
+        log.info(
+                "게시글 수정: postId={}, userId={}, bakeryTags={}",
+                postId,
+                userId,
+                request.getBakeryTags());
     }
 
     @Transactional
@@ -167,6 +231,8 @@ public class CommunityService {
         validatePostAuthority(post, userId, role);
         post.getImageUrls().forEach(gcsService::deleteQuietly);
         commentRepository.deactivateAllByPostId(postId);
+        bakeryTagRepository.deleteAll(
+                bakeryTagRepository.findAllBySourceTypeAndSourceId("POST", postId));
         post.deactivate();
 
         log.info("게시글 삭제: postId={}, userId={}", postId, userId);
@@ -279,6 +345,33 @@ public class CommunityService {
         }
         if (!post.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.POST_AUTHOR_ONLY);
+        }
+    }
+
+    private void syncBakeryTags(
+            String sourceType, Long sourceId, List<BakeryTagType> requested, Bakery bakery) {
+        List<BakeryTag> existing =
+                bakeryTagRepository.findAllBySourceTypeAndSourceId(sourceType, sourceId);
+        List<BakeryTagType> existingTypes = existing.stream().map(BakeryTag::getTag).toList();
+
+        List<BakeryTagType> toAdd =
+                requested.stream().distinct().filter(t -> !existingTypes.contains(t)).toList();
+        List<BakeryTag> toRemove =
+                existing.stream().filter(t -> !requested.contains(t.getTag())).toList();
+
+        bakeryTagRepository.deleteAll(toRemove);
+        if (bakery != null) {
+            bakeryTagRepository.saveAll(
+                    toAdd.stream()
+                            .map(
+                                    tag ->
+                                            BakeryTag.builder()
+                                                    .bakery(bakery)
+                                                    .tag(tag)
+                                                    .sourceType(sourceType)
+                                                    .sourceId(sourceId)
+                                                    .build())
+                            .toList());
         }
     }
 }

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST,
             "E0310",
             "빵집 승인에 필요한 필드가 입력되지 않았습니다. (name, address, latitude, longitude, region, dong, bakeryType)"),
+    MENU_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "E0311", "메뉴당 태그는 최대 2개까지 등록할 수 있습니다."),
 
     // 코스/AI추천 E04xx
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E0401", "존재하지 않는 코스입니다."),
@@ -128,6 +129,9 @@ public enum ErrorCode {
     NOT_POST_LIKED(HttpStatus.BAD_REQUEST, "E0804", "좋아요하지 않은 게시글입니다."),
     POST_AUTHOR_ONLY(HttpStatus.FORBIDDEN, "E0805", "게시글 작성자만 수행할 수 있습니다."),
     COMMENT_AUTHOR_ONLY(HttpStatus.FORBIDDEN, "E0806", "댓글 작성자만 수행할 수 있습니다."),
+    TAG_REQUIRES_BAKERY(HttpStatus.BAD_REQUEST, "E0807", "태그를 추가하려면 빵집을 먼저 선택해야 합니다."),
+    BAKERY_TAG_NOT_ALLOWED_POST_TYPE(
+            HttpStatus.BAD_REQUEST, "E0808", "빵집 태그는 자유게시판 글에만 추가할 수 있습니다."),
 
     // 투어 E09xx
     TOUR_NOT_FOUND(HttpStatus.NOT_FOUND, "E0901", "진행 중인 투어가 없습니다."),

--- a/apps/be/src/main/resources/db/migration/V23__add_tag_tables.sql
+++ b/apps/be/src/main/resources/db/migration/V23__add_tag_tables.sql
@@ -1,0 +1,29 @@
+-- bakery_tag: 리뷰/게시글에서 빵집에 붙인 선택형 태그
+CREATE TABLE bakery_tag (
+    id              BIGSERIAL PRIMARY KEY,
+    bakery_id       BIGINT       NOT NULL REFERENCES bakery (id),
+    tag             VARCHAR(50)  NOT NULL,
+    source_type     VARCHAR(10)  NOT NULL CHECK (source_type IN ('POST', 'REVIEW')),
+    source_id       BIGINT       NOT NULL,
+    created_at      TIMESTAMP    NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMP    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_bakery_tag_bakery_id ON bakery_tag (bakery_id);
+CREATE INDEX idx_bakery_tag_source ON bakery_tag (source_type, source_id);
+
+-- bread_tag: 리뷰에서 메뉴에 붙인 선택형 태그
+CREATE TABLE bread_tag (
+    id          BIGSERIAL PRIMARY KEY,
+    bread_id    BIGINT      NOT NULL REFERENCES bread (id),
+    review_id   BIGINT      NOT NULL REFERENCES review (id),
+    tag         VARCHAR(50) NOT NULL,
+    created_at  TIMESTAMP   NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMP   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_bread_tag_bread_id ON bread_tag (bread_id);
+CREATE INDEX idx_bread_tag_review_id ON bread_tag (review_id);
+
+-- post에 bakery 연결 (게시판 글 작성 시 빵집 선택, optional)
+ALTER TABLE post ADD COLUMN bakery_id BIGINT REFERENCES bakery (id);

--- a/apps/be/src/test/java/com/breadbread/bakery/service/ReviewServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/ReviewServiceTest.java
@@ -3,18 +3,29 @@ package com.breadbread.bakery.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.breadbread.bakery.dto.request.CreateReviewRequest;
+import com.breadbread.bakery.dto.request.MenuTagRequest;
 import com.breadbread.bakery.dto.request.UpdateReviewRequest;
 import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BakeryTag;
+import com.breadbread.bakery.entity.Bread;
+import com.breadbread.bakery.entity.BreadTag;
 import com.breadbread.bakery.entity.Review;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import com.breadbread.bakery.entity.enums.BreadTagType;
 import com.breadbread.bakery.entity.enums.ReviewSortType;
 import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BakeryTagRepository;
+import com.breadbread.bakery.repository.BreadRepository;
+import com.breadbread.bakery.repository.BreadTagRepository;
 import com.breadbread.bakery.repository.ReviewRepository;
 import com.breadbread.global.dto.UploadFolder;
 import com.breadbread.global.exception.CustomException;
@@ -42,8 +53,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 class ReviewServiceTest {
 
     @Mock private BakeryRepository bakeryRepository;
+    @Mock private BreadRepository breadRepository;
     @Mock private UserRepository userRepository;
     @Mock private ReviewRepository reviewRepository;
+    @Mock private BakeryTagRepository bakeryTagRepository;
+    @Mock private BreadTagRepository breadTagRepository;
     @Mock private GcsService gcsService;
     @Mock private TempImageService tempImageService;
 
@@ -70,6 +84,91 @@ class ReviewServiceTest {
 
         assertThat(reviewId).isEqualTo(900L);
         assertThat(bakery.getRating()).isEqualTo(4.25);
+    }
+
+    @Test
+    void createReview_saves_bakeryTags_when_provided() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(30L, UserRole.ROLE_USER);
+        CreateReviewRequest request = createReviewRequest("좋아요", 5);
+        ReflectionTestUtils.setField(
+                request, "bakeryTags", List.of(BakeryTagType.COZY, BakeryTagType.QUIET));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(20L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+        when(userRepository.findById(30L)).thenReturn(Optional.of(author));
+        when(reviewRepository.save(any(Review.class)))
+                .thenAnswer(
+                        inv -> {
+                            Review r = inv.getArgument(0);
+                            ReflectionTestUtils.setField(r, "id", 1L);
+                            return r;
+                        });
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
+
+        reviewService.createReview(20L, 30L, request);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<BakeryTag>> captor = ArgumentCaptor.forClass(List.class);
+        verify(bakeryTagRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+    }
+
+    @Test
+    void createReview_saves_menuTags_when_provided() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(30L, UserRole.ROLE_USER);
+        Bread bread = breadWithId(5L, bakery);
+        CreateReviewRequest request = createReviewRequest("좋아요", 5);
+        MenuTagRequest menuTag = new MenuTagRequest();
+        ReflectionTestUtils.setField(menuTag, "breadId", 5L);
+        ReflectionTestUtils.setField(menuTag, "tags", List.of(BreadTagType.SAVORY));
+        ReflectionTestUtils.setField(request, "menuTags", List.of(menuTag));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(20L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+        when(userRepository.findById(30L)).thenReturn(Optional.of(author));
+        when(reviewRepository.save(any(Review.class)))
+                .thenAnswer(
+                        inv -> {
+                            Review r = inv.getArgument(0);
+                            ReflectionTestUtils.setField(r, "id", 1L);
+                            return r;
+                        });
+        when(breadRepository.findByIdAndBakeryId(5L, 20L)).thenReturn(Optional.of(bread));
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
+
+        reviewService.createReview(20L, 30L, request);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<BreadTag>> captor = ArgumentCaptor.forClass(List.class);
+        verify(breadTagRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+    }
+
+    @Test
+    void createReview_throws_when_menu_not_in_bakery() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(30L, UserRole.ROLE_USER);
+        CreateReviewRequest request = createReviewRequest("좋아요", 5);
+        MenuTagRequest menuTag = new MenuTagRequest();
+        ReflectionTestUtils.setField(menuTag, "breadId", 99L);
+        ReflectionTestUtils.setField(menuTag, "tags", List.of(BreadTagType.SAVORY));
+        ReflectionTestUtils.setField(request, "menuTags", List.of(menuTag));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(20L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+        when(userRepository.findById(30L)).thenReturn(Optional.of(author));
+        when(reviewRepository.save(any(Review.class)))
+                .thenAnswer(
+                        inv -> {
+                            Review r = inv.getArgument(0);
+                            ReflectionTestUtils.setField(r, "id", 1L);
+                            return r;
+                        });
+        when(breadRepository.findByIdAndBakeryId(99L, 20L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reviewService.createReview(20L, 30L, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MENU_NOT_FOUND);
     }
 
     @Test
@@ -155,6 +254,9 @@ class ReviewServiceTest {
                 .thenReturn(true);
         when(reviewRepository.findAllByBakeryIdAndActiveTrue(eq(20L), pageableCaptor.capture()))
                 .thenReturn(new PageImpl<>(List.of(review), PageRequest.of(0, 10), 1));
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceIdIn(anyString(), anyList()))
+                .thenReturn(List.of());
+        when(breadTagRepository.findAllByReviewIdIn(anyList())).thenReturn(List.of());
 
         var result = reviewService.getReviews(20L, ReviewSortType.LATEST, 0, 10, 30L);
 
@@ -267,7 +369,35 @@ class ReviewServiceTest {
     }
 
     @Test
-    void deleteReview_succeeds_when_admin_not_author() {
+    void updateReview_syncs_bakeryTags_when_provided() {
+        Bakery bakery = bakeryWithId(20L);
+        User author = user(40L, UserRole.ROLE_USER);
+        Review review =
+                Review.builder()
+                        .content("a")
+                        .rating(3)
+                        .imageUrls(List.of())
+                        .user(author)
+                        .bakery(bakery)
+                        .build();
+        ReflectionTestUtils.setField(review, "id", 11L);
+        UpdateReviewRequest request = new UpdateReviewRequest();
+        ReflectionTestUtils.setField(request, "bakeryTags", List.of(BakeryTagType.COZY));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(20L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+        when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
+                .thenReturn(Optional.of(review));
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId("REVIEW", 11L))
+                .thenReturn(List.of());
+        when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
+
+        reviewService.updateReview(20L, 11L, 40L, request);
+
+        verify(bakeryTagRepository).saveAll(anyList());
+    }
+
+    @Test
+    void deleteReview_deletes_tags_and_deactivates() {
         Bakery bakery = bakeryWithId(20L);
         User author = user(40L, UserRole.ROLE_USER);
         Review review =
@@ -283,12 +413,16 @@ class ReviewServiceTest {
                 .thenReturn(Optional.of(bakery));
         when(reviewRepository.findByIdAndBakeryIdAndActiveTrue(11L, 20L))
                 .thenReturn(Optional.of(review));
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId("REVIEW", 11L))
+                .thenReturn(List.of());
+        when(breadTagRepository.findAllByReviewId(11L)).thenReturn(List.of());
         when(reviewRepository.findAverageRatingByBakeryId(20L)).thenReturn(Optional.empty());
 
         reviewService.deleteReview(20L, 11L, 999L, UserRole.ROLE_ADMIN);
 
+        verify(bakeryTagRepository).deleteAll(anyList());
+        verify(breadTagRepository).deleteAll(anyList());
         assertThat(review.isActive()).isFalse();
-        verify(reviewRepository).findAverageRatingByBakeryId(20L);
     }
 
     @Test
@@ -346,6 +480,19 @@ class ReviewServiceTest {
                         .parkingAvailable(false)
                         .drinkAvailable(true)
                         .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+
+    private static Bread breadWithId(long id, Bakery bakery) {
+        Bread b =
+                Bread.builder()
+                        .name("소금빵")
+                        .price(3000)
+                        .bakery(bakery)
+                        .signature(false)
+                        .selloutMin(0)
                         .build();
         ReflectionTestUtils.setField(b, "id", id);
         return b;

--- a/apps/be/src/test/java/com/breadbread/community/service/CommunityServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/community/service/CommunityServiceTest.java
@@ -3,11 +3,19 @@ package com.breadbread.community.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.enums.BakeryStatus;
+import com.breadbread.bakery.entity.enums.BakeryTagType;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BakeryTagRepository;
 import com.breadbread.community.dto.CreateCommentRequest;
 import com.breadbread.community.dto.CreatePostRequest;
 import com.breadbread.community.dto.PostListSort;
@@ -51,6 +59,8 @@ class CommunityServiceTest {
     @Mock private CommentRepository commentRepository;
     @Mock private PostLikeRepository postLikeRepository;
     @Mock private UserRepository userRepository;
+    @Mock private BakeryRepository bakeryRepository;
+    @Mock private BakeryTagRepository bakeryTagRepository;
     @Mock private GcsService gcsService;
     @Mock private TempImageService tempImageService;
 
@@ -137,6 +147,58 @@ class CommunityServiceTest {
     }
 
     @Test
+    void createPost_throws_when_bakeryTag_without_bakeryId() {
+        CreatePostRequest request = createPostRequest("글", "내용", PostType.FREE, null);
+        ReflectionTestUtils.setField(request, "bakeryTags", List.of(BakeryTagType.COZY));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L)));
+
+        assertThatThrownBy(() -> communityService.createPost(1L, UserRole.ROLE_USER, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TAG_REQUIRES_BAKERY);
+
+        verify(postRepository, never()).save(any(Post.class));
+    }
+
+    @Test
+    void createPost_throws_when_bakeryTag_on_non_free_post() {
+        CreatePostRequest request = createPostRequest("공지", "내용", PostType.NOTICE, null);
+        ReflectionTestUtils.setField(request, "bakeryId", 1L);
+        ReflectionTestUtils.setField(request, "bakeryTags", List.of(BakeryTagType.COZY));
+        User admin = user(3L);
+        when(userRepository.findById(3L)).thenReturn(Optional.of(admin));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(1L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakeryWithId(1L)));
+
+        assertThatThrownBy(() -> communityService.createPost(3L, UserRole.ROLE_ADMIN, request))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_TAG_NOT_ALLOWED_POST_TYPE);
+    }
+
+    @Test
+    void createPost_saves_bakeryTags_when_bakeryId_and_tags_provided() {
+        User author = user(2L);
+        CreatePostRequest request = createPostRequest("자유", "본문", PostType.FREE, null);
+        ReflectionTestUtils.setField(request, "bakeryId", 10L);
+        ReflectionTestUtils.setField(request, "bakeryTags", List.of(BakeryTagType.COZY));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(author));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakeryWithId(10L)));
+        when(postRepository.save(any(Post.class)))
+                .thenAnswer(
+                        inv -> {
+                            Post p = inv.getArgument(0);
+                            ReflectionTestUtils.setField(p, "id", 100L);
+                            return p;
+                        });
+
+        communityService.createPost(2L, UserRole.ROLE_USER, request);
+
+        verify(bakeryTagRepository).saveAll(anyList());
+    }
+
+    @Test
     void createPost_returns_id_when_free_and_user_exists() {
         User author = user(2L);
         CreatePostRequest request =
@@ -200,6 +262,8 @@ class CommunityServiceTest {
         when(postLikeRepository.countByPostId(50L)).thenReturn(3L);
         when(commentRepository.findAllByPostIdWithUserOrderByCreatedAtAsc(50L))
                 .thenReturn(List.of());
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId(anyString(), anyLong()))
+                .thenReturn(List.of());
 
         var detail = communityService.findOne(50L, 10L);
 
@@ -217,6 +281,8 @@ class CommunityServiceTest {
         when(postLikeRepository.existsByUserIdAndPostId(11L, 60L)).thenReturn(false);
         when(postLikeRepository.countByPostId(60L)).thenReturn(0L);
         when(commentRepository.findAllByPostIdWithUserOrderByCreatedAtAsc(60L))
+                .thenReturn(List.of());
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId(anyString(), anyLong()))
                 .thenReturn(List.of());
 
         var detail = communityService.findOne(60L, 11L);
@@ -276,25 +342,46 @@ class CommunityServiceTest {
     }
 
     @Test
-    void removePost_deletes_when_author() {
+    void updatePost_throws_when_bakeryTag_without_bakery() {
+        User owner = user(1L);
+        Post post = post(7L, "t", PostType.FREE, owner, List.of());
+        when(postRepository.findByIdWithUser(7L)).thenReturn(Optional.of(post));
+        UpdatePostRequest req = new UpdatePostRequest();
+        ReflectionTestUtils.setField(req, "bakeryTags", List.of(BakeryTagType.COZY));
+
+        assertThatThrownBy(
+                        () ->
+                                communityService.updatePost(
+                                        7L, owner.getId(), UserRole.ROLE_USER, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TAG_REQUIRES_BAKERY);
+    }
+
+    @Test
+    void removePost_deletes_tags_and_deactivates_when_author() {
         User owner = user(1L);
         Post post = post(9L, "t", PostType.FREE, owner, List.of());
         when(postRepository.findByIdWithUser(9L)).thenReturn(Optional.of(post));
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId("POST", 9L)).thenReturn(List.of());
 
         communityService.removePost(9L, owner.getId(), UserRole.ROLE_USER);
 
+        verify(bakeryTagRepository).deleteAll(anyList());
         verify(commentRepository).deactivateAllByPostId(9L);
         assertThat(post.isActive()).isFalse();
     }
 
     @Test
-    void removePost_deletes_when_admin() {
+    void removePost_deletes_tags_and_deactivates_when_admin() {
         User owner = user(1L);
         Post post = post(9L, "t", PostType.FREE, owner, List.of());
         when(postRepository.findByIdWithUser(9L)).thenReturn(Optional.of(post));
+        when(bakeryTagRepository.findAllBySourceTypeAndSourceId("POST", 9L)).thenReturn(List.of());
 
         communityService.removePost(9L, 50L, UserRole.ROLE_ADMIN);
 
+        verify(bakeryTagRepository).deleteAll(anyList());
         verify(commentRepository).deactivateAllByPostId(9L);
         assertThat(post.isActive()).isFalse();
     }
@@ -423,21 +510,6 @@ class CommunityServiceTest {
     }
 
     @Test
-    void likePost_maps_integrity_violation_when_race_on_save() {
-        Post post = post(1L, "t", PostType.FREE, user(1L), List.of());
-        when(postRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(post));
-        when(userRepository.findById(2L)).thenReturn(Optional.of(user(2L)));
-        doThrow(new DataIntegrityViolationException("dup"))
-                .when(postLikeRepository)
-                .saveAndFlush(any(PostLike.class));
-
-        assertThatThrownBy(() -> communityService.likePost(1L, 2L))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.ALREADY_POST_LIKED);
-    }
-
-    @Test
     void unlikePost_throws_when_not_liked() {
         when(postLikeRepository.findByUserIdAndPostId(2L, 1L)).thenReturn(Optional.empty());
 
@@ -457,6 +529,20 @@ class CommunityServiceTest {
         communityService.unlikePost(1L, 2L);
 
         verify(postLikeRepository).delete(like);
+    }
+
+    private static Bakery bakeryWithId(long id) {
+        Bakery b =
+                Bakery.builder()
+                        .name("테스트빵집")
+                        .address("주소")
+                        .region("대전")
+                        .latitude(36.0)
+                        .longitude(127.0)
+                        .drinkAvailable(false)
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
     }
 
     private static CreatePostRequest createPostRequest(


### PR DESCRIPTION
## Task
- BakeryTag, BreadTag 엔티티 및 마이그레이션(V23) 추가
- 리뷰 작성/수정/삭제 시 빵집 태그, 메뉴 태그 처리
- 게시글 작성/수정/삭제 시 빵집 연결 및 태그 처리 (자유게시판 전용)
- 리뷰 목록/상세, 게시글 상세 응답에 태그 포함
- 태그 삭제 시 하드 삭제, 인기 태그 집계 쿼리 active 필터 적용 

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #298 
