### PR TITLE
fix: 혼잡도 신호 저장 시 collectedAt null 오류 수정 및 중복 저장 제거

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/event/BakeryApprovalEventListener.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/event/BakeryApprovalEventListener.java
@@ -1,9 +1,7 @@
 package com.breadbread.bakery.event;
 
-import com.breadbread.congestion.service.CongestionSignalService;
 import com.breadbread.tour.client.CongestionInstantCheckClient;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +15,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class BakeryApprovalEventListener {
 
     private final CongestionInstantCheckClient congestionInstantCheckClient;
-    private final CongestionSignalService congestionSignalService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onBakeriesApproved(BakeriesApprovedEvent event) {
@@ -25,9 +22,7 @@ public class BakeryApprovalEventListener {
             Map<String, Object> body = new HashMap<>();
             body.put("userId", event.getAdminUserId());
             body.put("bakeryIds", event.getApprovedBakeryIds());
-            congestionSignalService.saveAllFromInstantCheck(
-                    congestionInstantCheckClient.check(body).getData(),
-                    new HashSet<>(event.getApprovedBakeryIds()));
+            congestionInstantCheckClient.check(body);
         } catch (Exception e) {
             log.warn("빵집 승인 후 혼잡도 초기화 실패: {}", e.getMessage());
         }

--- a/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
+++ b/apps/be/src/main/java/com/breadbread/congestion/service/CongestionSignalService.java
@@ -12,12 +12,10 @@ import com.breadbread.congestion.entity.CongestionLevel;
 import com.breadbread.congestion.repository.BakeryCongestionSignalRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
-import com.breadbread.tour.dto.CongestionInstantCheckResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -107,74 +105,6 @@ public class CongestionSignalService {
         log.info("[혼잡도 신호] {}건 저장 완료 (요청 {}건 중)", signals.size(), requests.size());
     }
 
-    @Transactional
-    public void saveAllFromInstantCheck(
-            List<CongestionInstantCheckResponse.CongestionResult> results) {
-        saveAllFromInstantCheck(results, null);
-    }
-
-    @Transactional
-    public void saveAllFromInstantCheck(
-            List<CongestionInstantCheckResponse.CongestionResult> results,
-            Set<Long> allowedBakeryIds) {
-        if (results == null || results.isEmpty()) {
-            log.warn("[혼잡도 신호] 저장 가능한 데이터가 없습니다.");
-            return;
-        }
-        List<Long> bakeryIds =
-                results.stream()
-                        .map(CongestionInstantCheckResponse.CongestionResult::getBakeryId)
-                        .filter(id -> id != null)
-                        .toList();
-        Set<Long> approvedIds =
-                bakeryRepository
-                        .findAllByIdInAndActiveTrueAndStatus(bakeryIds, BakeryStatus.APPROVED)
-                        .stream()
-                        .map(Bakery::getId)
-                        .collect(Collectors.toSet());
-
-        List<BakeryCongestionSignal> entities =
-                results.stream()
-                        .filter(
-                                r ->
-                                        r.getBakeryId() != null
-                                                && approvedIds.contains(r.getBakeryId()))
-                        .filter(
-                                r ->
-                                        allowedBakeryIds == null
-                                                || allowedBakeryIds.contains(r.getBakeryId()))
-                        .map(this::toEntity)
-                        .toList();
-
-        if (entities.isEmpty()) {
-            log.warn("[혼잡도 신호] 저장 가능한 데이터가 없습니다.");
-            return;
-        }
-        repository.saveAll(entities);
-        log.info("[혼잡도 신호] {}건 저장 완료 (응답 {}건 중)", entities.size(), results.size());
-    }
-
-    private BakeryCongestionSignal toEntity(
-            CongestionInstantCheckResponse.CongestionResult result) {
-        CongestionInstantCheckResponse.CongestionResult.Signals s = result.getSignals();
-        return BakeryCongestionSignal.builder()
-                .bakeryId(result.getBakeryId())
-                .bakeryName(result.getBakeryName())
-                .congestionScore(result.getCongestionScore())
-                .level(parseLevel(result.getLevel()))
-                .expectedWaitMin(result.getExpectedWaitMin())
-                .reason(result.getReason())
-                .waitingKeywordCount(s != null ? s.getWaitingKeywordCount() : null)
-                .openRunKeywordCount(s != null ? s.getOpenRunKeywordCount() : null)
-                .soldOutKeywordCount(s != null ? s.getSoldOutKeywordCount() : null)
-                .recentMentionCount(s != null ? s.getRecentMentionCount() : null)
-                .morningMentions(s != null ? s.getMorningMentions() : null)
-                .afternoonMentions(s != null ? s.getAfternoonMentions() : null)
-                .eveningMentions(s != null ? s.getEveningMentions() : null)
-                .collectedAt(result.getCheckedAt())
-                .build();
-    }
-
     @Transactional(readOnly = true)
     public CongestionResponse getByBakeryId(Long bakeryId) {
         BakeryCongestionSignal signal =
@@ -207,7 +137,8 @@ public class CongestionSignalService {
                 .morningMentions(s != null ? s.getMorningMentions() : null)
                 .afternoonMentions(s != null ? s.getAfternoonMentions() : null)
                 .eveningMentions(s != null ? s.getEveningMentions() : null)
-                .collectedAt(req.getCollectedAt())
+                .collectedAt(
+                        req.getCollectedAt() != null ? req.getCollectedAt() : LocalDateTime.now())
                 .build();
     }
 

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
@@ -1,6 +1,5 @@
 package com.breadbread.tour.service;
 
-import com.breadbread.congestion.service.CongestionSignalService;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
@@ -23,9 +22,7 @@ import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,7 +39,6 @@ public class TourService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final CongestionInstantCheckClient congestionInstantCheckClient;
-    private final CongestionSignalService congestionSignalService;
 
     @Transactional
     public TourStartResponse startTour(Long userId, UserRole role, Long courseId) {
@@ -152,15 +148,7 @@ public class TourService {
         if (request.getTargetBakeryId() != null) {
             body.put("targetBakeryId", request.getTargetBakeryId());
         }
-        Set<Long> allowedIds = new HashSet<>(request.getBakeryIds());
-        if (request.getTargetBakeryId() != null) {
-            allowedIds.add(request.getTargetBakeryId());
-        }
-        CongestionInstantCheckResponse response = congestionInstantCheckClient.check(body);
-        if (response.getData() != null && !response.getData().isEmpty()) {
-            congestionSignalService.saveAllFromInstantCheck(response.getData(), allowedIds);
-        }
-        return response;
+        return congestionInstantCheckClient.check(body);
     }
 
     private void completeReservationIfExists(Long userId, Long courseId) {

--- a/apps/be/src/test/java/com/breadbread/bakery/event/BakeryApprovalEventListenerTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/event/BakeryApprovalEventListenerTest.java
@@ -1,39 +1,28 @@
 package com.breadbread.bakery.event;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.breadbread.congestion.service.CongestionSignalService;
 import com.breadbread.tour.client.CongestionInstantCheckClient;
-import com.breadbread.tour.dto.CongestionInstantCheckResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class BakeryApprovalEventListenerTest {
 
     @Mock private CongestionInstantCheckClient congestionInstantCheckClient;
-    @Mock private CongestionSignalService congestionSignalService;
 
     @InjectMocks private BakeryApprovalEventListener listener;
 
     @Test
     void onBakeriesApproved_sends_userId_and_bakeryIds_to_n8n() {
-        CongestionInstantCheckResponse response = new CongestionInstantCheckResponse();
-        ReflectionTestUtils.setField(response, "success", true);
-        ReflectionTestUtils.setField(response, "data", List.of());
-        when(congestionInstantCheckClient.check(any())).thenReturn(response);
-
         listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L, 2L)));
 
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
@@ -44,27 +33,11 @@ class BakeryApprovalEventListenerTest {
     }
 
     @Test
-    void onBakeriesApproved_saves_with_allowed_ids() {
-        CongestionInstantCheckResponse.CongestionResult result =
-                new CongestionInstantCheckResponse.CongestionResult();
-        ReflectionTestUtils.setField(result, "bakeryId", 1L);
-
-        CongestionInstantCheckResponse response = new CongestionInstantCheckResponse();
-        ReflectionTestUtils.setField(response, "success", true);
-        ReflectionTestUtils.setField(response, "data", List.of(result));
-        when(congestionInstantCheckClient.check(any())).thenReturn(response);
-
-        listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L, 2L)));
-
-        verify(congestionSignalService).saveAllFromInstantCheck(List.of(result), Set.of(1L, 2L));
-    }
-
-    @Test
     void onBakeriesApproved_does_not_propagate_exception() {
         when(congestionInstantCheckClient.check(any())).thenThrow(new RuntimeException("n8n 오류"));
 
         listener.onBakeriesApproved(new BakeriesApprovedEvent(99L, List.of(1L)));
 
-        verify(congestionSignalService, never()).saveAllFromInstantCheck(any(), any());
+        // 예외가 외부로 전파되지 않으면 통과
     }
 }

