### PR TITLE
feat: 메뉴 건의 제보 등록 및 승인 플로우 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryReportController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryReportController.java
@@ -1,5 +1,6 @@
 package com.breadbread.bakery.controller;
 
+import com.breadbread.bakery.dto.request.ApproveMenuReportRequest;
 import com.breadbread.bakery.dto.response.BakeryReportListResponse;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.service.BakeryReportService;
@@ -7,6 +8,7 @@ import com.breadbread.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -41,6 +43,17 @@ public class AdminBakeryReportController {
     @PostMapping("/{id}/approve")
     public ApiResponse<Void> approve(@PathVariable Long id) {
         bakeryReportService.approve(id);
+        return ApiResponse.ok();
+    }
+
+    @Operation(
+            summary = "메뉴 건의 승인",
+            description =
+                    "MENU_SUGGESTION 제보를 승인합니다. price(필수), breadType(필수), imageUrl(선택)을 입력하면 Bread 엔티티가 생성됩니다.")
+    @PostMapping("/{id}/approve-menu")
+    public ApiResponse<Void> approveMenu(
+            @PathVariable Long id, @Valid @RequestBody ApproveMenuReportRequest request) {
+        bakeryReportService.approveMenu(id, request);
         return ApiResponse.ok();
     }
 

--- a/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryReportController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/BakeryReportController.java
@@ -1,6 +1,7 @@
 package com.breadbread.bakery.controller;
 
 import com.breadbread.auth.dto.CustomUserDetails;
+import com.breadbread.bakery.dto.request.CreateMenuReportRequest;
 import com.breadbread.bakery.dto.request.CreateNewBakeryReportRequest;
 import com.breadbread.bakery.dto.request.CreateUpdateBakeryReportRequest;
 import com.breadbread.bakery.service.BakeryReportService;
@@ -41,5 +42,14 @@ public class BakeryReportController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CreateUpdateBakeryReportRequest request) {
         return ApiResponse.ok(bakeryReportService.submitUpdate(userDetails.getId(), request));
+    }
+
+    @Operation(summary = "메뉴 건의", description = "등록된 빵집에 빠진 메뉴를 건의합니다.")
+    @PostMapping("/menu")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Long> submitMenu(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody CreateMenuReportRequest request) {
+        return ApiResponse.ok(bakeryReportService.submitMenu(userDetails.getId(), request));
     }
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/request/ApproveMenuReportRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/request/ApproveMenuReportRequest.java
@@ -1,0 +1,16 @@
+package com.breadbread.bakery.dto.request;
+
+import com.breadbread.bakery.entity.enums.BreadType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApproveMenuReportRequest {
+
+    @NotNull private Integer price;
+    private String imageUrl;
+    @NotNull private BreadType breadType;
+    private Boolean signature;
+}

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/request/CreateMenuReportRequest.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/request/CreateMenuReportRequest.java
@@ -1,17 +1,21 @@
 package com.breadbread.bakery.dto.request;
 
