### PR TITLE
fix: TMAP Matrix API 요청/응답 형식 오류 수정 및 안정성 개선

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
@@ -43,45 +43,30 @@ public class TmapMatrixClient {
         TmapMatrixResponse response = callApi(body);
         log.info("[Tmap Matrix] 완료: elapsed={}ms", System.currentTimeMillis() - startTime);
 
-        int[][] matrix = new int[m][n];
-        List<TmapMatrixResponse.MatrixResult> results = response.getResultList();
-        for (int i = 0; i < m; i++) {
-            for (int j = 0; j < n; j++) {
-                int idx = i * n + j;
-                matrix[i][j] =
-                        (results != null && idx < results.size() && results.get(idx) != null)
-                                ? results.get(idx).getTime()
-                                : Integer.MAX_VALUE;
-            }
-        }
-        return matrix;
+        return parseMatrix(response, m, n);
     }
 
     private Map<String, Object> buildRequestBody(
             List<double[]> origins, List<double[]> destinations, String transportMode) {
-        List<Map<String, Object>> startList = new ArrayList<>();
-        for (int i = 0; i < origins.size(); i++) {
-            double[] o = origins.get(i);
-            Map<String, Object> start = new HashMap<>();
-            start.put("startX", String.valueOf(o[1])); // lng
-            start.put("startY", String.valueOf(o[0])); // lat
-            start.put("startName", "s" + i);
-            startList.add(start);
+        List<Map<String, Object>> originList = new ArrayList<>();
+        for (double[] o : origins) {
+            Map<String, Object> point = new HashMap<>();
+            point.put("lon", String.valueOf(o[1])); // lng
+            point.put("lat", String.valueOf(o[0])); // lat
+            originList.add(point);
         }
 
-        List<Map<String, Object>> endList = new ArrayList<>();
-        for (int j = 0; j < destinations.size(); j++) {
-            double[] d = destinations.get(j);
-            Map<String, Object> end = new HashMap<>();
-            end.put("endX", String.valueOf(d[1])); // lng
-            end.put("endY", String.valueOf(d[0])); // lat
-            end.put("endName", "e" + j);
-            endList.add(end);
+        List<Map<String, Object>> destinationList = new ArrayList<>();
+        for (double[] d : destinations) {
+            Map<String, Object> point = new HashMap<>();
+            point.put("lon", String.valueOf(d[1])); // lng
+            point.put("lat", String.valueOf(d[0])); // lat
+            destinationList.add(point);
         }
 
         Map<String, Object> body = new HashMap<>();
-        body.put("startList", startList);
-        body.put("endList", endList);
+        body.put("origins", originList);
+        body.put("destinations", destinationList);
         body.put("transportMode", transportMode);
         return body;
     }
@@ -90,14 +75,7 @@ public class TmapMatrixClient {
         TmapMatrixResponse response =
                 webClient
                         .post()
-                        .uri(
-                                uriBuilder ->
-                                        uriBuilder
-                                                .scheme("https")
-                                                .host("apis.openapi.sk.com")
-                                                .path(MATRIX_PATH)
-                                                .queryParam("version", "1")
-                                                .build())
+                        .uri(properties.getBaseUrl() + MATRIX_PATH + "?version=1")
                         .header("appKey", properties.getAppKey())
                         .contentType(MediaType.APPLICATION_JSON)
                         .bodyValue(body)
@@ -111,6 +89,26 @@ public class TmapMatrixClient {
             throw new RuntimeException("TMAP matrix 응답 없음");
         }
         return response;
+    }
+
+    int[][] parseMatrix(TmapMatrixResponse response, int m, int n) {
+        int[][] matrix = new int[m][n];
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                matrix[i][j] = Integer.MAX_VALUE;
+            }
+        }
+        List<TmapMatrixResponse.MatrixRoute> routes = response.getMatrixRoutes();
+        if (routes != null) {
+            for (TmapMatrixResponse.MatrixRoute r : routes) {
+                int oi = r.getOriginIndex();
+                int di = r.getDestinationIndex();
+                if (oi >= 0 && oi < m && di >= 0 && di < n) {
+                    matrix[oi][di] = r.getDuration();
+                }
+            }
+        }
+        return matrix;
     }
 
     private Mono<Throwable> handleErrorResponse(ClientResponse res) {
@@ -130,13 +128,15 @@ public class TmapMatrixClient {
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class TmapMatrixResponse {
-        private List<MatrixResult> resultList;
+        private List<MatrixRoute> matrixRoutes;
 
         @Getter
         @JsonIgnoreProperties(ignoreUnknown = true)
-        static class MatrixResult {
-            private int time;
-            private int distance;
+        static class MatrixRoute {
+            private int originIndex;
+            private int destinationIndex;
+            private int duration;
+            private double distance;
         }
     }
 }

--- a/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryOrderService.java
@@ -268,7 +268,7 @@ public class CourseBakeryOrderService {
                             orderedBakeries,
                             orderedBakeries.stream().map(Bakery::getEstimatedStayMinutes).toList(),
                             totalStayMinutes,
-                            RouteMode.DRIVING);
+                            routeMode);
             estimatedTotalMinutes = routeResponse.getTotalMinutes();
             course.updateTotalMinutes(estimatedTotalMinutes);
         } catch (CustomException e) {

--- a/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRouteOptimizer.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/ai/AiCourseRouteOptimizer.java
@@ -85,7 +85,13 @@ public class AiCourseRouteOptimizer {
                     bestDest = j;
                 }
             }