--- a/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/congestion/service/CongestionSignalServiceTest.java
@@ -19,7 +19,6 @@ import com.breadbread.congestion.entity.CongestionLevel;
 import com.breadbread.congestion.repository.BakeryCongestionSignalRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
-import com.breadbread.tour.dto.CongestionInstantCheckResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -130,62 +129,6 @@ class CongestionSignalServiceTest {
         verify(repository).saveAll(captor.capture());
         assertThat(captor.getValue()).hasSize(1);
         assertThat(captor.getValue().get(0).getBakeryId()).isEqualTo(1L);
-    }
-
-    // ── saveAllFromInstantCheck ───────────────────────────────────────────────
-
-    @Test
-    void saveAllFromInstantCheck_saves_entities_when_data_present() {
-        Bakery bakery = bakery(1L, "파리바게뜨");
-        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
-                        List.of(1L), BakeryStatus.APPROVED))
-                .thenReturn(List.of(bakery));
-        CongestionInstantCheckResponse.CongestionResult result =
-                instantCheckResult(1L, "파리바게뜨", "HIGH");
-
-        service.saveAllFromInstantCheck(List.of(result));
-
-        ArgumentCaptor<List<BakeryCongestionSignal>> captor = ArgumentCaptor.forClass(List.class);
-        verify(repository).saveAll(captor.capture());
-        assertThat(captor.getValue()).hasSize(1);
-        assertThat(captor.getValue().get(0).getBakeryId()).isEqualTo(1L);
-        assertThat(captor.getValue().get(0).getLevel()).isEqualTo(CongestionLevel.HIGH);
-    }
-
-    @Test
-    void saveAllFromInstantCheck_skips_unapproved_bakery() {
-        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
-                        List.of(1L), BakeryStatus.APPROVED))
-                .thenReturn(List.of());
-        CongestionInstantCheckResponse.CongestionResult result =
-                instantCheckResult(1L, "파리바게뜨", "HIGH");
-
-        service.saveAllFromInstantCheck(List.of(result));
-
-        verify(repository, never()).saveAll(anyList());
-    }
-
-    @Test
-    void saveAllFromInstantCheck_skips_save_when_empty() {
-        service.saveAllFromInstantCheck(List.of());
-
-        verify(repository, never()).saveAll(anyList());
-    }
-
-    @Test
-    void saveAllFromInstantCheck_handles_unknown_level_gracefully() {
-        Bakery bakery = bakery(1L, "파리바게뜨");
-        when(bakeryRepository.findAllByIdInAndActiveTrueAndStatus(
-                        List.of(1L), BakeryStatus.APPROVED))
-                .thenReturn(List.of(bakery));
-        CongestionInstantCheckResponse.CongestionResult result =
-                instantCheckResult(1L, "파리바게뜨", "UNKNOWN_LEVEL");
-
-        service.saveAllFromInstantCheck(List.of(result));
-
-        ArgumentCaptor<List<BakeryCongestionSignal>> captor = ArgumentCaptor.forClass(List.class);
-        verify(repository).saveAll(captor.capture());
-        assertThat(captor.getValue().get(0).getLevel()).isNull();
     }
 
     // ── getByBakeryId ─────────────────────────────────────────────────────────