-import com.breadbread.bakery.entity.enums.BakeryUpdateField;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class CreateUpdateBakeryReportRequest {
+public class CreateMenuReportRequest {
 
-    @NotNull private Long targetBakeryId;
-    @NotNull private BakeryUpdateField updateField;
-    @NotBlank private String correctValue;
+    @NotNull private Long bakeryId;
+
+    @NotBlank
+    @Size(max = 120)
+    private String menuName;
+
+    @Size(max = 500)
     private String description;
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/dto/response/BakeryReportResponse.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/dto/response/BakeryReportResponse.java
@@ -27,10 +27,14 @@ public class BakeryReportResponse {
     private String recommendation;
 
     // UPDATE_BAKERY
-    private String targetBakeryName;
+    private Long targetBakeryId;
     private BakeryUpdateField updateField;
     private String correctValue;
     private String description;
+
+    // MENU_SUGGESTION
+    private String menuName;
+    private String menuDescription;
 
     public static BakeryReportResponse from(BakeryReport report) {
         return BakeryReportResponse.builder()
@@ -44,10 +48,12 @@ public class BakeryReportResponse {
                 .district(report.getDistrict())
                 .representativeMenus(report.getRepresentativeMenus())
                 .recommendation(report.getRecommendation())
-                .targetBakeryName(report.getTargetBakeryName())
+                .targetBakeryId(report.getTargetBakeryId())
                 .updateField(report.getUpdateField())
                 .correctValue(report.getCorrectValue())
                 .description(report.getDescription())
+                .menuName(report.getMenuName())
+                .menuDescription(report.getMenuDescription())
                 .build();
     }
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryReport.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BakeryReport.java
@@ -64,6 +64,11 @@ public class BakeryReport extends BaseEntity {
     // UPDATE_BAKERY 필드
     private String targetBakeryName;
 
+    // MENU_SUGGESTION 필드
+    private Long targetBakeryId;
+    private String menuName;
+    private String menuDescription;
+
     @Enumerated(EnumType.STRING)
     private BakeryUpdateField updateField;
 
@@ -85,7 +90,10 @@ public class BakeryReport extends BaseEntity {
             String targetBakeryName,
             BakeryUpdateField updateField,
             String correctValue,
-            String description) {
+            String description,
+            Long targetBakeryId,
+            String menuName,
+            String menuDescription) {
         this.type = type;
         this.user = user;
         this.bakeryName = bakeryName;
@@ -97,6 +105,9 @@ public class BakeryReport extends BaseEntity {
         this.updateField = updateField;
         this.correctValue = correctValue;
         this.description = description;
+        this.targetBakeryId = targetBakeryId;
+        this.menuName = menuName;
+        this.menuDescription = menuDescription;
     }
 
     public void approve() {

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BakeryReportType.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/enums/BakeryReportType.java
@@ -2,5 +2,6 @@ package com.breadbread.bakery.entity.enums;
 
 public enum BakeryReportType {
     NEW_BAKERY,
-    UPDATE_BAKERY
+    UPDATE_BAKERY,
+    MENU_SUGGESTION
 }

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryReportService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryReportService.java
@@ -1,15 +1,19 @@
 package com.breadbread.bakery.service;
 
+import com.breadbread.bakery.dto.request.ApproveMenuReportRequest;
+import com.breadbread.bakery.dto.request.CreateMenuReportRequest;
 import com.breadbread.bakery.dto.request.CreateNewBakeryReportRequest;
 import com.breadbread.bakery.dto.request.CreateUpdateBakeryReportRequest;
 import com.breadbread.bakery.dto.response.BakeryReportListResponse;
 import com.breadbread.bakery.dto.response.BakeryReportResponse;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryReport;
+import com.breadbread.bakery.entity.Bread;
 import com.breadbread.bakery.entity.enums.BakeryReportType;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.repository.BakeryReportRepository;
 import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BreadRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
@@ -28,6 +32,7 @@ public class BakeryReportService {
 
     private final BakeryReportRepository bakeryReportRepository;
     private final BakeryRepository bakeryRepository;
+    private final BreadRepository breadRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -60,11 +65,15 @@ public class BakeryReportService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        bakeryRepository
+                .findByIdAndActiveTrueAndStatus(request.getTargetBakeryId(), BakeryStatus.APPROVED)
+                .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
         BakeryReport report =
                 BakeryReport.builder()
                         .type(BakeryReportType.UPDATE_BAKERY)
                         .user(user)
-                        .targetBakeryName(request.getTargetBakeryName())
+                        .targetBakeryId(request.getTargetBakeryId())
                         .updateField(request.getUpdateField())
                         .correctValue(request.getCorrectValue())
                         .description(request.getDescription())
@@ -72,6 +81,34 @@ public class BakeryReportService {
 
         Long reportId = bakeryReportRepository.save(report).getId();
         log.info("빵집 정보 수정 제보 등록: reportId={}, userId={}", reportId, userId);
+        return reportId;
+    }
+
+    @Transactional
+    public Long submitMenu(Long userId, CreateMenuReportRequest request) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        bakeryRepository
+                .findByIdAndActiveTrueAndStatus(request.getBakeryId(), BakeryStatus.APPROVED)
+                .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        BakeryReport report =
+                BakeryReport.builder()
+                        .type(BakeryReportType.MENU_SUGGESTION)
+                        .user(user)
+                        .targetBakeryId(request.getBakeryId())
+                        .menuName(request.getMenuName())
+                        .menuDescription(request.getDescription())
+                        .build();
+
+        Long reportId = bakeryReportRepository.save(report).getId();
+        log.info(
+                "메뉴 건의 등록: reportId={}, userId={}, bakeryId={}",
+                reportId,
+                userId,
+                request.getBakeryId());
         return reportId;
     }
 
@@ -96,6 +133,9 @@ public class BakeryReportService {
         if (report.getStatus() != BakeryStatus.PENDING) {
             throw new CustomException(ErrorCode.BAKERY_REPORT_ALREADY_PROCESSED);
         }
+        if (report.getType() == BakeryReportType.MENU_SUGGESTION) {
+            throw new CustomException(ErrorCode.BAKERY_REPORT_TYPE_MISMATCH);
+        }
         if (report.getType() == BakeryReportType.NEW_BAKERY) {
             Bakery pendingBakery =
                     Bakery.builder()
@@ -118,6 +158,40 @@ public class BakeryReportService {
     }
 
     @Transactional
+    public void approveMenu(Long reportId, ApproveMenuReportRequest request) {
+        BakeryReport report = findReport(reportId);
+        if (report.getStatus() != BakeryStatus.PENDING) {
+            throw new CustomException(ErrorCode.BAKERY_REPORT_ALREADY_PROCESSED);
+        }
+        if (report.getType() != BakeryReportType.MENU_SUGGESTION) {
+            throw new CustomException(ErrorCode.BAKERY_REPORT_TYPE_MISMATCH);
+        }
+        Bakery bakery =
+                bakeryRepository
+                        .findByIdAndActiveTrueAndStatus(
+                                report.getTargetBakeryId(), BakeryStatus.APPROVED)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+
+        Bread bread =
+                Bread.builder()
+                        .name(report.getMenuName())
+                        .price(request.getPrice())
+                        .imageUrl(request.getImageUrl())
+                        .breadType(request.getBreadType())
+                        .bakery(bakery)
+                        .signature(Boolean.TRUE.equals(request.getSignature()))
+                        .selloutMin(0)
+                        .build();
+        breadRepository.save(bread);
+        report.approve();
+        log.info(
+                "메뉴 건의 승인: reportId={}, bakeryId={}, menuName={}",
+                reportId,
+                bakery.getId(),
+                bread.getName());
+    }
+
+    @Transactional
     public void reject(Long reportId) {
         BakeryReport report = findReport(reportId);
         if (report.getStatus() != BakeryStatus.PENDING) {
@@ -130,7 +204,8 @@ public class BakeryReportService {
     private void applyUpdateReport(BakeryReport report) {
         Bakery bakery =
                 bakeryRepository
-                        .findFirstByNameAndActiveTrue(report.getTargetBakeryName())
+                        .findByIdAndActiveTrueAndStatus(
+                                report.getTargetBakeryId(), BakeryStatus.APPROVED)
                         .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
         switch (report.getUpdateField()) {
             case ADDRESS -> bakery.updateAddress(report.getCorrectValue());

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     BAKERY_NOT_PENDING(HttpStatus.BAD_REQUEST, "E0307", "대기 중인 빵집이 아닙니다."),
     BAKERY_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "E0308", "존재하지 않는 빵집 제보입니다."),
     BAKERY_REPORT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "E0309", "이미 처리된 빵집 제보입니다."),
+    BAKERY_REPORT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "E0311", "제보 유형이 올바르지 않습니다."),
     BAKERY_APPROVE_INCOMPLETE(
             HttpStatus.BAD_REQUEST,
             "E0310",

--- a/apps/be/src/main/resources/db/migration/V25__add_menu_suggestion_fields.sql
+++ b/apps/be/src/main/resources/db/migration/V25__add_menu_suggestion_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE bakery_report
+    ADD COLUMN target_bakery_id BIGINT,
+    ADD COLUMN menu_name VARCHAR(120),
+    ADD COLUMN menu_description VARCHAR(500);

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryReportServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryReportServiceTest.java
@@ -7,16 +7,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.breadbread.bakery.dto.request.ApproveMenuReportRequest;
+import com.breadbread.bakery.dto.request.CreateMenuReportRequest;
 import com.breadbread.bakery.dto.request.CreateNewBakeryReportRequest;
 import com.breadbread.bakery.dto.request.CreateUpdateBakeryReportRequest;
 import com.breadbread.bakery.dto.response.BakeryReportListResponse;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.BakeryReport;
+import com.breadbread.bakery.entity.Bread;
 import com.breadbread.bakery.entity.enums.BakeryReportType;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.entity.enums.BakeryUpdateField;
+import com.breadbread.bakery.entity.enums.BreadType;
 import com.breadbread.bakery.repository.BakeryReportRepository;
 import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.bakery.repository.BreadRepository;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.user.entity.User;
@@ -39,6 +44,7 @@ class BakeryReportServiceTest {
 
     @Mock private BakeryReportRepository bakeryReportRepository;
     @Mock private BakeryRepository bakeryRepository;
+    @Mock private BreadRepository breadRepository;
     @Mock private UserRepository userRepository;
 
     @InjectMocks private BakeryReportService bakeryReportService;
@@ -82,19 +88,40 @@ class BakeryReportServiceTest {
     @Test
     void submitUpdate_saves_report_and_returns_id() {
         User user = user(1L);
+        Bakery bakery = approvedBakeryWithId(10L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
 
         BakeryReport saved = updateBakeryReport(20L, BakeryStatus.PENDING);
         when(bakeryReportRepository.save(any())).thenReturn(saved);
 
         CreateUpdateBakeryReportRequest req = new CreateUpdateBakeryReportRequest();
-        ReflectionTestUtils.setField(req, "targetBakeryName", "기존 빵집");
+        ReflectionTestUtils.setField(req, "targetBakeryId", 10L);
         ReflectionTestUtils.setField(req, "updateField", BakeryUpdateField.ADDRESS);
         ReflectionTestUtils.setField(req, "correctValue", "서울 강남구 삼성동 99-1");
 
         Long id = bakeryReportService.submitUpdate(1L, req);
 
         assertThat(id).isEqualTo(20L);
+    }
+
+    @Test
+    void submitUpdate_throws_BAKERY_NOT_FOUND_when_bakery_missing() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(99L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.empty());
+
+        CreateUpdateBakeryReportRequest req = new CreateUpdateBakeryReportRequest();
+        ReflectionTestUtils.setField(req, "targetBakeryId", 99L);
+        ReflectionTestUtils.setField(req, "updateField", BakeryUpdateField.ADDRESS);
+        ReflectionTestUtils.setField(req, "correctValue", "주소");
+
+        assertThatThrownBy(() -> bakeryReportService.submitUpdate(1L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
     }
 
     // ── getReports ────────────────────────────────────────────────────────────
@@ -164,6 +191,19 @@ class BakeryReportServiceTest {
     }
 
     @Test
+    void approve_throws_BAKERY_REPORT_TYPE_MISMATCH_when_menu_suggestion() {
+        BakeryReport report = menuReport(30L, BakeryStatus.PENDING);
+        when(bakeryReportRepository.findById(30L)).thenReturn(Optional.of(report));
+
+        assertThatThrownBy(() -> bakeryReportService.approve(30L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_REPORT_TYPE_MISMATCH);
+
+        verify(bakeryRepository, never()).save(any());
+    }
+
+    @Test
     void approve_throws_BAKERY_REPORT_ALREADY_PROCESSED_when_not_pending() {
         BakeryReport report = newBakeryReport(1L, BakeryStatus.APPROVED);
         when(bakeryReportRepository.findById(1L)).thenReturn(Optional.of(report));
@@ -193,15 +233,15 @@ class BakeryReportServiceTest {
         BakeryReport report =
                 BakeryReport.builder()
                         .type(BakeryReportType.UPDATE_BAKERY)
-                        .targetBakeryName("기존 빵집")
+                        .targetBakeryId(10L)
                         .updateField(BakeryUpdateField.ADDRESS)
                         .correctValue("서울 강남구 삼성동 99-1")
                         .build();
         ReflectionTestUtils.setField(report, "id", 2L);
 
-        Bakery bakery = bakeryWithId(10L);
+        Bakery bakery = approvedBakeryWithId(10L);
         when(bakeryReportRepository.findById(2L)).thenReturn(Optional.of(report));
-        when(bakeryRepository.findFirstByNameAndActiveTrue("기존 빵집"))
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
                 .thenReturn(Optional.of(bakery));
 
         bakeryReportService.approve(2L);
@@ -215,15 +255,15 @@ class BakeryReportServiceTest {
         BakeryReport report =
                 BakeryReport.builder()
                         .type(BakeryReportType.UPDATE_BAKERY)
-                        .targetBakeryName("기존 빵집")
+                        .targetBakeryId(10L)
                         .updateField(BakeryUpdateField.DISTRICT)
                         .correctValue("삼성동")
                         .build();
         ReflectionTestUtils.setField(report, "id", 3L);
 
-        Bakery bakery = bakeryWithId(10L);
+        Bakery bakery = approvedBakeryWithId(10L);
         when(bakeryReportRepository.findById(3L)).thenReturn(Optional.of(report));
-        when(bakeryRepository.findFirstByNameAndActiveTrue("기존 빵집"))
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
                 .thenReturn(Optional.of(bakery));
 
         bakeryReportService.approve(3L);
@@ -236,14 +276,15 @@ class BakeryReportServiceTest {
         BakeryReport report =
                 BakeryReport.builder()
                         .type(BakeryReportType.UPDATE_BAKERY)
-                        .targetBakeryName("없는 빵집")
+                        .targetBakeryId(99L)
                         .updateField(BakeryUpdateField.ADDRESS)
                         .correctValue("주소")
                         .build();
         ReflectionTestUtils.setField(report, "id", 4L);
 
         when(bakeryReportRepository.findById(4L)).thenReturn(Optional.of(report));
-        when(bakeryRepository.findFirstByNameAndActiveTrue("없는 빵집")).thenReturn(Optional.empty());
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(99L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> bakeryReportService.approve(4L))
                 .isInstanceOf(CustomException.class)
@@ -251,6 +292,166 @@ class BakeryReportServiceTest {
                 .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
 
         assertThat(report.getStatus()).isEqualTo(BakeryStatus.PENDING);
+    }
+
+    // ── submitMenu ────────────────────────────────────────────────────────────
+
+    @Test
+    void submitMenu_saves_report_and_returns_id() {
+        User user = user(1L);
+        Bakery bakery = approvedBakeryWithId(10L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+
+        BakeryReport saved = menuReport(30L, BakeryStatus.PENDING);
+        when(bakeryReportRepository.save(any())).thenReturn(saved);
+
+        CreateMenuReportRequest req = new CreateMenuReportRequest();
+        ReflectionTestUtils.setField(req, "bakeryId", 10L);
+        ReflectionTestUtils.setField(req, "menuName", "소금빵");
+        ReflectionTestUtils.setField(req, "description", "가격 2500원");
+
+        Long id = bakeryReportService.submitMenu(1L, req);
+
+        assertThat(id).isEqualTo(30L);
+        verify(bakeryReportRepository).save(any(BakeryReport.class));
+    }
+
+    @Test
+    void submitMenu_throws_USER_NOT_FOUND_when_user_missing() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        CreateMenuReportRequest req = new CreateMenuReportRequest();
+        ReflectionTestUtils.setField(req, "bakeryId", 10L);
+        ReflectionTestUtils.setField(req, "menuName", "소금빵");
+
+        assertThatThrownBy(() -> bakeryReportService.submitMenu(99L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    void submitMenu_throws_BAKERY_NOT_FOUND_when_bakery_not_approved() {
+        User user = user(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(99L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.empty());
+
+        CreateMenuReportRequest req = new CreateMenuReportRequest();
+        ReflectionTestUtils.setField(req, "bakeryId", 99L);
+        ReflectionTestUtils.setField(req, "menuName", "소금빵");
+
+        assertThatThrownBy(() -> bakeryReportService.submitMenu(1L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+    }
+
+    // ── approveMenu ───────────────────────────────────────────────────────────
+
+    @Test
+    void approveMenu_creates_bread_and_approves_report() {
+        BakeryReport report = menuReport(30L, BakeryStatus.PENDING);
+        Bakery bakery = approvedBakeryWithId(10L);
+        when(bakeryReportRepository.findById(30L)).thenReturn(Optional.of(report));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+
+        ApproveMenuReportRequest req = new ApproveMenuReportRequest();
+        ReflectionTestUtils.setField(req, "price", 2500);
+        ReflectionTestUtils.setField(req, "imageUrl", "https://example.com/bread.jpg");
+        ReflectionTestUtils.setField(req, "breadType", BreadType.BREAD);
+        ReflectionTestUtils.setField(req, "signature", true);
+
+        bakeryReportService.approveMenu(30L, req);
+
+        ArgumentCaptor<Bread> captor = ArgumentCaptor.forClass(Bread.class);
+        verify(breadRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("소금빵");
+        assertThat(captor.getValue().getPrice()).isEqualTo(2500);
+        assertThat(captor.getValue().getImageUrl()).isEqualTo("https://example.com/bread.jpg");
+        assertThat(captor.getValue().getBreadType()).isEqualTo(BreadType.BREAD);
+        assertThat(captor.getValue().isSignature()).isTrue();
+        assertThat(report.getStatus()).isEqualTo(BakeryStatus.APPROVED);
+    }
+
+    @Test
+    void approveMenu_creates_bread_without_imageUrl() {
+        BakeryReport report = menuReport(30L, BakeryStatus.PENDING);
+        Bakery bakery = approvedBakeryWithId(10L);
+        when(bakeryReportRepository.findById(30L)).thenReturn(Optional.of(report));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.of(bakery));
+
+        ApproveMenuReportRequest req = new ApproveMenuReportRequest();
+        ReflectionTestUtils.setField(req, "price", 2500);
+        ReflectionTestUtils.setField(req, "imageUrl", null);
+        ReflectionTestUtils.setField(req, "breadType", BreadType.BREAD);
+        ReflectionTestUtils.setField(req, "signature", false);
+
+        bakeryReportService.approveMenu(30L, req);
+
+        ArgumentCaptor<Bread> captor = ArgumentCaptor.forClass(Bread.class);
+        verify(breadRepository).save(captor.capture());
+        assertThat(captor.getValue().getImageUrl()).isNull();
+    }
+
+    @Test
+    void approveMenu_throws_BAKERY_REPORT_ALREADY_PROCESSED_when_not_pending() {
+        BakeryReport report = menuReport(30L, BakeryStatus.APPROVED);
+        when(bakeryReportRepository.findById(30L)).thenReturn(Optional.of(report));
+
+        ApproveMenuReportRequest req = new ApproveMenuReportRequest();
+        ReflectionTestUtils.setField(req, "price", 2500);
+        ReflectionTestUtils.setField(req, "breadType", BreadType.BREAD);
+        ReflectionTestUtils.setField(req, "signature", false);
+
+        assertThatThrownBy(() -> bakeryReportService.approveMenu(30L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_REPORT_ALREADY_PROCESSED);
+
+        verify(breadRepository, never()).save(any());
+    }
+
+    @Test
+    void approveMenu_throws_BAKERY_REPORT_TYPE_MISMATCH_when_not_menu_suggestion() {
+        BakeryReport report = newBakeryReport(1L, BakeryStatus.PENDING);
+        when(bakeryReportRepository.findById(1L)).thenReturn(Optional.of(report));
+
+        ApproveMenuReportRequest req = new ApproveMenuReportRequest();
+        ReflectionTestUtils.setField(req, "price", 2500);
+        ReflectionTestUtils.setField(req, "breadType", BreadType.BREAD);
+        ReflectionTestUtils.setField(req, "signature", false);
+
+        assertThatThrownBy(() -> bakeryReportService.approveMenu(1L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_REPORT_TYPE_MISMATCH);
+
+        verify(breadRepository, never()).save(any());
+    }
+
+    @Test
+    void approveMenu_throws_BAKERY_NOT_FOUND_when_bakery_missing() {
+        BakeryReport report = menuReport(30L, BakeryStatus.PENDING);
+        when(bakeryReportRepository.findById(30L)).thenReturn(Optional.of(report));
+        when(bakeryRepository.findByIdAndActiveTrueAndStatus(10L, BakeryStatus.APPROVED))
+                .thenReturn(Optional.empty());
+
+        ApproveMenuReportRequest req = new ApproveMenuReportRequest();
+        ReflectionTestUtils.setField(req, "price", 2500);
+        ReflectionTestUtils.setField(req, "breadType", BreadType.BREAD);
+        ReflectionTestUtils.setField(req, "signature", false);
+
+        assertThatThrownBy(() -> bakeryReportService.approveMenu(30L, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_NOT_FOUND);
+
+        verify(breadRepository, never()).save(any());
     }
 
     // ── reject ────────────────────────────────────────────────────────────────
@@ -296,7 +497,7 @@ class BakeryReportServiceTest {
         BakeryReport report =
                 BakeryReport.builder()
                         .type(BakeryReportType.UPDATE_BAKERY)
-                        .targetBakeryName("기존 빵집")
+                        .targetBakeryId(10L)
                         .updateField(BakeryUpdateField.ADDRESS)
                         .correctValue("서울 강남구 삼성동 99-1")
                         .build();
@@ -305,7 +506,20 @@ class BakeryReportServiceTest {
         return report;
     }
 
-    private static Bakery bakeryWithId(long id) {
+    private static BakeryReport menuReport(long id, BakeryStatus status) {
+        BakeryReport report =
+                BakeryReport.builder()
+                        .type(BakeryReportType.MENU_SUGGESTION)
+                        .targetBakeryId(10L)
+                        .menuName("소금빵")
+                        .menuDescription("가격 2500원")
+                        .build();
+        ReflectionTestUtils.setField(report, "id", id);
+        ReflectionTestUtils.setField(report, "status", status);
+        return report;
+    }
+
+    private static Bakery approvedBakeryWithId(long id) {
         Bakery b =
                 Bakery.builder()
                         .name("테스트빵집")
@@ -320,6 +534,7 @@ class BakeryReportServiceTest {
                         .holidayClosed(false)
                         .build();
         ReflectionTestUtils.setField(b, "id", id);
+        ReflectionTestUtils.setField(b, "status", BakeryStatus.APPROVED);
         return b;
     }
 


### PR DESCRIPTION
## Task
- POST /bakeries/reports/menu — 메뉴 건의 등록 (bakeryId, menuName 필수)
- POST /admin/bakery-reports/{id}/approve-menu — 메뉴 건의 승인 시 Bread 엔티티 생성
- BakeryReportType에 MENU_SUGGESTION 추가
- 일반 승인 API에서 MENU_SUGGESTION 타입 차단
- 정보 수정 제보 bakeryId 기반으로 변경 (기존 targetBakeryName → targetBakeryId)
- BakeryReportResponse에 targetBakeryId, menuName, menuDescription 필드 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #310 