-            if (bestDest < 0) break;
+            if (bestDest < 0) {
+                // 일부 구간 누락으로 다음 목적지를 못 찾은 경우 — 미방문 빵집을 원래 순서대로 append
+                for (int j = 0; j < n; j++) {
+                    if (!visited[j]) order.add(j);
+                }
+                break;
+            }
             visited[bestDest] = true;
             order.add(bestDest);
             currentOriginIdx = bestDest + 1; // 빵집 destIdx → originsIdx = destIdx + 1

--- a/apps/be/src/test/java/com/breadbread/course/client/TmapMatrixClientTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/client/TmapMatrixClientTest.java
@@ -43,26 +43,26 @@ class TmapMatrixClientTest {
                                 client, "buildRequestBody", origins, destinations, "car");
 
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> startList = (List<Map<String, Object>>) body.get("startList");
+        List<Map<String, Object>> originList = (List<Map<String, Object>>) body.get("origins");
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> endList = (List<Map<String, Object>>) body.get("endList");
+        List<Map<String, Object>> destinationList =
+                (List<Map<String, Object>>) body.get("destinations");
 
-        assertThat(startList).hasSize(2);
-        assertThat(endList).hasSize(1);
+        assertThat(originList).hasSize(2);
+        assertThat(destinationList).hasSize(1);
 
-        // lat → startY, lng → startX
-        assertThat(startList.get(0).get("startX")).isEqualTo("127.0");
-        assertThat(startList.get(0).get("startY")).isEqualTo("36.0");
-        assertThat(startList.get(1).get("startX")).isEqualTo("127.1");
-        assertThat(startList.get(1).get("startY")).isEqualTo("36.1");
+        assertThat(originList.get(0).get("lon")).isEqualTo("127.0");
+        assertThat(originList.get(0).get("lat")).isEqualTo("36.0");
+        assertThat(originList.get(1).get("lon")).isEqualTo("127.1");
+        assertThat(originList.get(1).get("lat")).isEqualTo("36.1");
 
-        assertThat(endList.get(0).get("endX")).isEqualTo("127.2");
-        assertThat(endList.get(0).get("endY")).isEqualTo("36.2");
+        assertThat(destinationList.get(0).get("lon")).isEqualTo("127.2");
+        assertThat(destinationList.get(0).get("lat")).isEqualTo("36.2");
     }
 
     @Test