@@ -316,20 +259,6 @@ class CongestionSignalServiceTest {
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
-
-    private static CongestionInstantCheckResponse.CongestionResult instantCheckResult(
-            Long bakeryId, String bakeryName, String level) {
-        CongestionInstantCheckResponse.CongestionResult result =
-                new CongestionInstantCheckResponse.CongestionResult();
-        ReflectionTestUtils.setField(result, "bakeryId", bakeryId);
-        ReflectionTestUtils.setField(result, "bakeryName", bakeryName);
-        ReflectionTestUtils.setField(result, "congestionScore", 70.0);
-        ReflectionTestUtils.setField(result, "level", level);
-        ReflectionTestUtils.setField(result, "expectedWaitMin", 15);
-        ReflectionTestUtils.setField(result, "checkedAt", LocalDateTime.now());
-        ReflectionTestUtils.setField(result, "signals", null);
-        return result;
-    }
 
     private static Bakery bakery(Long id, String name) {
         Bakery bakery =

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.breadbread.congestion.service.CongestionSignalService;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.repository.CourseBakeryRepository;
@@ -33,7 +32,6 @@ import com.breadbread.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -54,7 +52,6 @@ class TourServiceTest {
     @Mock private ReservationRepository reservationRepository;
     @Mock private UserRepository userRepository;
     @Mock private CongestionInstantCheckClient congestionInstantCheckClient;
-    @Mock private CongestionSignalService congestionSignalService;
 
     // ── startTour ──────────────────────────────────────────────────────────────
 
@@ -373,7 +370,6 @@ class TourServiceTest {
         when(request.getBakeryIds()).thenReturn(List.of(1L, 2L, 3L));
         when(request.getTargetBakeryId()).thenReturn(null);
         when(congestionInstantCheckClient.check(any())).thenReturn(response);
-        when(response.getData()).thenReturn(null);
 
         CongestionInstantCheckResponse result = tourService.checkCongestionInstant(1L, request);
 
@@ -389,63 +385,12 @@ class TourServiceTest {
         when(request.getBakeryIds()).thenReturn(List.of(1L, 2L));
         when(request.getTargetBakeryId()).thenReturn(1L);
         when(congestionInstantCheckClient.check(any())).thenReturn(response);
-        when(response.getData()).thenReturn(null);
 
         tourService.checkCongestionInstant(1L, request);
 
         ArgumentCaptor<java.util.Map> captor = ArgumentCaptor.forClass(java.util.Map.class);
         verify(congestionInstantCheckClient).check(captor.capture());
         assertThat(captor.getValue()).containsKey("targetBakeryId");
-    }
-
-    @Test
-    void checkCongestionInstant_saves_congestion_when_data_present() {
-        CongestionInstantCheckRequest request = mock(CongestionInstantCheckRequest.class);
-        CongestionInstantCheckResponse response = mock(CongestionInstantCheckResponse.class);
-        CongestionInstantCheckResponse.CongestionResult result =
-                mock(CongestionInstantCheckResponse.CongestionResult.class);
-        when(request.getCourseId()).thenReturn(10L);
-        when(request.getBakeryIds()).thenReturn(List.of(1L));
-        when(request.getTargetBakeryId()).thenReturn(null);
-        when(congestionInstantCheckClient.check(any())).thenReturn(response);
-        when(response.getData()).thenReturn(List.of(result));
-
-        tourService.checkCongestionInstant(1L, request);
-
-        verify(congestionSignalService).saveAllFromInstantCheck(List.of(result), Set.of(1L));
-    }
-
-    @Test
-    void checkCongestionInstant_includes_targetBakeryId_in_allowed_ids() {
-        CongestionInstantCheckRequest request = mock(CongestionInstantCheckRequest.class);
-        CongestionInstantCheckResponse response = mock(CongestionInstantCheckResponse.class);
-        CongestionInstantCheckResponse.CongestionResult result =
-                mock(CongestionInstantCheckResponse.CongestionResult.class);
-        when(request.getCourseId()).thenReturn(10L);
-        when(request.getBakeryIds()).thenReturn(List.of(1L, 2L));
-        when(request.getTargetBakeryId()).thenReturn(3L);
-        when(congestionInstantCheckClient.check(any())).thenReturn(response);
-        when(response.getData()).thenReturn(List.of(result));
-
-        tourService.checkCongestionInstant(1L, request);
-
-        verify(congestionSignalService)
-                .saveAllFromInstantCheck(List.of(result), Set.of(1L, 2L, 3L));
-    }
-
-    @Test
-    void checkCongestionInstant_skips_save_when_data_empty() {
-        CongestionInstantCheckRequest request = mock(CongestionInstantCheckRequest.class);
-        CongestionInstantCheckResponse response = mock(CongestionInstantCheckResponse.class);
-        when(request.getCourseId()).thenReturn(10L);
-        when(request.getBakeryIds()).thenReturn(List.of(1L));
-        when(request.getTargetBakeryId()).thenReturn(null);
-        when(congestionInstantCheckClient.check(any())).thenReturn(response);
-        when(response.getData()).thenReturn(List.of());
-
-        tourService.checkCongestionInstant(1L, request);
-
-        verify(congestionSignalService, never()).saveAllFromInstantCheck(any(), any());
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Task
- 혼잡도 신호 저장 시 collectedAt null 오류 수정 및 중복 저장 제거

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [ ] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
