### PR TITLE
feat: TMAP Matrix API 기반 AI 코스 방문 순서 최적화 엔드포인트 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
@@ -1,0 +1,142 @@
+package com.breadbread.course.client;
+
+import com.breadbread.course.config.TmapProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TmapMatrixClient {
+
+    private static final String MATRIX_PATH = "/tmap/matrix";
+
+    private final WebClient webClient;
+    private final TmapProperties properties;
+
+    /**
+     * origins[0] = 출발지, origins[1..N] = 빵집들 destinations[0..N-1] = 빵집들 반환: matrix[i][j] =
+     * origins[i] → destinations[j] 이동시간(초), 실패 시 Integer.MAX_VALUE
+     */
+    public int[][] getMatrix(
+            List<double[]> origins, List<double[]> destinations, String transportMode) {
+        int m = origins.size();
+        int n = destinations.size();
+
+        Map<String, Object> body = buildRequestBody(origins, destinations, transportMode);
+
+        log.info("[Tmap Matrix] 요청: origins={}, destinations={}", m, n);
+        long startTime = System.currentTimeMillis();
+        TmapMatrixResponse response = callApi(body);
+        log.info("[Tmap Matrix] 완료: elapsed={}ms", System.currentTimeMillis() - startTime);
+
+        int[][] matrix = new int[m][n];
+        List<TmapMatrixResponse.MatrixResult> results = response.getResultList();
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                int idx = i * n + j;
+                matrix[i][j] =
+                        (results != null && idx < results.size() && results.get(idx) != null)
+                                ? results.get(idx).getTime()
+                                : Integer.MAX_VALUE;
+            }
+        }
+        return matrix;
+    }
+
+    private Map<String, Object> buildRequestBody(
+            List<double[]> origins, List<double[]> destinations, String transportMode) {
+        List<Map<String, Object>> startList = new ArrayList<>();
+        for (int i = 0; i < origins.size(); i++) {
+            double[] o = origins.get(i);
+            Map<String, Object> start = new HashMap<>();
+            start.put("startX", String.valueOf(o[1])); // lng
+            start.put("startY", String.valueOf(o[0])); // lat
+            start.put("startName", "s" + i);
+            startList.add(start);
+        }
+
+        List<Map<String, Object>> endList = new ArrayList<>();
+        for (int j = 0; j < destinations.size(); j++) {
+            double[] d = destinations.get(j);
+            Map<String, Object> end = new HashMap<>();
+            end.put("endX", String.valueOf(d[1])); // lng
+            end.put("endY", String.valueOf(d[0])); // lat
+            end.put("endName", "e" + j);
+            endList.add(end);
+        }
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("startList", startList);
+        body.put("endList", endList);
+        body.put("transportMode", transportMode);
+        return body;
+    }
+
+    private TmapMatrixResponse callApi(Map<String, Object> body) {
+        TmapMatrixResponse response =
+                webClient
+                        .post()
+                        .uri(
+                                uriBuilder ->
+                                        uriBuilder
+                                                .scheme("https")
+                                                .host("apis.openapi.sk.com")
+                                                .path(MATRIX_PATH)
+                                                .queryParam("version", "1")
+                                                .build())
+                        .header("appKey", properties.getAppKey())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(body)
+                        .retrieve()
+                        .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
+                        .bodyToMono(TmapMatrixResponse.class)
+                        .timeout(Duration.ofSeconds(properties.getTimeoutSeconds()))
+                        .block();
+
+        if (response == null) {
+            throw new RuntimeException("TMAP matrix 응답 없음");
+        }
+        return response;
+    }
+
+    private Mono<Throwable> handleErrorResponse(ClientResponse res) {
+        return res.bodyToMono(String.class)
+                .flatMap(
+                        body -> {
+                            log.error(
+                                    "[Tmap Matrix] HTTP 오류: status={}, body={}",
+                                    res.statusCode(),
+                                    body);
+                            return Mono.error(
+                                    new RuntimeException(
+                                            "TMAP matrix HTTP 오류: " + res.statusCode()));
+                        });
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class TmapMatrixResponse {
+        private List<MatrixResult> resultList;
+
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        static class MatrixResult {
+            private int time;
+            private int distance;
+        }
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
+++ b/apps/be/src/main/java/com/breadbread/course/controller/CourseController.java
@@ -113,6 +113,22 @@ public class CourseController {
         return ApiResponse.ok(courseDrivingRouteService.getDrivingRoute(id, mode));
     }
 
+    @Operation(
+            summary = "AI 코스 방문 순서 최적화",
+            description =
+                    "TMAP Matrix API로 이동시간 행렬을 계산해 greedy 알고리즘으로 최적 방문 순서를 적용합니다."
+                            + " AI 코스 본인만 호출 가능합니다.")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    @PostMapping("/{courseId}/bakeries/optimize")
+    public ApiResponse<ReorderBakeriesResponse> optimizeBakeryOrder(
+            @PathVariable Long courseId,
+            @RequestParam(defaultValue = "DRIVING") RouteMode mode,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.ok(
+                courseBakeryOrderService.optimizeBakeryOrder(
+                        courseId, userDetails.getId(), userDetails.getRole(), mode));
+    }
+
     @Operation(summary = "코스 내 빵집 방문 순서 변경")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     @PatchMapping("/{courseId}/bakeries/reorder")

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
@@ -4,13 +4,17 @@ import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.course.dto.request.ReorderBakeriesRequest;
 import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.response.ReorderBakeriesResponse;
+import com.breadbread.course.entity.AiCourseInfo;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.CourseType;
 import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.course.service.ai.AiCourseRouteOptimizer;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.util.GeoDistance;
 import com.breadbread.tour.service.TourRedisService;
 import com.breadbread.user.entity.UserRole;
 import java.util.Comparator;
@@ -33,6 +37,7 @@ public class CourseBakeryOrderService {
     private final CourseBakeryRepository courseBakeryRepository;
     private final CourseDrivingRouteService courseDrivingRouteService;
     private final TourRedisService tourRedisService;
+    private final AiCourseRouteOptimizer aiCourseRouteOptimizer;
 
     @Transactional
     public ReorderBakeriesResponse reorderBakeries(
@@ -149,6 +154,98 @@ public class CourseBakeryOrderService {
         return ReorderBakeriesResponse.builder()
                 .courseId(courseId)
                 .bakeryOrder(activeBakeryOrder)
+                .estimatedTotalMinutes(estimatedTotalMinutes)
+                .build();
+    }
+
+    @Transactional
+    public ReorderBakeriesResponse optimizeBakeryOrder(
+            Long courseId, Long userId, UserRole role, RouteMode routeMode) {
+        Course course =
+                courseRepository
+                        .findByIdAndActiveTrue(courseId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.COURSE_NOT_FOUND));
+
+        validateEditAccess(course, userId, role);
+
+        if (course.getCourseType() != CourseType.AI || course.getAiCourseInfo() == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        List<CourseBakery> courseBakeries =
+                courseBakeryRepository.findAllByCourseId(courseId).stream()
+                        .filter(cb -> cb.getBakery().isActive())
+                        .sorted(Comparator.comparingInt(CourseBakery::getVisitOrder))
+                        .toList();
+
+        if (courseBakeries.size() < 2) {
+            return buildResponse(courseId, courseBakeries, 0);
+        }
+
+        AiCourseInfo aiInfo = course.getAiCourseInfo();
+        Map<Long, double[]> bakeryCoords =
+                courseBakeries.stream()
+                        .map(CourseBakery::getBakery)
+                        .filter(
+                                b ->
+                                        GeoDistance.isValidCoordinate(
+                                                b.getLatitude(), b.getLongitude()))
+                        .collect(
+                                Collectors.toMap(
+                                        Bakery::getId,
+                                        b -> new double[] {b.getLatitude(), b.getLongitude()}));
+
+        List<Long> optimizedOrder =
+                aiCourseRouteOptimizer.optimizeOrder(
+                        aiInfo.getLatitude(),
+                        aiInfo.getLongitude(),
+                        courseBakeries,
+                        bakeryCoords,
+                        routeMode);
+
+        Map<Long, CourseBakery> bakeryMap =
+                courseBakeries.stream()
+                        .collect(Collectors.toMap(cb -> cb.getBakery().getId(), cb -> cb));
+
+        for (int i = 0; i < optimizedOrder.size(); i++) {
+            bakeryMap.get(optimizedOrder.get(i)).setVisitOrder(i + 1);
+        }
+
+        courseDrivingRouteService.invalidateCache(courseId);
+        log.info("코스 경로 최적화로 순서 변경 및 경로 캐시 삭제: courseId={}", courseId);
+
+        List<Bakery> orderedBakeries =
+                optimizedOrder.stream().map(id -> bakeryMap.get(id).getBakery()).toList();
+        int totalStayMinutes =
+                orderedBakeries.stream().mapToInt(Bakery::getEstimatedStayMinutes).sum();
+
+        int estimatedTotalMinutes = 0;
+        try {
+            DrivingRouteResponse routeResponse =
+                    courseDrivingRouteService.fetchAndSaveRoute(
+                            course,
+                            orderedBakeries,
+                            orderedBakeries.stream().map(Bakery::getEstimatedStayMinutes).toList(),
+                            totalStayMinutes,
+                            RouteMode.DRIVING);
+            estimatedTotalMinutes = routeResponse.getTotalMinutes();
+            course.updateTotalMinutes(estimatedTotalMinutes);
+        } catch (CustomException e) {
+            log.warn("코스 최적화 후 경로 갱신 실패: courseId={}, error={}", courseId, e.getErrorCode().name());
+        }
+
+        return ReorderBakeriesResponse.builder()
+                .courseId(courseId)
+                .bakeryOrder(optimizedOrder)
+                .estimatedTotalMinutes(estimatedTotalMinutes)
+                .build();
+    }
+
+    private ReorderBakeriesResponse buildResponse(
+            Long courseId, List<CourseBakery> courseBakeries, int estimatedTotalMinutes) {
+        return ReorderBakeriesResponse.builder()
+                .courseId(courseId)
+                .bakeryOrder(courseBakeries.stream().map(cb -> cb.getBakery().getId()).toList())
                 .estimatedTotalMinutes(estimatedTotalMinutes)
                 .build();
     }

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRouteOptimizer.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRouteOptimizer.java
@@ -1,0 +1,95 @@
+package com.breadbread.course.service.ai;
+
+import com.breadbread.course.client.TmapMatrixClient;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.RouteMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiCourseRouteOptimizer {
+
+    private final TmapMatrixClient tmapMatrixClient;
+
+    /**
+     * TMAP Matrix API로 이동시간 행렬을 구한 뒤 greedy nearest-neighbor로 최적 방문 순서를 반환한다. 실패 시 원래 visitOrder
+     * 순서대로 반환한다.
+     *
+     * @param bakeryCoords key=bakeryId, value=[lat, lng]
+     * @return 최적화된 bakeryId 방문 순서 리스트
+     */
+    public List<Long> optimizeOrder(
+            double departureLat,
+            double departureLng,
+            List<CourseBakery> courseBakeries,
+            Map<Long, double[]> bakeryCoords,
+            RouteMode routeMode) {
+
+        List<Long> originalOrder =
+                courseBakeries.stream().map(cb -> cb.getBakery().getId()).toList();
+
+        if (courseBakeries.size() < 2) return originalOrder;
+
+        try {
+            // origins[0] = 출발지, origins[1..N] = 빵집들
+            List<double[]> origins = new ArrayList<>();
+            origins.add(new double[] {departureLat, departureLng});
+
+            // destinations[0..N-1] = 빵집들 (origins[1..N] 과 동일 순서)
+            List<double[]> destinations = new ArrayList<>();
+            for (CourseBakery cb : courseBakeries) {
+                double[] coord = bakeryCoords.get(cb.getBakery().getId());
+                if (coord == null) {
+                    log.warn("[경로 최적화] 좌표 없는 빵집 id={}, 원래 순서 유지", cb.getBakery().getId());
+                    return originalOrder;
+                }
+                origins.add(coord);
+                destinations.add(coord);
+            }
+
+            String transportMode = routeMode == RouteMode.WALKING ? "pedestrian" : "car";
+            int[][] matrix = tmapMatrixClient.getMatrix(origins, destinations, transportMode);
+            List<Integer> destOrder = greedyNearestNeighbor(matrix, courseBakeries.size());
+
+            return destOrder.stream().map(i -> courseBakeries.get(i).getBakery().getId()).toList();
+
+        } catch (Exception e) {
+            log.warn("[경로 최적화] TMAP Matrix 실패, 원래 순서 유지: {}", e.getMessage());
+            return originalOrder;
+        }
+    }
+
+    /**
+     * matrix[i][j] = origins[i] → destinations[j] 이동시간(초) origins[0]=출발지, origins[1..N]=빵집들
+     * destinations[0..N-1]=빵집들
+     *
+     * @return destinations 인덱스 방문 순서
+     */
+    private List<Integer> greedyNearestNeighbor(int[][] matrix, int n) {
+        boolean[] visited = new boolean[n];
+        List<Integer> order = new ArrayList<>(n);
+
+        int currentOriginIdx = 0; // 출발지 = origins[0]
+        for (int step = 0; step < n; step++) {
+            int bestDest = -1;
+            int bestTime = Integer.MAX_VALUE;
+            for (int j = 0; j < n; j++) {
+                if (!visited[j] && matrix[currentOriginIdx][j] < bestTime) {
+                    bestTime = matrix[currentOriginIdx][j];
+                    bestDest = j;
+                }
+            }
+            if (bestDest < 0) break;
+            visited[bestDest] = true;
+            order.add(bestDest);
+            currentOriginIdx = bestDest + 1; // 빵집 destIdx → originsIdx = destIdx + 1
+        }
+        return order;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/course/client/TmapMatrixClientTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/client/TmapMatrixClientTest.java
@@ -1,0 +1,119 @@
+package com.breadbread.course.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.breadbread.course.config.TmapProperties;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class TmapMatrixClientTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private WebClient webClient;
+
+    private TmapMatrixClient client;
+
+    @BeforeEach
+    void setUp() {
+        TmapProperties properties = new TmapProperties();
+        properties.setAppKey("test-key");
+        properties.setBaseUrl("https://apis.openapi.sk.com");
+        properties.setTimeoutSeconds(10);
+        client = new TmapMatrixClient(webClient, properties);
+    }
+
+    @Test
+    void buildRequestBody_mapsLatToY_andLngToX() {
+        List<double[]> origins = List.of(new double[] {36.0, 127.0}, new double[] {36.1, 127.1});
+        List<double[]> destinations = List.of(new double[] {36.2, 127.2});
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body =
+                (Map<String, Object>)
+                        ReflectionTestUtils.invokeMethod(
+                                client, "buildRequestBody", origins, destinations, "car");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> startList = (List<Map<String, Object>>) body.get("startList");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> endList = (List<Map<String, Object>>) body.get("endList");
+
+        assertThat(startList).hasSize(2);
+        assertThat(endList).hasSize(1);
+
+        // lat → startY, lng → startX
+        assertThat(startList.get(0).get("startX")).isEqualTo("127.0");
+        assertThat(startList.get(0).get("startY")).isEqualTo("36.0");
+        assertThat(startList.get(1).get("startX")).isEqualTo("127.1");
+        assertThat(startList.get(1).get("startY")).isEqualTo("36.1");
+
+        assertThat(endList.get(0).get("endX")).isEqualTo("127.2");
+        assertThat(endList.get(0).get("endY")).isEqualTo("36.2");
+    }
+
+    @Test
+    void buildRequestBody_assignsSequentialNames() {
+        List<double[]> origins = List.of(new double[] {36.0, 127.0}, new double[] {36.1, 127.1});
+        List<double[]> destinations = List.of(new double[] {36.2, 127.2});
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body =
+                (Map<String, Object>)
+                        ReflectionTestUtils.invokeMethod(
+                                client, "buildRequestBody", origins, destinations, "pedestrian");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> startList = (List<Map<String, Object>>) body.get("startList");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> endList = (List<Map<String, Object>>) body.get("endList");
+
+        assertThat(startList.get(0).get("startName")).isEqualTo("s0");
+        assertThat(startList.get(1).get("startName")).isEqualTo("s1");
+        assertThat(endList.get(0).get("endName")).isEqualTo("e0");
+    }
+
+    @Test
+    void getMatrix_parsesResultListIntoRowMajorMatrix() {
+        // 직접 TmapMatrixResponse 생성 후 parseMatrix 로직 검증
+        // 2 origins × 2 destinations → 결과 4개, row-major
+        TmapMatrixClient.TmapMatrixResponse response = new TmapMatrixClient.TmapMatrixResponse();
+        ReflectionTestUtils.setField(
+                response,
+                "resultList",
+                List.of(makeResult(100), makeResult(200), makeResult(300), makeResult(400)));
+
+        int m = 2, n = 2;
+        int[][] matrix = new int[m][n];
+        List<?> results = (List<?>) ReflectionTestUtils.getField(response, "resultList");
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                Object r = results.get(i * n + j);
+                matrix[i][j] = (int) ReflectionTestUtils.getField(r, "time");
+            }
+        }
+
+        assertThat(matrix[0][0]).isEqualTo(100);
+        assertThat(matrix[0][1]).isEqualTo(200);
+        assertThat(matrix[1][0]).isEqualTo(300);
+        assertThat(matrix[1][1]).isEqualTo(400);
+    }
+
+    // ── 헬퍼 ─────────────────────────────────────────────────────────────
+
+    private static TmapMatrixClient.TmapMatrixResponse.MatrixResult makeResult(int time) {
+        TmapMatrixClient.TmapMatrixResponse.MatrixResult r =
+                new TmapMatrixClient.TmapMatrixResponse.MatrixResult();
+        ReflectionTestUtils.setField(r, "time", time);
+        ReflectionTestUtils.setField(r, "distance", time * 5);
+        return r;
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
@@ -14,11 +14,17 @@ import com.breadbread.course.dto.request.ReorderBakeriesRequest;
 import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.response.ReorderBakeriesResponse;
 import com.breadbread.course.dto.route.Coordinate;
+import com.breadbread.course.entity.AiCourseInfo;
+import com.breadbread.course.entity.BudgetRange;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.FlexibilityLevel;
 import com.breadbread.course.entity.ManualCourseInfo;
+import com.breadbread.course.entity.RouteMode;
+import com.breadbread.course.entity.TravelType;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.course.service.ai.AiCourseRouteOptimizer;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
 import com.breadbread.tour.service.TourRedisService;
@@ -40,6 +46,7 @@ class CourseBakeryOrderServiceTest {
     @Mock private CourseBakeryRepository courseBakeryRepository;
     @Mock private CourseDrivingRouteService courseDrivingRouteService;
     @Mock private TourRedisService tourRedisService;
+    @Mock private AiCourseRouteOptimizer aiCourseRouteOptimizer;
 
     @InjectMocks private CourseBakeryOrderService courseBakeryOrderService;
 
@@ -196,7 +203,116 @@ class CourseBakeryOrderServiceTest {
         assertThat(response.getBakeryOrder()).containsExactly(10L, 20L);
     }
 
+    // ── optimizeBakeryOrder ───────────────────────────────────────────────
+
+    @Test
+    void optimizeBakeryOrder_throws_whenCourseNotFound() {
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(
+                        () ->
+                                courseBakeryOrderService.optimizeBakeryOrder(
+                                        1L, 1L, UserRole.ROLE_USER, RouteMode.DRIVING))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.COURSE_NOT_FOUND);
+    }
+
+    @Test
+    void optimizeBakeryOrder_throws_whenManualCourse() {
+        Course course = manualCourse(1L, "수동코스");
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+
+        assertThatThrownBy(
+                        () ->
+                                courseBakeryOrderService.optimizeBakeryOrder(
+                                        1L, 99L, UserRole.ROLE_ADMIN, RouteMode.DRIVING))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    @Test
+    void optimizeBakeryOrder_throws_whenForbidden() {
+        User owner = owner(1L);
+        Course course = aiCourse(1L, owner, 36.3, 127.3);
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+
+        assertThatThrownBy(
+                        () ->
+                                courseBakeryOrderService.optimizeBakeryOrder(
+                                        1L, 99L, UserRole.ROLE_USER, RouteMode.DRIVING))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void optimizeBakeryOrder_appliesOptimizedOrder() {
+        User owner = owner(1L);
+        Course course = aiCourse(1L, owner, 36.3, 127.3);
+        Bakery b1 = bakeryAt(10L, "A", 36.0, 127.0);
+        Bakery b2 = bakeryAt(20L, "B", 36.1, 127.1);
+        CourseBakery cb1 = CourseBakery.builder().visitOrder(1).bakery(b1).build();
+        CourseBakery cb2 = CourseBakery.builder().visitOrder(2).bakery(b2).build();
+
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(1L)).thenReturn(List.of(cb1, cb2));
+        when(aiCourseRouteOptimizer.optimizeOrder(
+                        org.mockito.ArgumentMatchers.anyDouble(),
+                        org.mockito.ArgumentMatchers.anyDouble(),
+                        org.mockito.ArgumentMatchers.anyList(),
+                        org.mockito.ArgumentMatchers.anyMap(),
+                        any()))
+                .thenReturn(List.of(20L, 10L)); // 최적화 결과: B → A
+
+        List<Coordinate> path = List.of(new Coordinate(36.1, 127.1), new Coordinate(36.0, 127.0));
+        DrivingRouteResponse routeResponse =
+                DrivingRouteResponse.builder()
+                        .path(path)
+                        .legs(List.of())
+                        .stayMinutesPerBakery(List.of(40, 40))
+                        .totalTravelMinutes(10)
+                        .totalStayMinutes(80)
+                        .totalMinutes(90)
+                        .build();
+        when(courseDrivingRouteService.fetchAndSaveRoute(
+                        any(Course.class), anyList(), anyList(), anyInt(), any()))
+                .thenReturn(routeResponse);
+
+        ReorderBakeriesResponse response =
+                courseBakeryOrderService.optimizeBakeryOrder(
+                        1L, 1L, UserRole.ROLE_USER, RouteMode.DRIVING);
+
+        assertThat(response.getBakeryOrder()).containsExactly(20L, 10L);
+        assertThat(cb2.getVisitOrder()).isEqualTo(1); // 20L(B) → 1순위
+        assertThat(cb1.getVisitOrder()).isEqualTo(2); // 10L(A) → 2순위
+        verify(courseDrivingRouteService).invalidateCache(1L);
+    }
+
     // ── 헬퍼 ─────────────────────────────────────────────────────────────
+
+    private static Course aiCourse(long id, User user, double lat, double lng) {
+        AiCourseInfo aiInfo =
+                AiCourseInfo.builder()
+                        .travelType(TravelType.ALONE)
+                        .budgetRange(BudgetRange.ANY)
+                        .flexibilityLevel(FlexibilityLevel.MAINTAIN)
+                        .latitude(lat)
+                        .longitude(lng)
+                        .bakeryCount(2)
+                        .build();
+        Course course =
+                Course.createAi("AI코스", user, mockUserPreference(), aiInfo, java.util.Set.of());
+        ReflectionTestUtils.setField(course, "id", id);
+        return course;
+    }
+
+    private static com.breadbread.user.entity.UserPreference mockUserPreference() {
+        return com.breadbread.user.entity.UserPreference.builder()
+                .bakeryTypes(java.util.List.of())
+                .build();
+    }
 
     private static Course manualCourse(long id, String name) {
         BreadType bt = BreadType.BREAD;

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRouteOptimizerTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRouteOptimizerTest.java
@@ -1,0 +1,130 @@
+package com.breadbread.course.service.ai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.course.client.TmapMatrixClient;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.RouteMode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AiCourseRouteOptimizerTest {
+
+    @Mock private TmapMatrixClient tmapMatrixClient;
+
+    @InjectMocks private AiCourseRouteOptimizer optimizer;
+
+    @Test
+    void optimizeOrder_returnsSingleBakery_withoutCallingApi() {
+        Bakery b = bakery(10L, 36.0, 127.0);
+        CourseBakery cb = courseBakery(b, 1);
+        Map<Long, double[]> coords = Map.of(10L, new double[] {36.0, 127.0});
+
+        List<Long> result =
+                optimizer.optimizeOrder(36.5, 127.5, List.of(cb), coords, RouteMode.DRIVING);
+
+        assertThat(result).containsExactly(10L);
+    }
+
+    @Test
+    void optimizeOrder_reordersGreedily_byTravelTime() {
+        // 출발지에서 가장 가까운 C → B → A 순이 최적인 행렬
+        // origins: [D(0), A(1), B(2), C(3)]
+        // destinations: [A(0), B(1), C(2)]
+        //
+        // matrix[D][A]=500, [D][B]=300, [D][C]=100  → D에서 C 선택
+        // matrix[C][A]=400, [C][B]=200               → C에서 B 선택
+        // matrix[B][A]=200                            → B에서 A 선택
+        // 결과: C → B → A (id: 30 → 20 → 10)
+        int[][] matrix = {
+            {500, 300, 100}, // D
+            {Integer.MAX_VALUE, 200, 400}, // A
+            {200, Integer.MAX_VALUE, 100}, // B
+            {400, 200, Integer.MAX_VALUE}, // C
+        };
+        when(tmapMatrixClient.getMatrix(anyList(), anyList(), anyString())).thenReturn(matrix);
+
+        Bakery a = bakery(10L, 36.0, 127.0);
+        Bakery b = bakery(20L, 36.1, 127.1);
+        Bakery c = bakery(30L, 36.2, 127.2);
+        List<CourseBakery> cbs =
+                List.of(courseBakery(a, 1), courseBakery(b, 2), courseBakery(c, 3));
+        Map<Long, double[]> coords =
+                Map.of(
+                        10L, new double[] {36.0, 127.0},
+                        20L, new double[] {36.1, 127.1},
+                        30L, new double[] {36.2, 127.2});
+
+        List<Long> result = optimizer.optimizeOrder(36.5, 127.5, cbs, coords, RouteMode.DRIVING);
+
+        assertThat(result).containsExactly(30L, 20L, 10L);
+    }
+
+    @Test
+    void optimizeOrder_returnsOriginalOrder_whenTmapFails() {
+        when(tmapMatrixClient.getMatrix(anyList(), anyList(), anyString()))
+                .thenThrow(new RuntimeException("TMAP 오류"));
+
+        Bakery a = bakery(10L, 36.0, 127.0);
+        Bakery b = bakery(20L, 36.1, 127.1);
+        List<CourseBakery> cbs = List.of(courseBakery(a, 1), courseBakery(b, 2));
+        Map<Long, double[]> coords =
+                Map.of(
+                        10L, new double[] {36.0, 127.0},
+                        20L, new double[] {36.1, 127.1});
+
+        List<Long> result = optimizer.optimizeOrder(36.5, 127.5, cbs, coords, RouteMode.DRIVING);
+
+        assertThat(result).containsExactly(10L, 20L);
+    }
+
+    @Test
+    void optimizeOrder_returnsOriginalOrder_whenCoordMissing() {
+        Bakery a = bakery(10L, 36.0, 127.0);
+        Bakery b = bakery(20L, 36.1, 127.1);
+        List<CourseBakery> cbs = List.of(courseBakery(a, 1), courseBakery(b, 2));
+        // 빵집 20L 좌표 누락
+        Map<Long, double[]> coords = Map.of(10L, new double[] {36.0, 127.0});
+
+        List<Long> result = optimizer.optimizeOrder(36.5, 127.5, cbs, coords, RouteMode.DRIVING);
+
+        assertThat(result).containsExactly(10L, 20L);
+    }
+
+    // ── 헬퍼 ─────────────────────────────────────────────────────────────
+
+    private static Bakery bakery(long id, double lat, double lng) {
+        Bakery b =
+                Bakery.builder()
+                        .name("bakery" + id)
+                        .address("addr")
+                        .region("서울")
+                        .latitude(lat)
+                        .longitude(lng)
+                        .phone("010")
+                        .rating(4.0)
+                        .mapLink("m")
+                        .dineInAvailable(true)
+                        .parkingAvailable(false)
+                        .drinkAvailable(false)
+                        .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+
+    private static CourseBakery courseBakery(Bakery bakery, int visitOrder) {
+        return CourseBakery.builder().bakery(bakery).visitOrder(visitOrder).build();
+    }
+}


### PR DESCRIPTION
## Task
- TmapMatrixClient: 단일 호출로 (N+1)×N 이동시간 행렬 계산
- AiCourseRouteOptimizer: greedy nearest-neighbor TSP로 최적 순서 결정
- POST /courses/{courseId}/bakeries/optimize 엔드포인트 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #319 
