### PR TITLE
fix: excludeBakery REQUIRES_NEW 데드락 제거 및 대체 빵집 에러 코드 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryMutationService.java
+++ b/apps/be/src/main/java/com/breadbread/course/service/CourseBakeryMutationService.java
@@ -4,11 +4,9 @@ import com.breadbread.bakery.dto.request.BakerySearch;
 import com.breadbread.bakery.entity.Bakery;
 import com.breadbread.bakery.entity.enums.BakeryStatus;
 import com.breadbread.bakery.repository.BakeryRepository;
-import com.breadbread.course.dto.response.DrivingRouteResponse;
 import com.breadbread.course.dto.response.ModifyCourseBakeryResponse;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
-import com.breadbread.course.entity.RouteMode;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
@@ -69,7 +67,7 @@ public class CourseBakeryMutationService {
                         .toList();
         renumberVisitOrders(remaining);
 
-        return buildResponse(course, courseId, target.getBakery().getId(), targetName, null, null);
+        return buildResponse(courseId, target.getBakery().getId(), targetName, null, null);
     }
 
     @Transactional
@@ -99,7 +97,6 @@ public class CourseBakeryMutationService {
         target.replaceBakery(replacement);
 
         return buildResponse(
-                course,
                 courseId,
                 targetBakery.getId(),
                 targetBakery.getName(),
@@ -130,7 +127,6 @@ public class CourseBakeryMutationService {
     }
 
     private ModifyCourseBakeryResponse buildResponse(
-            Course course,
             Long courseId,
             Long targetBakeryId,
             String targetBakeryName,
@@ -144,33 +140,12 @@ public class CourseBakeryMutationService {
                         .sorted(Comparator.comparingInt(CourseBakery::getVisitOrder))
                         .toList();
 
-        List<Bakery> orderedBakeries = ordered.stream().map(CourseBakery::getBakery).toList();
-        List<Long> bakeryOrder = orderedBakeries.stream().map(Bakery::getId).toList();
-        int totalStayMinutes =
-                orderedBakeries.stream().mapToInt(Bakery::getEstimatedStayMinutes).sum();
-
-        int estimatedTotalMinutes = 0;
-        try {
-            DrivingRouteResponse routeResponse =
-                    courseDrivingRouteService.fetchAndSaveRoute(
-                            course,
-                            orderedBakeries,
-                            orderedBakeries.stream().map(Bakery::getEstimatedStayMinutes).toList(),
-                            totalStayMinutes,
-                            RouteMode.DRIVING);
-            estimatedTotalMinutes = routeResponse.getTotalMinutes();
-            course.updateTotalMinutes(estimatedTotalMinutes);
-        } catch (CustomException e) {
-            log.warn(
-                    "코스 빵집 변경 후 경로 갱신 실패: courseId={}, error={}",
-                    courseId,
-                    e.getErrorCode().name());
-        }
+        List<Long> bakeryOrder = ordered.stream().map(cb -> cb.getBakery().getId()).toList();
 
         return ModifyCourseBakeryResponse.builder()
                 .courseId(courseId)
                 .bakeryOrder(bakeryOrder)
-                .estimatedTotalMinutes(estimatedTotalMinutes)
+                .estimatedTotalMinutes(0)
                 .targetBakeryId(targetBakeryId)
                 .targetBakeryName(targetBakeryName)
                 .replacementBakeryId(replacementBakeryId)
@@ -226,7 +201,7 @@ public class CourseBakeryMutationService {
 
         return candidates.stream()
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.BAKERY_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_REPLACEMENT_BAKERY_FOUND));
     }
 
     private boolean isClosedToday(Bakery bakery) {

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "E0313", "선택한 candidateId가 검색 결과에 존재하지 않습니다."),
     BAKERY_IMPORT_SEARCH_FAILED(
             HttpStatus.BAD_GATEWAY, "E0314", "외부 검색 API 호출에 실패했습니다. 잠시 후 다시 시도해주세요."),
+    NO_REPLACEMENT_BAKERY_FOUND(HttpStatus.NOT_FOUND, "E0315", "대체할 유사 빵집이 존재하지 않습니다."),
 
     // 코스/AI추천 E04xx
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E0401", "존재하지 않는 코스입니다."),

--- a/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryMutationServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/course/service/CourseBakeryMutationServiceTest.java
@@ -1,0 +1,144 @@
+package com.breadbread.course.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.repository.BakeryRepository;
+import com.breadbread.course.entity.AiCourseInfo;
+import com.breadbread.course.entity.BudgetRange;
+import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
+import com.breadbread.course.entity.FlexibilityLevel;
+import com.breadbread.course.entity.TravelType;
+import com.breadbread.course.repository.CourseBakeryRepository;
+import com.breadbread.course.repository.CourseRepository;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.user.entity.User;
+import com.breadbread.user.entity.UserRole;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CourseBakeryMutationServiceTest {
+
+    @Mock private CourseRepository courseRepository;
+    @Mock private CourseBakeryRepository courseBakeryRepository;
+    @Mock private BakeryRepository bakeryRepository;
+    @Mock private CourseDrivingRouteService courseDrivingRouteService;
+
+    @InjectMocks private CourseBakeryMutationService service;
+
+    @Test
+    void excludeBakery_doesNotCallFetchAndSaveRoute() {
+        User owner = owner(1L);
+        Course course = aiCourse(1L, owner);
+
+        Bakery bakeryA = bakery(10L, "A");
+        Bakery bakeryB = bakery(20L, "B");
+        CourseBakery cbA =
+                CourseBakery.builder().visitOrder(1).course(course).bakery(bakeryA).build();
+        CourseBakery cbB =
+                CourseBakery.builder().visitOrder(2).course(course).bakery(bakeryB).build();
+        course.getCourseBakeries().add(cbA);
+        course.getCourseBakeries().add(cbB);
+
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(1L))
+                .thenReturn(List.of(cbA, cbB))
+                .thenReturn(List.of(cbB));
+
+        service.excludeBakery(1L, 1L, UserRole.ROLE_USER, 10L);
+
+        verify(courseDrivingRouteService).invalidateCache(1L);
+        verify(courseDrivingRouteService, never())
+                .fetchAndSaveRoute(any(), any(), any(), anyInt(), any());
+    }
+
+    @Test
+    void replaceBakery_autoSuggest_throwsNoReplacementBakeryFound_whenNoCandidates() {
+        User owner = owner(1L);
+        Course course = aiCourse(1L, owner);
+
+        Bakery target = bakery(10L, "Target");
+        CourseBakery cb =
+                CourseBakery.builder().visitOrder(1).course(course).bakery(target).build();
+        course.getCourseBakeries().add(cb);
+
+        when(courseRepository.findByIdAndActiveTrue(1L)).thenReturn(Optional.of(course));
+        when(courseBakeryRepository.findAllByCourseId(1L)).thenReturn(List.of(cb));
+        when(bakeryRepository.search(any(), any())).thenReturn(new PageImpl<>(List.of()));
+
+        assertThatThrownBy(() -> service.replaceBakery(1L, 1L, UserRole.ROLE_USER, 10L, null))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NO_REPLACEMENT_BAKERY_FOUND);
+    }
+
+    private static User owner(long id) {
+        User u =
+                User.builder()
+                        .loginId("u" + id)
+                        .password("p")
+                        .name("n")
+                        .nickname("nick" + id)
+                        .email(id + "@e.com")
+                        .phone("010" + id)
+                        .role(UserRole.ROLE_USER)
+                        .termsAgreed(true)
+                        .privacyAgreed(true)
+                        .build();
+        ReflectionTestUtils.setField(u, "id", id);
+        return u;
+    }
+
+    private static Course aiCourse(long id, User user) {
+        AiCourseInfo aiInfo =
+                AiCourseInfo.builder()
+                        .travelType(TravelType.ALONE)
+                        .budgetRange(BudgetRange.ANY)
+                        .flexibilityLevel(FlexibilityLevel.MAINTAIN)
+                        .latitude(37.5)
+                        .longitude(127.0)
+                        .bakeryCount(2)
+                        .build();
+        com.breadbread.user.entity.UserPreference pref =
+                com.breadbread.user.entity.UserPreference.builder().bakeryTypes(List.of()).build();
+        Course course = Course.createAi("AI코스", user, pref, aiInfo, Set.of());
+        ReflectionTestUtils.setField(course, "id", id);
+        return course;
+    }
+
+    private static Bakery bakery(long id, String name) {
+        Bakery b =
+                Bakery.builder()
+                        .name(name)
+                        .address("addr")
+                        .region("서울")
+                        .latitude(37.5)
+                        .longitude(127.0)
+                        .phone("010")
+                        .rating(4.0)
+                        .mapLink("m")
+                        .dineInAvailable(true)
+                        .parkingAvailable(false)
+                        .drinkAvailable(true)
+                        .note("")
+                        .build();
+        ReflectionTestUtils.setField(b, "id", id);
+        return b;
+    }
+}


### PR DESCRIPTION
## Task
- excludeBakery에서 REQUIRES_NEW 데드락으로 인한 504 수정
  → buildResponse에서 fetchAndSaveRoute 제거, 경로는 다음 조회 시 재계산
- 대체 빵집 자동 추천 실패 시 에러 메시지 변경
  → BAKERY_NOT_FOUND → NO_REPLACEMENT_BAKERY_FOUND (E0315)

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
