### PR TITLE
feat: T맵 보행자 경로 API 추가 및 도보/자동차 모드 분리

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -348,7 +348,7 @@ public class BakeryService {
         if (coordinatesChanged) {
             List<Long> courseIds = courseBakeryRepository.findCourseIdsByBakeryId(bakeryId);
             if (!courseIds.isEmpty()) {
-                courseDrivingRouteRepository.deleteAllByCourseIdIn(courseIds);
+                courseDrivingRouteRepository.deleteByIdCourseIdIn(courseIds);
                 log.info("빵집 좌표 변경으로 경로 캐시 삭제: bakeryId={}, courseIds={}", bakeryId, courseIds);
             }
         }
@@ -372,7 +372,7 @@ public class BakeryService {
 
         List<Long> courseIds = courseBakeryRepository.findCourseIdsByBakeryId(bakeryId);
         if (!courseIds.isEmpty()) {
-            courseDrivingRouteRepository.deleteAllByCourseIdIn(courseIds);
+            courseDrivingRouteRepository.deleteByIdCourseIdIn(courseIds);
             log.info("빵집 삭제로 경로 캐시 삭제: bakeryId={}, courseIds={}", bakeryId, courseIds);
         }
     }
@@ -565,7 +565,7 @@ public class BakeryService {
     private void deleteRelatedData(Long bakeryId) {
         List<Long> courseIds = courseBakeryRepository.findCourseIdsByBakeryId(bakeryId);
         if (!courseIds.isEmpty()) {
-            courseDrivingRouteRepository.deleteAllByCourseIdIn(courseIds);
+            courseDrivingRouteRepository.deleteByIdCourseIdIn(courseIds);
         }
         courseBakeryRepository.deleteAllByBakeryId(bakeryId);
         breadRepository.deleteAllByBakeryId(bakeryId);

--- a/apps/be/src/main/java/com/breadbread/course/client/TmapWalkingRouteClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/TmapWalkingRouteClient.java
@@ -1,0 +1,198 @@
+package com.breadbread.course.client;
+
+import com.breadbread.course.config.TmapProperties;
+import com.breadbread.course.dto.route.Coordinate;
+import com.breadbread.course.dto.route.RouteResult;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TmapWalkingRouteClient implements WalkingRouteClient {
+
+    private static final String PEDESTRIAN_PATH = "/tmap/routes/pedestrian";
+
+    private final WebClient webClient;
+    private final TmapProperties properties;
+
+    @Override
+    public RouteResult getPath(List<Coordinate> coordinates) {
+        Coordinate start = coordinates.get(0);
+        Coordinate end = coordinates.get(coordinates.size() - 1);
+        List<Coordinate> waypoints = coordinates.subList(1, coordinates.size() - 1);
+
+        Map<String, Object> body = buildRequestBody(start, end, waypoints);
+
+        log.info(
+                "[Tmap 경로] 요청: totalPoints={}, waypointCount={}",
+                coordinates.size(),
+                waypoints.size());
+
+        long startTime = System.currentTimeMillis();
+        TmapRouteResponse response = callApi(body);
+        log.info("[Tmap 경로] 완료: elapsed={}ms", System.currentTimeMillis() - startTime);
+
+        return toRouteResult(response, end);
+    }
+
+    private Map<String, Object> buildRequestBody(
+            Coordinate start, Coordinate end, List<Coordinate> waypoints) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("startX", String.valueOf(start.getLng()));
+        body.put("startY", String.valueOf(start.getLat()));
+        body.put("endX", String.valueOf(end.getLng()));
+        body.put("endY", String.valueOf(end.getLat()));
+        body.put("startName", "출발지");
+        body.put("endName", "도착지");
+        body.put("searchOption", "10");
+        body.put("sort", "custom");
+
+        if (!waypoints.isEmpty()) {
+            String passList =
+                    waypoints.stream()
+                            .map(w -> w.getLng() + "," + w.getLat())
+                            .collect(Collectors.joining("_"));
+            body.put("passList", passList);
+        }
+
+        return body;
+    }
+
+    private TmapRouteResponse callApi(Map<String, Object> body) {
+        try {
+            TmapRouteResponse response =
+                    webClient
+                            .post()
+                            .uri(
+                                    uriBuilder ->
+                                            uriBuilder
+                                                    .scheme("https")
+                                                    .host("apis.openapi.sk.com")
+                                                    .path(PEDESTRIAN_PATH)
+                                                    .queryParam("version", "1")
+                                                    .build())
+                            .header("appKey", properties.getAppKey())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(body)
+                            .retrieve()
+                            .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
+                            .bodyToMono(TmapRouteResponse.class)
+                            .timeout(Duration.ofSeconds(properties.getTimeoutSeconds()))
+                            .block();
+
+            if (response == null) {
+                log.error("[Tmap 경로] 응답 body 없음");
+                throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+            }
+            return response;
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            if (reactor.core.Exceptions.unwrap(e)
+                    instanceof java.util.concurrent.TimeoutException) {
+                log.error("[Tmap 경로] 타임아웃: timeoutSeconds={}", properties.getTimeoutSeconds());
+            } else {
+                log.error("[Tmap 경로] API 호출 실패", e);
+            }
+            throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+        }
+    }
+
+    private Mono<Throwable> handleErrorResponse(ClientResponse res) {
+        return res.bodyToMono(String.class)
+                .flatMap(
+                        body -> {
+                            log.error(
+                                    "[Tmap 경로] HTTP 오류: status={}, body={}",
+                                    res.statusCode(),
+                                    body);
+                            return Mono.error(new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR));
+                        });
+    }
+
+    private RouteResult toRouteResult(TmapRouteResponse response, Coordinate destination) {
+        if (response.getFeatures() == null || response.getFeatures().isEmpty()) {
+            log.error("[Tmap 경로] features 없음");
+            throw new CustomException(ErrorCode.ROUTE_NOT_FOUND);
+        }
+
+        int totalDurationSeconds = 0;
+        List<Coordinate> path = new ArrayList<>();
+
+        for (TmapRouteResponse.Feature feature : response.getFeatures()) {
+            JsonNode geometry = feature.getGeometry();
+            if (geometry == null) continue;
+
+            String geometryType = geometry.path("type").asText();
+
+            if ("Point".equals(geometryType) && totalDurationSeconds == 0) {
+                // 첫 번째 Point(SP)에서 totalTime 추출
+                JsonNode props = feature.getProperties();
+                if (props != null && props.has("totalTime")) {
+                    totalDurationSeconds = props.path("totalTime").asInt();
+                }
+            } else if ("LineString".equals(geometryType)) {
+                JsonNode coords = geometry.path("coordinates");
+                if (coords.isArray()) {
+                    for (JsonNode point : coords) {
+                        double lng = point.get(0).asDouble();
+                        double lat = point.get(1).asDouble();
+                        path.add(new Coordinate(lat, lng));
+                    }
+                }
+            }
+        }
+
+        if (path.isEmpty()) {
+            log.error("[Tmap 경로] path 좌표 없음");
+            throw new CustomException(ErrorCode.ROUTE_NOT_FOUND);
+        }
+
+        Coordinate last = path.get(path.size() - 1);
+        if (Math.abs(last.getLat() - destination.getLat()) > 1e-6
+                || Math.abs(last.getLng() - destination.getLng()) > 1e-6) {
+            path.add(destination);
+        }
+
+        log.info(
+                "[Tmap 경로] 응답 수신: pathPoints={}, totalSeconds={}",
+                path.size(),
+                totalDurationSeconds);
+
+        // T맵 단일 요청에서는 구간별 시간을 제공하지 않으므로 빈 리스트
+        return new RouteResult(path, List.of(), totalDurationSeconds);
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class TmapRouteResponse {
+
+        private List<Feature> features;
+
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        static class Feature {
+            private JsonNode geometry;
+            private JsonNode properties;
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/client/WalkingRouteClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/WalkingRouteClient.java
@@ -1,0 +1,10 @@
+package com.breadbread.course.client;
+
+import com.breadbread.course.dto.route.Coordinate;
+import com.breadbread.course.dto.route.RouteResult;
+import java.util.List;
+
+public interface WalkingRouteClient {
+
+    RouteResult getPath(List<Coordinate> coordinates);
+}

--- a/apps/be/src/main/java/com/breadbread/course/config/TmapProperties.java
+++ b/apps/be/src/main/java/com/breadbread/course/config/TmapProperties.java
@@ -1,0 +1,17 @@
+package com.breadbread.course.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "tmap")
+public class TmapProperties {
+
+    private String appKey;
+    private String baseUrl = "https://apis.openapi.sk.com";
+    private long timeoutSeconds = 10;
+}

--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -5,6 +5,7 @@ import com.breadbread.course.dto.request.CourseSearch;
 import com.breadbread.course.dto.request.ReorderBakeriesRequest;
 import com.breadbread.course.dto.request.ReplaceCourseBakeryRequest;
 import com.breadbread.course.dto.response.*;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.service.CourseBakeryMutationService;
 import com.breadbread.course.service.CourseBakeryOrderService;
 import com.breadbread.course.service.CourseDrivingRouteService;
@@ -101,11 +102,15 @@ public class CourseController {
     }
 
     @Operation(
-            summary = "코스 자동차 경로 조회",
-            description = "코스에 포함된 빵집 순서대로 자동차 주행 경로의 vertex 좌표를 반환합니다. 비공개 AI 코스는 본인만 조회할 수 있습니다.")
+            summary = "코스 경로 조회",
+            description =
+                    "코스에 포함된 빵집 순서대로 경로의 vertex 좌표를 반환합니다."
+                            + " mode=DRIVING(기본값)이면 자동차 경로, WALKING이면 보도 경로를 반환합니다."
+                            + " 로그인 없이도 조회 가능합니다.")
     @GetMapping("/{id}/directions")
-    public ApiResponse<DrivingRouteResponse> getDrivingRoute(@PathVariable Long id) {
-        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id));
+    public ApiResponse<DrivingRouteResponse> getDrivingRoute(
+            @PathVariable Long id, @RequestParam(defaultValue = "DRIVING") RouteMode mode) {
+        return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id, mode));
     }
 
     @Operation(summary = "코스 내 빵집 방문 순서 변경")