-    void buildRequestBody_assignsSequentialNames() {
-        List<double[]> origins = List.of(new double[] {36.0, 127.0}, new double[] {36.1, 127.1});
+    void buildRequestBody_setsTransportMode() {
+        List<double[]> origins = List.of(new double[] {36.0, 127.0});
         List<double[]> destinations = List.of(new double[] {36.2, 127.2});
 
         @SuppressWarnings("unchecked")
@@ -71,35 +71,22 @@ class TmapMatrixClientTest {
                         ReflectionTestUtils.invokeMethod(
                                 client, "buildRequestBody", origins, destinations, "pedestrian");
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> startList = (List<Map<String, Object>>) body.get("startList");
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> endList = (List<Map<String, Object>>) body.get("endList");
-
-        assertThat(startList.get(0).get("startName")).isEqualTo("s0");
-        assertThat(startList.get(1).get("startName")).isEqualTo("s1");
-        assertThat(endList.get(0).get("endName")).isEqualTo("e0");
+        assertThat(body.get("transportMode")).isEqualTo("pedestrian");
     }
 
     @Test
-    void getMatrix_parsesResultListIntoRowMajorMatrix() {
-        // 직접 TmapMatrixResponse 생성 후 parseMatrix 로직 검증
-        // 2 origins × 2 destinations → 결과 4개, row-major
+    void parseMatrix_placesDurationByOriginAndDestinationIndex() {
         TmapMatrixClient.TmapMatrixResponse response = new TmapMatrixClient.TmapMatrixResponse();
         ReflectionTestUtils.setField(
                 response,
-                "resultList",
-                List.of(makeResult(100), makeResult(200), makeResult(300), makeResult(400)));
+                "matrixRoutes",
+                List.of(
+                        makeRoute(0, 0, 100),
+                        makeRoute(0, 1, 200),
+                        makeRoute(1, 0, 300),
+                        makeRoute(1, 1, 400)));
 
-        int m = 2, n = 2;
-        int[][] matrix = new int[m][n];
-        List<?> results = (List<?>) ReflectionTestUtils.getField(response, "resultList");
-        for (int i = 0; i < m; i++) {
-            for (int j = 0; j < n; j++) {
-                Object r = results.get(i * n + j);
-                matrix[i][j] = (int) ReflectionTestUtils.getField(r, "time");
-            }
-        }
+        int[][] matrix = client.parseMatrix(response, 2, 2);
 
         assertThat(matrix[0][0]).isEqualTo(100);
         assertThat(matrix[0][1]).isEqualTo(200);
@@ -107,13 +94,29 @@ class TmapMatrixClientTest {
         assertThat(matrix[1][1]).isEqualTo(400);
     }
 
+    @Test
+    void parseMatrix_fillsMaxValueForMissingRoutes() {
+        TmapMatrixClient.TmapMatrixResponse response = new TmapMatrixClient.TmapMatrixResponse();
+        ReflectionTestUtils.setField(response, "matrixRoutes", List.of(makeRoute(0, 0, 500)));
+
+        int[][] matrix = client.parseMatrix(response, 2, 2);
+
+        assertThat(matrix[0][0]).isEqualTo(500);
+        assertThat(matrix[0][1]).isEqualTo(Integer.MAX_VALUE);
+        assertThat(matrix[1][0]).isEqualTo(Integer.MAX_VALUE);
+        assertThat(matrix[1][1]).isEqualTo(Integer.MAX_VALUE);
+    }
+
     // ── 헬퍼 ─────────────────────────────────────────────────────────────
 
-    private static TmapMatrixClient.TmapMatrixResponse.MatrixResult makeResult(int time) {
-        TmapMatrixClient.TmapMatrixResponse.MatrixResult r =
-                new TmapMatrixClient.TmapMatrixResponse.MatrixResult();
-        ReflectionTestUtils.setField(r, "time", time);
-        ReflectionTestUtils.setField(r, "distance", time * 5);
+    private static TmapMatrixClient.TmapMatrixResponse.MatrixRoute makeRoute(
+            int originIndex, int destinationIndex, int duration) {
+        TmapMatrixClient.TmapMatrixResponse.MatrixRoute r =
+                new TmapMatrixClient.TmapMatrixResponse.MatrixRoute();
+        ReflectionTestUtils.setField(r, "originIndex", originIndex);
+        ReflectionTestUtils.setField(r, "destinationIndex", destinationIndex);
+        ReflectionTestUtils.setField(r, "duration", duration);
+        ReflectionTestUtils.setField(r, "distance", (double) duration * 5);
         return r;
     }
 }

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryOrderServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -288,6 +289,46 @@ class CourseBakeryOrderServiceTest {
         assertThat(cb2.getVisitOrder()).isEqualTo(1); // 20L(B) → 1순위
         assertThat(cb1.getVisitOrder()).isEqualTo(2); // 10L(A) → 2순위
         verify(courseDrivingRouteService).invalidateCache(1L);
+    }
+
+    @Test
+    void optimizeBakeryOrder_passesRouteModeToFetchAndSaveRoute() {
+        User owner = owner(1L);
+        Course course = aiCourse(1L, owner, 36.3, 127.3);
+        Bakery b1 = bakeryAt(10L, "A", 36.0, 127.0);
+        Bakery b2 = bakeryAt(20L, "B", 36.1, 127.1);
+        CourseBakery cb1 = CourseBakery.builder().visitOrder(1).bakery(b1).build();
+        CourseBakery cb2 = CourseBakery.builder().visitOrder(2).bakery(b2).build();
+
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(1L)).thenReturn(List.of(cb1, cb2));
+        when(aiCourseRouteOptimizer.optimizeOrder(
+                        org.mockito.ArgumentMatchers.anyDouble(),
+                        org.mockito.ArgumentMatchers.anyDouble(),
+                        org.mockito.ArgumentMatchers.anyList(),
+                        org.mockito.ArgumentMatchers.anyMap(),
+                        any()))
+                .thenReturn(List.of(20L, 10L));
+
+        List<Coordinate> path = List.of(new Coordinate(36.1, 127.1), new Coordinate(36.0, 127.0));
+        DrivingRouteResponse routeResponse =
+                DrivingRouteResponse.builder()
+                        .path(path)
+                        .legs(List.of())
+                        .stayMinutesPerBakery(List.of(40, 40))
+                        .totalTravelMinutes(10)
+                        .totalStayMinutes(80)
+                        .totalMinutes(90)
+                        .build();
+        when(courseDrivingRouteService.fetchAndSaveRoute(
+                        any(Course.class), anyList(), anyList(), anyInt(), any()))
+                .thenReturn(routeResponse);
+
+        courseBakeryOrderService.optimizeBakeryOrder(1L, 1L, UserRole.ROLE_USER, RouteMode.WALKING);
+
+        verify(courseDrivingRouteService)
+                .fetchAndSaveRoute(
+                        any(Course.class), anyList(), anyList(), anyInt(), eq(RouteMode.WALKING));
     }
 
     // ── 헬퍼 ─────────────────────────────────────────────────────────────

--- a/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRouteOptimizerTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/ai/AiCourseRouteOptimizerTest.java
@@ -72,6 +72,37 @@ class AiCourseRouteOptimizerTest {
     }
 
     @Test
+    void optimizeOrder_appendsRemainingBakeries_whenSomeRoutesAreMissing() {
+        // D→A=100(최소), D→B=MAX, D→C=MAX → A 선택 후 A→B, A→C 모두 MAX → break
+        // break 시 미방문(B, C)를 원래 순서대로 append → A, B, C 전체 포함
+        int max = Integer.MAX_VALUE;
+        int[][] matrix = {
+            {100, max, max}, // D
+            {max, max, max}, // A
+            {max, max, max}, // B
+            {max, max, max}, // C
+        };
+        when(tmapMatrixClient.getMatrix(anyList(), anyList(), anyString())).thenReturn(matrix);
+
+        Bakery a = bakery(10L, 36.0, 127.0);
+        Bakery b = bakery(20L, 36.1, 127.1);
+        Bakery c = bakery(30L, 36.2, 127.2);
+        List<CourseBakery> cbs =
+                List.of(courseBakery(a, 1), courseBakery(b, 2), courseBakery(c, 3));
+        Map<Long, double[]> coords =
+                Map.of(
+                        10L, new double[] {36.0, 127.0},
+                        20L, new double[] {36.1, 127.1},
+                        30L, new double[] {36.2, 127.2});
+
+        List<Long> result = optimizer.optimizeOrder(36.5, 127.5, cbs, coords, RouteMode.DRIVING);
+
+        assertThat(result).containsExactlyInAnyOrder(10L, 20L, 30L);
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualTo(10L); // A가 첫 번째
+    }
+
+    @Test
     void optimizeOrder_returnsOriginalOrder_whenTmapFails() {
         when(tmapMatrixClient.getMatrix(anyList(), anyList(), anyString()))
                 .thenThrow(new RuntimeException("TMAP 오류"));


### PR DESCRIPTION
## Task
- 요청 필드명 수정: startList/endList → origins/destinations, 좌표값 문자열로 변경
- 응답 파싱 수정: resultList → matrixRoutes, time → duration, index 기반 배치
- greedy 구간 누락 시 미방문 빵집 원래 순서로 append (누락 방지)
- 경로 재계산 시 RouteMode 하드코딩 제거, 요청 mode 그대로 전달
- baseUrl 하드코딩 제거, TmapProperties.baseUrl 사용

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