--- a/apps/be/src/main/java/com/breadbread/course/entity/CourseDrivingRoute.java
+++ b/apps/be/src/main/java/com/breadbread/course/entity/CourseDrivingRoute.java
@@ -5,8 +5,8 @@ import com.breadbread.course.converter.IntegerListConverter;
 import com.breadbread.course.dto.route.Coordinate;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseDrivingRoute {
 
-    @Id private Long courseId;
+    @EmbeddedId private CourseDrivingRouteId id;
 
     @Convert(converter = CoordinateListConverter.class)
     @Column(columnDefinition = "text", nullable = false)
@@ -38,10 +38,11 @@ public class CourseDrivingRoute {
     @Builder
     public CourseDrivingRoute(
             Long courseId,
+            RouteMode routeMode,
             List<Coordinate> path,
             Integer totalTravelSeconds,
             List<Integer> legDurations) {
-        this.courseId = courseId;
+        this.id = new CourseDrivingRouteId(courseId, routeMode);
         this.path = path;
         this.totalTravelSeconds = totalTravelSeconds;
         this.legDurations = legDurations;

--- a/apps/be/src/main/java/com/breadbread/course/entity/CourseDrivingRouteId.java
+++ b/apps/be/src/main/java/com/breadbread/course/entity/CourseDrivingRouteId.java
@@ -1,0 +1,24 @@
+package com.breadbread.course.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CourseDrivingRouteId implements Serializable {
+
+    private Long courseId;
+
+    @Enumerated(EnumType.STRING)
+    private RouteMode routeMode;
+}

--- a/apps/be/src/main/java/com/breadbread/course/entity/RouteMode.java
+++ b/apps/be/src/main/java/com/breadbread/course/entity/RouteMode.java
@@ -1,0 +1,6 @@
+package com.breadbread.course.entity;
+
+public enum RouteMode {
+    DRIVING,
+    WALKING
+}

--- a/apps/be/src/main/java/com/breadbread/course/repository/CourseDrivingRouteRepository.java
+++ b/apps/be/src/main/java/com/breadbread/course/repository/CourseDrivingRouteRepository.java
@@ -1,10 +1,16 @@
 package com.breadbread.course.repository;
 
 import com.breadbread.course.entity.CourseDrivingRoute;
+import com.breadbread.course.entity.CourseDrivingRouteId;
+import com.breadbread.course.entity.RouteMode;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CourseDrivingRouteRepository extends JpaRepository<CourseDrivingRoute, Long> {
+public interface CourseDrivingRouteRepository
+        extends JpaRepository<CourseDrivingRoute, CourseDrivingRouteId> {
 
-    void deleteAllByCourseIdIn(List<Long> courseIds);
+    Optional<CourseDrivingRoute> findByIdCourseIdAndIdRouteMode(Long courseId, RouteMode routeMode);
+
+    void deleteByIdCourseIdIn(List<Long> courseIds);
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/AiCourseSaveService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/AiCourseSaveService.java
@@ -286,7 +286,7 @@ public class AiCourseSaveService {
         }
 
         course.deactivate();
-        courseDrivingRouteRepository.deleteAllByCourseIdIn(List.of(courseId));
+        courseDrivingRouteRepository.deleteByIdCourseIdIn(List.of(courseId));
         log.info("AI 코스 삭제: courseId={}, userId={}", courseId, userId);
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryMutationService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryMutationService.java
@@ -8,6 +8,7 @@ import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.response.ModifyCourseBakeryResponse;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
@@ -151,11 +152,12 @@ public class CourseBakeryMutationService {
         int estimatedTotalMinutes = 0;
         try {
             DrivingRouteResponse routeResponse =
-                    courseDrivingRouteService.fetchAndSaveDrivingRoute(
+                    courseDrivingRouteService.fetchAndSaveRoute(
                             course,
                             orderedBakeries,
                             orderedBakeries.stream().map(Bakery::getEstimatedStayMinutes).toList(),
-                            totalStayMinutes);
+                            totalStayMinutes,
+                            RouteMode.DRIVING);
             estimatedTotalMinutes = routeResponse.getTotalMinutes();
             course.updateTotalMinutes(estimatedTotalMinutes);
         } catch (CustomException e) {

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
@@ -6,6 +6,7 @@ import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.response.ReorderBakeriesResponse;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
@@ -124,11 +125,12 @@ public class CourseBakeryOrderService {
         int estimatedTotalMinutes = 0;
         try {
             DrivingRouteResponse routeResponse =
-                    courseDrivingRouteService.fetchAndSaveDrivingRoute(
+                    courseDrivingRouteService.fetchAndSaveRoute(
                             course,
                             orderedBakeries,
                             orderedBakeries.stream().map(Bakery::getEstimatedStayMinutes).toList(),
-                            totalStayMinutes);
+                            totalStayMinutes,
+                            RouteMode.DRIVING);
             estimatedTotalMinutes = routeResponse.getTotalMinutes();
             course.updateTotalMinutes(estimatedTotalMinutes);
         } catch (CustomException e) {

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteSaver.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteSaver.java
@@ -2,6 +2,7 @@ package com.breadbread.course.service;
 
 import com.breadbread.course.dto.route.RouteResult;
 import com.breadbread.course.entity.CourseDrivingRoute;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,11 @@ public class CourseDrivingRouteSaver {
     private final CourseRepository courseRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void save(Long courseId, RouteResult result) {
+    public void save(Long courseId, RouteMode routeMode, RouteResult result) {
         courseDrivingRouteRepository.save(
                 CourseDrivingRoute.builder()
                         .courseId(courseId)
+                        .routeMode(routeMode)
                         .path(result.getPath())
                         .totalTravelSeconds(result.getTotalDurationSeconds())
                         .legDurations(result.getLegDurationsSeconds())

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseDrivingRouteService.java
@@ -2,6 +2,7 @@ package com.breadbread.course.service;
 
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.course.client.DrivingRouteClient;
+import com.breadbread.course.client.WalkingRouteClient;
 import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.route.Coordinate;
 import com.breadbread.course.dto.route.RouteResult;
@@ -10,6 +11,7 @@ import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.entity.CourseDrivingRoute;
 import com.breadbread.course.entity.CourseType;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
@@ -32,9 +34,10 @@ public class CourseDrivingRouteService {
     private final CourseDrivingRouteRepository courseDrivingRouteRepository;
     private final CourseDrivingRouteSaver courseDrivingRouteSaver;
     private final DrivingRouteClient drivingRouteClient;
+    private final WalkingRouteClient walkingRouteClient;
 
     @Transactional
-    public DrivingRouteResponse getDrivingRoute(Long courseId) {
+    public DrivingRouteResponse getDrivingRoute(Long courseId, RouteMode mode) {
         Course course =
                 courseRepository
                         .findActiveWithBakeriesById(courseId)
@@ -53,70 +56,59 @@ public class CourseDrivingRouteService {
 
         DrivingRouteResponse response =
                 courseDrivingRouteRepository
-                        .findById(courseId)
+                        .findByIdCourseIdAndIdRouteMode(courseId, mode)
                         .map(
                                 cached ->
                                         buildResponseFromCache(
                                                 cached, stayMinutesPerBakery, totalStayMinutes))
                         .orElseGet(
                                 () ->
-                                        fetchAndSaveDrivingRoute(
+                                        fetchAndSaveRoute(
                                                 course,
                                                 orderedBakeries,
                                                 stayMinutesPerBakery,
-                                                totalStayMinutes));
+                                                totalStayMinutes,
+                                                mode));
 
-        courseDrivingRouteSaver.updateCourseTotalMinutes(courseId, response.getTotalMinutes());
+        if (mode == RouteMode.DRIVING) {
+            courseDrivingRouteSaver.updateCourseTotalMinutes(courseId, response.getTotalMinutes());
+        }
         return response;
     }
 
     public void invalidateCache(Long courseId) {
-        courseDrivingRouteRepository.deleteAllByCourseIdIn(List.of(courseId));
+        courseDrivingRouteRepository.deleteByIdCourseIdIn(List.of(courseId));
     }
 
-    public DrivingRouteResponse fetchAndSaveDrivingRoute(
+    public DrivingRouteResponse fetchAndSaveRoute(
             Course course,
             List<Bakery> orderedBakeries,
             List<Integer> stayMinutesPerBakery,
-            int totalStayMinutes) {
+            int totalStayMinutes,
+            RouteMode mode) {
         Long courseId = course.getId();
 
-        List<Coordinate> bakeryCoordinates =
-                orderedBakeries.stream()
-                        .map(bakery -> new Coordinate(bakery.getLatitude(), bakery.getLongitude()))
-                        .toList();
-
-        List<Coordinate> coordinates;
-        if (course.getCourseType() == CourseType.AI) {
-            AiCourseInfo aiInfo = course.getAiCourseInfo();
-            if (aiInfo == null) {
-                log.error("AI 코스 출발 위치 없음: courseId={}", courseId);
-                throw new CustomException(ErrorCode.ROUTE_NOT_FOUND);
-            }
-            Coordinate startCoord = new Coordinate(aiInfo.getLatitude(), aiInfo.getLongitude());
-            coordinates = new ArrayList<>();
-            coordinates.add(startCoord);
-            coordinates.addAll(bakeryCoordinates);
-        } else {
-            coordinates = bakeryCoordinates;
-        }
+        List<Coordinate> coordinates = buildCoordinates(course, orderedBakeries);
 
         if (coordinates.size() < 2) {
             log.warn("경로 조회 실패 - 경유지 부족: courseId={}, count={}", courseId, coordinates.size());
             throw new CustomException(ErrorCode.ROUTE_INSUFFICIENT_WAYPOINTS);
         }
 
-        // Kakao Directions API: waypoints 최대 5개 (origin + destination 제외)
         if (coordinates.size() > 7) {
             log.warn("경로 조회 실패 - 경유지 초과: courseId={}, count={}", courseId, coordinates.size());
             throw new CustomException(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
         }
 
-        RouteResult result = drivingRouteClient.getPath(coordinates);
+        RouteResult result =
+                mode == RouteMode.WALKING
+                        ? walkingRouteClient.getPath(coordinates)
+                        : drivingRouteClient.getPath(coordinates);
+
         try {
-            courseDrivingRouteSaver.save(courseId, result);
+            courseDrivingRouteSaver.save(courseId, mode, result);
         } catch (DataIntegrityViolationException e) {
-            log.info("동시 경로 저장 충돌 무시 (이미 저장됨): courseId={}", courseId);
+            log.info("동시 경로 저장 충돌 무시 (이미 저장됨): courseId={}, mode={}", courseId, mode);
         }
 
         List<Integer> legs =
@@ -131,6 +123,27 @@ public class CourseDrivingRouteService {
                 .totalStayMinutes(totalStayMinutes)
                 .totalMinutes(totalTravelMinutes + totalStayMinutes)
                 .build();
+    }
+
+    private List<Coordinate> buildCoordinates(Course course, List<Bakery> orderedBakeries) {
+        List<Coordinate> bakeryCoordinates =
+                orderedBakeries.stream()
+                        .map(bakery -> new Coordinate(bakery.getLatitude(), bakery.getLongitude()))
+                        .toList();
+
+        if (course.getCourseType() == CourseType.AI) {
+            AiCourseInfo aiInfo = course.getAiCourseInfo();
+            if (aiInfo == null) {
+                log.error("AI 코스 출발 위치 없음: courseId={}", course.getId());
+                throw new CustomException(ErrorCode.ROUTE_NOT_FOUND);
+            }
+            List<Coordinate> coordinates = new ArrayList<>();
+            coordinates.add(new Coordinate(aiInfo.getLatitude(), aiInfo.getLongitude()));
+            coordinates.addAll(bakeryCoordinates);
+            return coordinates;
+        }
+
+        return bakeryCoordinates;
     }
 
     private DrivingRouteResponse buildResponseFromCache(

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseService.java
@@ -300,7 +300,7 @@ public class CourseService {
                                 course.addCourseBakery(courseBakery);
                             });
 
-            courseDrivingRouteRepository.deleteAllByCourseIdIn(List.of(courseId));
+            courseDrivingRouteRepository.deleteByIdCourseIdIn(List.of(courseId));
             log.info("코스 빵집 변경으로 경로 캐시 삭제: courseId={}", courseId);
         }
 
@@ -348,7 +348,7 @@ public class CourseService {
                         .findByIdAndActiveTrue(courseId)
                         .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
         course.deactivate();
-        courseDrivingRouteRepository.deleteAllByCourseIdIn(List.of(courseId));
+        courseDrivingRouteRepository.deleteByIdCourseIdIn(List.of(courseId));
         log.info("코스 삭제: courseId={}", courseId);
     }
 

--- a/apps/be/src/main/resources/application.yml
+++ b/apps/be/src/main/resources/application.yml
@@ -180,6 +180,11 @@ rate-limit:
 route:
   provider: kakao  # naver | kakao
 
+tmap:
+  app-key: ${TMAP_APP_KEY:}
+  base-url: https://apis.openapi.sk.com
+  timeout-seconds: ${TMAP_TIMEOUT_SECONDS:10}
+
 google:
   places:
     api-key: ${GOOGLE_PLACES_API_KEY}

--- a/apps/be/src/main/resources/db/migration/V26__add_route_mode_to_course_driving_route.sql
+++ b/apps/be/src/main/resources/db/migration/V26__add_route_mode_to_course_driving_route.sql
@@ -1,0 +1,8 @@
+ALTER TABLE course_driving_route
+    ADD COLUMN route_mode VARCHAR(20) NOT NULL DEFAULT 'DRIVING';
+
+ALTER TABLE course_driving_route
+    DROP CONSTRAINT course_driving_route_pkey;
+
+ALTER TABLE course_driving_route
+    ADD PRIMARY KEY (course_id, route_mode);

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -609,7 +609,7 @@ class BakeryServiceTest {
         bakeryService.updateBakery(20L, UserRole.ROLE_BUSINESS, 7L, request);
 
         verify(courseBakeryRepository).findCourseIdsByBakeryId(7L);
-        verify(courseDrivingRouteRepository).deleteAllByCourseIdIn(List.of(100L, 200L));
+        verify(courseDrivingRouteRepository).deleteByIdCourseIdIn(List.of(100L, 200L));
     }
 
     @Test
@@ -623,7 +623,7 @@ class BakeryServiceTest {
         bakeryService.updateBakery(20L, UserRole.ROLE_BUSINESS, 7L, request);
 
         verify(courseBakeryRepository, never()).findCourseIdsByBakeryId(any());
-        verify(courseDrivingRouteRepository, never()).deleteAllByCourseIdIn(any());
+        verify(courseDrivingRouteRepository, never()).deleteByIdCourseIdIn(any());
     }
 
     // ── validateSearch ──────────────────────────────────────────────────────
@@ -861,7 +861,7 @@ class BakeryServiceTest {
 
         bakeryService.hardDeleteBakery(303L);
 
-        verify(courseDrivingRouteRepository).deleteAllByCourseIdIn(List.of(10L));
+        verify(courseDrivingRouteRepository).deleteByIdCourseIdIn(List.of(10L));
         verify(courseBakeryRepository).deleteAllByBakeryId(303L);
         verify(breadRepository).deleteAllByBakeryId(303L);
         verify(crowdTimeRepository).deleteAllByBakeryId(303L);

--- a/apps/be/src/test/java/com/breadbread/course/service/AiCourseSaveServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/AiCourseSaveServiceTest.java
@@ -150,7 +150,7 @@ class AiCourseSaveServiceTest {
         aiCourseSaveService.deleteAi(2L, 5L);
 
         assertThat(course.isActive()).isFalse();
-        verify(courseDrivingRouteRepository).deleteAllByCourseIdIn(List.of(2L));
+        verify(courseDrivingRouteRepository).deleteByIdCourseIdIn(List.of(2L));
     }
 
     @Test

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
@@ -147,8 +147,8 @@ class CourseBakeryOrderServiceTest {
                         .totalStayMinutes(40)
                         .totalMinutes(50)
                         .build();
-        when(courseDrivingRouteService.fetchAndSaveDrivingRoute(
-                        any(Course.class), anyList(), anyList(), anyInt()))
+        when(courseDrivingRouteService.fetchAndSaveRoute(
+                        any(Course.class), anyList(), anyList(), anyInt(), any()))
                 .thenReturn(routeResponse);
 
         // 순서 뒤집기: [20, 10]
@@ -184,8 +184,8 @@ class CourseBakeryOrderServiceTest {
                         .totalStayMinutes(40)
                         .totalMinutes(50)
                         .build();
-        when(courseDrivingRouteService.fetchAndSaveDrivingRoute(
-                        any(Course.class), anyList(), anyList(), anyInt()))
+        when(courseDrivingRouteService.fetchAndSaveRoute(
+                        any(Course.class), anyList(), anyList(), anyInt(), any()))
                 .thenReturn(routeResponse);
 
         // 비활성 ID 999는 필터링 후 활성 [10, 20]과 일치 → 성공

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
@@ -163,7 +163,8 @@ class CourseDrivingRouteServiceTest {
                 .thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L, RouteMode.DRIVING);
+        DrivingRouteResponse response =
+                courseDrivingRouteService.getDrivingRoute(2L, RouteMode.DRIVING);
 
         assertThat(response.getPath()).isEqualTo(path);
         verify(drivingRouteClient).getPath(any());

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseDrivingRouteServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.enums.BreadType;
 import com.breadbread.course.client.DrivingRouteClient;
+import com.breadbread.course.client.WalkingRouteClient;
 import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.route.Coordinate;
 import com.breadbread.course.dto.route.RouteResult;
@@ -22,6 +23,7 @@ import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.entity.CourseDrivingRoute;
 import com.breadbread.course.entity.FlexibilityLevel;
 import com.breadbread.course.entity.ManualCourseInfo;
+import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.entity.TravelType;
 import com.breadbread.course.repository.CourseDrivingRouteRepository;
 import com.breadbread.course.repository.CourseRepository;
@@ -50,6 +52,7 @@ class CourseDrivingRouteServiceTest {
     @Mock private CourseDrivingRouteRepository courseDrivingRouteRepository;
     @Mock private CourseDrivingRouteSaver courseDrivingRouteSaver;
     @Mock private DrivingRouteClient drivingRouteClient;
+    @Mock private WalkingRouteClient walkingRouteClient;
 
     @InjectMocks private CourseDrivingRouteService courseDrivingRouteService;
 
@@ -57,7 +60,7 @@ class CourseDrivingRouteServiceTest {
     void getDrivingRoute_throws_whenCourseNotFound() {
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
@@ -69,12 +72,18 @@ class CourseDrivingRouteServiceTest {
         List<Coordinate> cachedPath =
                 List.of(new Coordinate(36.0, 127.0), new Coordinate(36.1, 127.1));
         CourseDrivingRoute cached =
-                CourseDrivingRoute.builder().courseId(1L).path(cachedPath).build();
+                CourseDrivingRoute.builder()
+                        .courseId(1L)
+                        .routeMode(RouteMode.DRIVING)
+                        .path(cachedPath)
+                        .build();
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.of(cached));
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.of(cached));
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
+        DrivingRouteResponse response =
+                courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING);
 
         assertThat(response.getPath()).isEqualTo(cachedPath);
         verify(drivingRouteClient, never()).getPath(any());
@@ -93,10 +102,12 @@ class CourseDrivingRouteServiceTest {
         RouteResult routeResult = new RouteResult(path, List.of(), 600);
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
+        DrivingRouteResponse response =
+                courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING);
 
         assertThat(response.getPath()).isEqualTo(path);
 
@@ -107,7 +118,7 @@ class CourseDrivingRouteServiceTest {
         assertThat(coords.get(0).getLat()).isEqualTo(36.0);
         assertThat(coords.get(0).getLng()).isEqualTo(127.0);
 
-        verify(courseDrivingRouteSaver).save(eq(1L), any(RouteResult.class));
+        verify(courseDrivingRouteSaver).save(eq(1L), eq(RouteMode.DRIVING), any(RouteResult.class));
     }
 
     @Test
@@ -122,10 +133,11 @@ class CourseDrivingRouteServiceTest {
         RouteResult routeResult = new RouteResult(path, List.of(), 600);
 
         when(courseRepository.findActiveWithBakeriesById(2L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(2L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        courseDrivingRouteService.getDrivingRoute(2L);
+        courseDrivingRouteService.getDrivingRoute(2L, RouteMode.DRIVING);
 
         ArgumentCaptor<List<Coordinate>> coordCaptor = ArgumentCaptor.forClass(List.class);
         verify(drivingRouteClient).getPath(coordCaptor.capture());
@@ -147,10 +159,11 @@ class CourseDrivingRouteServiceTest {
         RouteResult routeResult = new RouteResult(path, List.of(), 600);
 
         when(courseRepository.findActiveWithBakeriesById(2L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(2L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L);
+        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(2L, RouteMode.DRIVING);
 
         assertThat(response.getPath()).isEqualTo(path);
         verify(drivingRouteClient).getPath(any());
@@ -163,9 +176,10 @@ class CourseDrivingRouteServiceTest {
         course.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(bakery).build());
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_INSUFFICIENT_WAYPOINTS);
@@ -185,9 +199,10 @@ class CourseDrivingRouteServiceTest {
         }
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -208,9 +223,10 @@ class CourseDrivingRouteServiceTest {
         }
 
         when(courseRepository.findActiveWithBakeriesById(2L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(2L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(2L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(2L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(2L, RouteMode.DRIVING))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_TOO_MANY_WAYPOINTS);
@@ -227,9 +243,10 @@ class CourseDrivingRouteServiceTest {
         course.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(bakery).build());
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L))
+        assertThatThrownBy(() -> courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ROUTE_NOT_FOUND);
@@ -249,15 +266,43 @@ class CourseDrivingRouteServiceTest {
         RouteResult routeResult = new RouteResult(path, List.of(), 600);
 
         when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
-        when(courseDrivingRouteRepository.findById(1L)).thenReturn(Optional.empty());
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.DRIVING))
+                .thenReturn(Optional.empty());
         when(drivingRouteClient.getPath(any())).thenReturn(routeResult);
         doThrow(new DataIntegrityViolationException("dup"))
                 .when(courseDrivingRouteSaver)
-                .save(eq(1L), any(RouteResult.class));
+                .save(eq(1L), eq(RouteMode.DRIVING), any(RouteResult.class));
 
-        DrivingRouteResponse response = courseDrivingRouteService.getDrivingRoute(1L);
+        DrivingRouteResponse response =
+                courseDrivingRouteService.getDrivingRoute(1L, RouteMode.DRIVING);
 
         assertThat(response.getPath()).isEqualTo(path);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getDrivingRoute_walking_usesWalkingClient_andSavesWithWalkingMode() {
+        Course course = manualCourse(1L, "공유코스");
+        Bakery b1 = bakeryAt(10L, "A빵집", 36.0, 127.0);
+        Bakery b2 = bakeryAt(20L, "B빵집", 36.1, 127.1);
+        course.addCourseBakery(CourseBakery.builder().visitOrder(1).bakery(b1).build());
+        course.addCourseBakery(CourseBakery.builder().visitOrder(2).bakery(b2).build());
+
+        List<Coordinate> path = List.of(new Coordinate(36.0, 127.0), new Coordinate(36.1, 127.1));
+        RouteResult routeResult = new RouteResult(path, List.of(), 900);
+
+        when(courseRepository.findActiveWithBakeriesById(1L)).thenReturn(Optional.of(course));
+        when(courseDrivingRouteRepository.findByIdCourseIdAndIdRouteMode(1L, RouteMode.WALKING))
+                .thenReturn(Optional.empty());
+        when(walkingRouteClient.getPath(any())).thenReturn(routeResult);
+
+        DrivingRouteResponse response =
+                courseDrivingRouteService.getDrivingRoute(1L, RouteMode.WALKING);
+
+        assertThat(response.getPath()).isEqualTo(path);
+        verify(walkingRouteClient).getPath(any());
+        verify(drivingRouteClient, never()).getPath(any());
+        verify(courseDrivingRouteSaver).save(eq(1L), eq(RouteMode.WALKING), any(RouteResult.class));
     }
 
     // ── 헬퍼 ─────────────────────────────────────────────────────────────

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseServiceTest.java
@@ -279,7 +279,7 @@ class CourseServiceTest {
 
         assertThat(course.getCourseBakeries()).hasSize(1);
         assertThat(course.getCourseBakeries().get(0).getBakery().getId()).isEqualTo(30L);
-        verify(courseDrivingRouteRepository).deleteAllByCourseIdIn(List.of(3L));
+        verify(courseDrivingRouteRepository).deleteByIdCourseIdIn(List.of(3L));
     }
 
     @Test
@@ -510,7 +510,7 @@ class CourseServiceTest {
 
         courseService.updateManual(1L, request);
 
-        verify(courseDrivingRouteRepository, never()).deleteAllByCourseIdIn(any());
+        verify(courseDrivingRouteRepository, never()).deleteByIdCourseIdIn(any());
     }
 
     // ── findAllAiForAdmin ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Task
- TmapWalkingRouteClient 추가 (WalkingRouteClient 인터페이스 구현)
- GET /courses/{id}/directions?mode=DRIVING|WALKING 파라미터 추가
- CourseDrivingRoute PK를 (course_id, route_mode) 복합키로 변경
- 기존 데이터 DRIVING으로 마이그레이션 (V26)
- RouteMode enum 추가, 도보/자동차 캐시 독립 관리

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #312 
