### PR TITLE
feat: 투어 시작 시 영업시간 검증 및 외부 API 재시도 로직 추가

### DIFF
--- a/apps/be/build.gradle
+++ b/apps/be/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// Retry (외부 API 일시 장애 재시도)
+	implementation 'org.springframework.retry:spring-retry'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
+++ b/apps/be/src/main/java/com/breadbread/BreadbreadApplication.java
@@ -4,11 +4,13 @@ import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableRetry
 @EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
 public class BreadbreadApplication {
 

--- a/apps/be/src/main/java/com/breadbread/ai/client/AiChatWebhookClient.java
+++ b/apps/be/src/main/java/com/breadbread/ai/client/AiChatWebhookClient.java
@@ -5,12 +5,15 @@ import com.breadbread.ai.dto.AiChatWebhookRequest;
 import com.breadbread.global.config.AiProperties;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -24,6 +27,10 @@ public class AiChatWebhookClient {
     private final ObjectMapper objectMapper;
     private final AiProperties aiProperties;
 
+    @Retryable(
+            retryFor = TransientApiException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 300, multiplier = 2))
     public AiChatResponse requestChat(AiChatWebhookRequest request) {
         log.info(
                 "[AI 채팅 웹훅] 요청 시작: messageLength={}",
@@ -46,6 +53,13 @@ public class AiChatWebhookClient {
                                     res -> {
                                         log.error(
                                                 "[AI 채팅 웹훅] HTTP 오류: status={}", res.statusCode());
+                                        if (res.statusCode().is5xxServerError()) {
+                                            return Mono.error(
+                                                    new TransientApiException(
+                                                            ErrorCode.AI_WEBHOOK_HTTP_ERROR,
+                                                            "AI 채팅 웹훅 서버 오류: " + res.statusCode(),
+                                                            null));
+                                        }
                                         return Mono.error(
                                                 new CustomException(
                                                         ErrorCode.AI_WEBHOOK_HTTP_ERROR));
@@ -60,7 +74,7 @@ public class AiChatWebhookClient {
             }
             return rawBody;
 
-        } catch (CustomException e) {
+        } catch (CustomException | TransientApiException e) {
             throw e;
         } catch (Exception e) {
             long elapsed = System.currentTimeMillis() - start;
@@ -70,10 +84,11 @@ public class AiChatWebhookClient {
                         "[AI 채팅 웹훅] 타임아웃: elapsed={}ms, timeout={}s",
                         elapsed,
                         aiProperties.getWebhookTimeoutSeconds());
-                throw new CustomException(ErrorCode.AI_WEBHOOK_TIMEOUT);
+                throw new TransientApiException(ErrorCode.AI_WEBHOOK_TIMEOUT, "AI 채팅 웹훅 타임아웃", e);
             }
-            log.error("[AI 채팅 웹훅] 호출 실패: elapsed={}ms", elapsed, e);
-            throw new CustomException(ErrorCode.AI_WEBHOOK_CONNECTION_ERROR);
+            log.error("[AI 채팅 웹훅] 호출 실패: elapsed={}ms, error={}", elapsed, e.toString());
+            throw new TransientApiException(
+                    ErrorCode.AI_WEBHOOK_CONNECTION_ERROR, "AI 채팅 웹훅 호출 실패", e);
         }
     }
 

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
@@ -36,6 +36,13 @@ public class BusinessHours {
         this.lastOrderTime = lastOrderTime;
     }
 
+    /** 해당 요일 타입(평일/주말)의 open/close 시간이 둘 다 설정돼 있는지. 미설정(영업시간 미정)인 경우 false. */
+    public boolean hasDefinedHours(DayOfWeek day) {
+        LocalTime open = isWeekend(day) ? weekendOpen : weekdayOpen;
+        LocalTime close = isWeekend(day) ? weekendClose : weekdayClose;
+        return open != null && close != null;
+    }
+
     public boolean isOpenNow(LocalTime now, DayOfWeek today, Set<DayOfWeek> closedDays) {
         // 정기 휴무일 체크
         if (closedDays != null && closedDays.contains(today)) {

--- a/apps/be/src/main/java/com/breadbread/course/client/KakaoDrivingRouteClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/KakaoDrivingRouteClient.java
@@ -5,6 +5,7 @@ import com.breadbread.course.dto.route.Coordinate;
 import com.breadbread.course.dto.route.RouteResult;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -14,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -30,6 +34,10 @@ public class KakaoDrivingRouteClient implements DrivingRouteClient {
     private final KakaoMobilityProperties properties;
 
     @Override
+    @Retryable(
+            retryFor = TransientApiException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 300, multiplier = 2))
     public RouteResult getPath(List<Coordinate> coordinates) {
         Coordinate origin = coordinates.get(0);
         Coordinate destination = coordinates.get(coordinates.size() - 1);
@@ -77,42 +85,48 @@ public class KakaoDrivingRouteClient implements DrivingRouteClient {
                             .uri(URI.create(url))
                             .header("Authorization", "KakaoAK " + properties.getAppKey())
                             .retrieve()
-                            .onStatus(
-                                    HttpStatusCode::isError,
-                                    res ->
-                                            res.bodyToMono(String.class)
-                                                    .flatMap(
-                                                            body -> {
-                                                                log.error(
-                                                                        "[Kakao 경로] HTTP 오류: status={}, body={}",
-                                                                        res.statusCode(),
-                                                                        body);
-                                                                return Mono.error(
-                                                                        new CustomException(
-                                                                                ErrorCode
-                                                                                        .ROUTE_PROVIDER_ERROR));
-                                                            }))
+                            .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
                             .bodyToMono(KakaoDirectionsResponse.class)
                             .timeout(Duration.ofSeconds(properties.getTimeoutSeconds()))
                             .block();
 
             if (response == null) {
                 log.error("[Kakao 경로] 응답 body 없음");
-                throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+                throw new TransientApiException(
+                        ErrorCode.ROUTE_PROVIDER_ERROR, "Kakao 경로 응답 body 없음", null);
             }
             return response;
 
-        } catch (CustomException e) {
+        } catch (CustomException | TransientApiException e) {
             throw e;
         } catch (Exception e) {
             if (reactor.core.Exceptions.unwrap(e)
                     instanceof java.util.concurrent.TimeoutException) {
                 log.error("[Kakao 경로] 타임아웃: timeoutSeconds={}", properties.getTimeoutSeconds());
-            } else {
-                log.error("[Kakao 경로] API 호출 실패", e);
+                throw new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "Kakao 경로 타임아웃", e);
             }
-            throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+            log.error("[Kakao 경로] API 호출 실패: {}", e.toString());
+            throw new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "Kakao 경로 호출 실패", e);
         }
+    }
+
+    private Mono<Throwable> handleErrorResponse(ClientResponse res) {
+        return res.bodyToMono(String.class)
+                .flatMap(
+                        body -> {
+                            log.error(
+                                    "[Kakao 경로] HTTP 오류: status={}, body={}",
+                                    res.statusCode(),
+                                    body);
+                            if (res.statusCode().is5xxServerError()) {
+                                return Mono.error(
+                                        new TransientApiException(
+                                                ErrorCode.ROUTE_PROVIDER_ERROR,
+                                                "Kakao 경로 서버 오류: " + res.statusCode(),
+                                                null));
+                            }
+                            return Mono.error(new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR));
+                        });
     }
 
     private RouteResult toRouteResult(KakaoDirectionsResponse response, Coordinate destination) {

--- a/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/TmapMatrixClient.java
@@ -1,6 +1,9 @@
 package com.breadbread.course.client;
 
 import com.breadbread.course.config.TmapProperties;
+import com.breadbread.global.exception.CustomException;
+import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -12,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -31,6 +36,10 @@ public class TmapMatrixClient {
      * origins[0] = 출발지, origins[1..N] = 빵집들 destinations[0..N-1] = 빵집들 반환: matrix[i][j] =
      * origins[i] → destinations[j] 이동시간(초), 실패 시 Integer.MAX_VALUE
      */
+    @Retryable(
+            retryFor = TransientApiException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 300, multiplier = 2))
     public int[][] getMatrix(
             List<double[]> origins, List<double[]> destinations, String transportMode) {
         int m = origins.size();
@@ -72,23 +81,39 @@ public class TmapMatrixClient {
     }
 
     private TmapMatrixResponse callApi(Map<String, Object> body) {
-        TmapMatrixResponse response =
-                webClient
-                        .post()
-                        .uri(properties.getBaseUrl() + MATRIX_PATH + "?version=1")
-                        .header("appKey", properties.getAppKey())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .bodyValue(body)
-                        .retrieve()
-                        .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
-                        .bodyToMono(TmapMatrixResponse.class)
-                        .timeout(Duration.ofSeconds(properties.getTimeoutSeconds()))
-                        .block();
+        try {
+            TmapMatrixResponse response =
+                    webClient
+                            .post()
+                            .uri(properties.getBaseUrl() + MATRIX_PATH + "?version=1")
+                            .header("appKey", properties.getAppKey())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(body)
+                            .retrieve()
+                            .onStatus(HttpStatusCode::isError, this::handleErrorResponse)
+                            .bodyToMono(TmapMatrixResponse.class)
+                            .timeout(Duration.ofSeconds(properties.getTimeoutSeconds()))
+                            .block();
 
-        if (response == null) {
-            throw new RuntimeException("TMAP matrix 응답 없음");
+            if (response == null) {
+                log.error("[Tmap Matrix] 응답 body 없음");
+                throw new TransientApiException(
+                        ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap Matrix 응답 body 없음", null);
+            }
+            return response;
+
+        } catch (CustomException | TransientApiException e) {
+            throw e;
+        } catch (Exception e) {
+            if (reactor.core.Exceptions.unwrap(e)
+                    instanceof java.util.concurrent.TimeoutException) {
+                log.error("[Tmap Matrix] 타임아웃: timeoutSeconds={}", properties.getTimeoutSeconds());
+                throw new TransientApiException(
+                        ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap Matrix 타임아웃", e);
+            }
+            log.error("[Tmap Matrix] API 호출 실패: {}", e.toString());
+            throw new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap Matrix 호출 실패", e);
         }
-        return response;
     }
 
     int[][] parseMatrix(TmapMatrixResponse response, int m, int n) {
@@ -119,9 +144,14 @@ public class TmapMatrixClient {
                                     "[Tmap Matrix] HTTP 오류: status={}, body={}",
                                     res.statusCode(),
                                     body);
-                            return Mono.error(
-                                    new RuntimeException(
-                                            "TMAP matrix HTTP 오류: " + res.statusCode()));
+                            if (res.statusCode().is5xxServerError()) {
+                                return Mono.error(
+                                        new TransientApiException(
+                                                ErrorCode.ROUTE_PROVIDER_ERROR,
+                                                "Tmap Matrix 서버 오류: " + res.statusCode(),
+                                                null));
+                            }
+                            return Mono.error(new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR));
                         });
     }
 

--- a/apps/be/src/main/java/com/breadbread/course/client/TmapWalkingRouteClient.java
+++ b/apps/be/src/main/java/com/breadbread/course/client/TmapWalkingRouteClient.java
@@ -5,6 +5,7 @@ import com.breadbread.course.dto.route.Coordinate;
 import com.breadbread.course.dto.route.RouteResult;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Duration;
@@ -18,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -34,6 +37,10 @@ public class TmapWalkingRouteClient implements WalkingRouteClient {
     private final TmapProperties properties;
 
     @Override
+    @Retryable(
+            retryFor = TransientApiException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 300, multiplier = 2))
     public RouteResult getPath(List<Coordinate> coordinates) {
         Coordinate start = coordinates.get(0);
         Coordinate end = coordinates.get(coordinates.size() - 1);
@@ -81,14 +88,7 @@ public class TmapWalkingRouteClient implements WalkingRouteClient {
             TmapRouteResponse response =
                     webClient
                             .post()
-                            .uri(
-                                    uriBuilder ->
-                                            uriBuilder
-                                                    .scheme("https")
-                                                    .host("apis.openapi.sk.com")
-                                                    .path(PEDESTRIAN_PATH)
-                                                    .queryParam("version", "1")
-                                                    .build())
+                            .uri(properties.getBaseUrl() + PEDESTRIAN_PATH + "?version=1")
                             .header("appKey", properties.getAppKey())
                             .contentType(MediaType.APPLICATION_JSON)
                             .bodyValue(body)
@@ -100,20 +100,21 @@ public class TmapWalkingRouteClient implements WalkingRouteClient {
 
             if (response == null) {
                 log.error("[Tmap 경로] 응답 body 없음");
-                throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+                throw new TransientApiException(
+                        ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap 경로 응답 body 없음", null);
             }
             return response;
 
-        } catch (CustomException e) {
+        } catch (CustomException | TransientApiException e) {
             throw e;
         } catch (Exception e) {
             if (reactor.core.Exceptions.unwrap(e)
                     instanceof java.util.concurrent.TimeoutException) {
                 log.error("[Tmap 경로] 타임아웃: timeoutSeconds={}", properties.getTimeoutSeconds());
-            } else {
-                log.error("[Tmap 경로] API 호출 실패", e);
+                throw new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap 경로 타임아웃", e);
             }
-            throw new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR);
+            log.error("[Tmap 경로] API 호출 실패: {}", e.toString());
+            throw new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "Tmap 경로 호출 실패", e);
         }
     }
 
@@ -125,6 +126,13 @@ public class TmapWalkingRouteClient implements WalkingRouteClient {
                                     "[Tmap 경로] HTTP 오류: status={}, body={}",
                                     res.statusCode(),
                                     body);
+                            if (res.statusCode().is5xxServerError()) {
+                                return Mono.error(
+                                        new TransientApiException(
+                                                ErrorCode.ROUTE_PROVIDER_ERROR,
+                                                "Tmap 경로 서버 오류: " + res.statusCode(),
+                                                null));
+                            }
                             return Mono.error(new CustomException(ErrorCode.ROUTE_PROVIDER_ERROR));
                         });
     }

--- a/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/ErrorCode.java
@@ -146,6 +146,7 @@ public enum ErrorCode {
     TOUR_ALREADY_STARTED(HttpStatus.CONFLICT, "E0902", "이미 시작된 투어가 있습니다."),
     TOUR_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "E0903", "이미 완료된 투어입니다."),
     TOUR_INVALID_VISIT_ORDER(HttpStatus.BAD_REQUEST, "E0904", "유효하지 않은 방문 순서입니다."),
+    TOUR_BAKERY_CLOSED(HttpStatus.BAD_REQUEST, "E0905", "현재 영업 중이지 않은 빵집이 포함되어 있어 투어를 시작할 수 없습니다."),
 
     // 혼잡도 E10xx
     CONGESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "E1001", "혼잡도 데이터가 없습니다.");

--- a/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.breadbread.global.exception;
 
 import com.breadbread.global.dto.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -21,16 +23,47 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @Slf4j
 public class GlobalExceptionHandler {
 
+    /**
+     * 외부 API 실패로 인한 5xx 에러코드. 원인(HTTP 상태/body)은 클라이언트 쪽에서 이미 로깅했으므로, 여기서는 스택트레이스 없이 메시지만 남긴다. 진짜 내부
+     * 버그로 인한 5xx(INTERNAL_SERVER_ERROR 등)는 별도로 트레이스를 유지한다.
+     */
+    private static final Set<ErrorCode> EXTERNAL_API_ERROR_CODES =
+            EnumSet.of(
+                    ErrorCode.BAKERY_IMPORT_SEARCH_FAILED,
+                    ErrorCode.ROUTE_PROVIDER_ERROR,
+                    ErrorCode.AI_SERVER_ERROR,
+                    ErrorCode.AI_WEBHOOK_HTTP_ERROR,
+                    ErrorCode.AI_WEBHOOK_TIMEOUT,
+                    ErrorCode.AI_WEBHOOK_CONNECTION_ERROR,
+                    ErrorCode.AI_WEBHOOK_EMPTY_RESPONSE);
+
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
         MDC.put("errorCode", errorCode.getCode());
         try {
-            if (errorCode.getStatus().is5xxServerError()) {
+            if (errorCode.getStatus().is5xxServerError()
+                    && !EXTERNAL_API_ERROR_CODES.contains(errorCode)) {
                 log.error("[{}] {}", errorCode.getCode(), e.getMessage(), e);
             } else {
                 log.warn("[{}] {}", errorCode.getCode(), e.getMessage());
             }
+        } finally {
+            MDC.remove("errorCode");
+        }
+        return ResponseEntity.status(errorCode.getStatus()).body(ApiResponse.fail(errorCode));
+    }
+
+    /**
+     * 재시도 대상 예외라 클라이언트 쪽 callApi가 시도마다 이미 트레이스를 남겼으므로, 여기서는 트레이스 없이 메시지만 남긴다(외부 API 문제라는 게 정의상
+     * 확실하므로 별도 코드 목록으로 분기할 필요가 없다).
+     */
+    @ExceptionHandler(TransientApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTransientApiException(TransientApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        MDC.put("errorCode", errorCode.getCode());
+        try {
+            log.error("[{}] 재시도 소진: {}", errorCode.getCode(), e.getMessage());
         } finally {
             MDC.remove("errorCode");
         }

--- a/apps/be/src/main/java/com/breadbread/global/exception/TransientApiException.java
+++ b/apps/be/src/main/java/com/breadbread/global/exception/TransientApiException.java
@@ -1,0 +1,20 @@
+package com.breadbread.global.exception;
+
+import lombok.Getter;
+
+/**
+ * 외부 API의 일시적 장애(타임아웃, 연결 실패, 5xx)를 나타내는 예외. {@code @Retryable}이 재시도 대상으로 잡을 수 있도록 CustomException과
+ * 분리했다. {@code @Recover}는 쓰지 않는다 — 재시도 대상이 아닌 예외까지 recovery를 타면서 매칭되는 핸들러가 없으면
+ * ExhaustedRetryException으로 감싸버리는 문제가 있어서, 재시도 소진 시 원본 예외가 그대로 전파되도록 두고 {@link
+ * GlobalExceptionHandler}에서 errorCode 기준으로 응답을 만든다.
+ */
+@Getter
+public class TransientApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public TransientApiException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/apps/be/src/main/java/com/breadbread/tour/client/CongestionInstantCheckClient.java
+++ b/apps/be/src/main/java/com/breadbread/tour/client/CongestionInstantCheckClient.java
@@ -3,6 +3,7 @@ package com.breadbread.tour.client;
 import com.breadbread.global.config.AiProperties;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import com.breadbread.tour.dto.CongestionInstantCheckResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -24,6 +27,10 @@ public class CongestionInstantCheckClient {
     private final ObjectMapper objectMapper;
     private final AiProperties aiProperties;
 
+    @Retryable(
+            retryFor = TransientApiException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 300, multiplier = 2))
     public CongestionInstantCheckResponse check(Map<String, Object> requestBody) {
         Object userId = requestBody.get("userId");
         Object courseId = requestBody.get("courseId");
@@ -45,6 +52,13 @@ public class CongestionInstantCheckClient {
                                                 "[혼잡도 즉시 체크] HTTP 오류: userId={}, status={}",
                                                 userId,
                                                 res.statusCode());
+                                        if (res.statusCode().is5xxServerError()) {
+                                            return Mono.error(
+                                                    new TransientApiException(
+                                                            ErrorCode.AI_WEBHOOK_HTTP_ERROR,
+                                                            "혼잡도 웹훅 서버 오류: " + res.statusCode(),
+                                                            null));
+                                        }
                                         return Mono.error(
                                                 new CustomException(
                                                         ErrorCode.AI_WEBHOOK_HTTP_ERROR));
@@ -52,7 +66,7 @@ public class CongestionInstantCheckClient {
                             .bodyToMono(String.class)
                             .timeout(Duration.ofSeconds(aiProperties.getWebhookTimeoutSeconds()))
                             .block();
-        } catch (CustomException e) {
+        } catch (CustomException | TransientApiException e) {
             throw e;
         } catch (Exception e) {
             long elapsed = System.currentTimeMillis() - start;
@@ -63,10 +77,15 @@ public class CongestionInstantCheckClient {
                         userId,
                         elapsed,
                         aiProperties.getWebhookTimeoutSeconds());
-                throw new CustomException(ErrorCode.AI_WEBHOOK_TIMEOUT);
+                throw new TransientApiException(ErrorCode.AI_WEBHOOK_TIMEOUT, "혼잡도 웹훅 타임아웃", e);
             }
-            log.error("[혼잡도 즉시 체크] 호출 실패: userId={}, elapsed={}ms", userId, elapsed, e);
-            throw new CustomException(ErrorCode.AI_WEBHOOK_CONNECTION_ERROR);
+            log.error(
+                    "[혼잡도 즉시 체크] 호출 실패: userId={}, elapsed={}ms, error={}",
+                    userId,
+                    elapsed,
+                    e.toString());
+            throw new TransientApiException(
+                    ErrorCode.AI_WEBHOOK_CONNECTION_ERROR, "혼잡도 웹훅 호출 실패", e);
         }
 
         if (rawBody == null || rawBody.isBlank()) {

--- a/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
+++ b/apps/be/src/main/java/com/breadbread/tour/service/TourService.java
@@ -1,6 +1,7 @@
 package com.breadbread.tour.service;
 
 import com.breadbread.course.entity.Course;
+import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.repository.CourseBakeryRepository;
 import com.breadbread.course.repository.CourseRepository;
 import com.breadbread.global.exception.CustomException;
@@ -19,9 +20,13 @@ import com.breadbread.tour.redis.TourStatus;
 import com.breadbread.user.entity.User;
 import com.breadbread.user.entity.UserRole;
 import com.breadbread.user.repository.UserRepository;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,19 +63,40 @@ public class TourService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
-        int totalBakeryCount = courseBakeryRepository.findAllByCourseId(courseId).size();
+        List<CourseBakery> courseBakeries =
+                courseBakeryRepository.findAllByCourseIdWithBakery(courseId);
+        int totalBakeryCount = courseBakeries.size();
 
         if (totalBakeryCount == 0) {
             throw new CustomException(ErrorCode.COURSE_BAKERY_REQUIRED);
         }
 
+        ZonedDateTime nowSeoul = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalTime nowTime = nowSeoul.toLocalTime();
+        DayOfWeek today = nowSeoul.getDayOfWeek();
+
+        // 영업시간이 미설정(카카오/구글 임포트 데이터 등)인 빵집은 "닫힘"이 아니라 "모름"으로 보고 검증 대상에서 제외
+        boolean hasClosed =
+                courseBakeries.stream()
+                        .map(CourseBakery::getBakery)
+                        .filter(bakery -> bakery.getBusinessHours() != null)
+                        .filter(bakery -> bakery.getBusinessHours().hasDefinedHours(today))
+                        .anyMatch(
+                                bakery ->
+                                        !bakery.getBusinessHours()
+                                                .isOpenNow(nowTime, today, bakery.getClosedDays()));
+
+        if (hasClosed) {
+            throw new CustomException(ErrorCode.TOUR_BAKERY_CLOSED);
+        }
+
         // Redis 먼저 성공해야 예약 상태 전환 (실패 시 DB 롤백으로 상태 보존)
         TourStateCache state = tourRedisService.startTour(userId, course.getId(), totalBakeryCount);
 
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate departureDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
         reservationRepository
                 .findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
-                        userId, courseId, today, ReservationStatus.CONFIRMED)
+                        userId, courseId, departureDate, ReservationStatus.CONFIRMED)
                 .ifPresent(Reservation::startTour);
 
         return TourStartResponse.from(state);

--- a/apps/be/src/test/java/com/breadbread/global/exception/GlobalExceptionHandlerTest.java
+++ b/apps/be/src/test/java/com/breadbread/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,24 @@
+package com.breadbread.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.breadbread.global.dto.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleTransientApiException_maps_toErrorCodeStatusAndBody() {
+        TransientApiException e =
+                new TransientApiException(ErrorCode.ROUTE_PROVIDER_ERROR, "재시도 소진", null);
+
+        ResponseEntity<ApiResponse<Void>> response = handler.handleTransientApiException(e);
+
+        assertThat(response.getStatusCode()).isEqualTo(ErrorCode.ROUTE_PROVIDER_ERROR.getStatus());
+        assertThat(response.getBody().getError().getCode())
+                .isEqualTo(ErrorCode.ROUTE_PROVIDER_ERROR.getCode());
+    }
+}

--- a/apps/be/src/test/java/com/breadbread/tour/client/CongestionInstantCheckClientTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/client/CongestionInstantCheckClientTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.breadbread.global.config.AiProperties;
 import com.breadbread.global.exception.CustomException;
 import com.breadbread.global.exception.ErrorCode;
+import com.breadbread.global.exception.TransientApiException;
 import com.breadbread.tour.dto.CongestionInstantCheckResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -147,7 +148,9 @@ class CongestionInstantCheckClientTest {
     }
 
     @Test
-    void check_throws_TIMEOUT_whenTimeoutException() {
+    void check_throws_TransientApiException_TIMEOUT_whenTimeoutException() {
+        // @Retryable은 Spring AOP 프록시로 동작하므로, 프록시 없이 직접 생성한 인스턴스에서는
+        // 재시도 없이 원본 TransientApiException이 그대로 던져진다(변환은 GlobalExceptionHandler가 담당).
         when(webClient
                         .post()
                         .uri(any(String.class))
@@ -163,13 +166,13 @@ class CongestionInstantCheckClientTest {
                                 new java.util.concurrent.TimeoutException()));
 
         assertThatThrownBy(() -> client.check(Map.of("userId", 1L, "courseId", 10L)))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(TransientApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_WEBHOOK_TIMEOUT);
     }
 
     @Test
-    void check_throws_CONNECTION_ERROR_whenOtherException() {
+    void check_throws_TransientApiException_CONNECTION_ERROR_whenOtherException() {
         when(webClient
                         .post()
                         .uri(any(String.class))
@@ -183,7 +186,7 @@ class CongestionInstantCheckClientTest {
                 .thenThrow(new RuntimeException("connection refused"));
 
         assertThatThrownBy(() -> client.check(Map.of("userId", 1L, "courseId", 10L)))
-                .isInstanceOf(CustomException.class)
+                .isInstanceOf(TransientApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AI_WEBHOOK_CONNECTION_ERROR);
     }

--- a/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/tour/service/TourServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BusinessHours;
 import com.breadbread.course.entity.Course;
 import com.breadbread.course.entity.CourseBakery;
 import com.breadbread.course.repository.CourseBakeryRepository;
@@ -108,12 +110,9 @@ class TourServiceTest {
         TourStateCache state = tourState(1L, 10L, 3, 0, TourStatus.IN_PROGRESS);
         when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
         when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
-        when(courseBakeryRepository.findAllByCourseId(10L))
-                .thenReturn(
-                        List.of(
-                                mock(CourseBakery.class),
-                                mock(CourseBakery.class),
-                                mock(CourseBakery.class)));
+        List<CourseBakery> courseBakeries =
+                List.of(openCourseBakery(), openCourseBakery(), openCourseBakery());
+        when(courseBakeryRepository.findAllByCourseIdWithBakery(10L)).thenReturn(courseBakeries);
         when(tourRedisService.startTour(1L, 10L, 3)).thenReturn(state);
         when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
                         eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
@@ -131,8 +130,8 @@ class TourServiceTest {
         TourStateCache state = tourState(5L, 10L, 2, 0, TourStatus.IN_PROGRESS);
         when(tourRedisService.hasActiveTour(5L)).thenReturn(false);
         when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
-        when(courseBakeryRepository.findAllByCourseId(10L))
-                .thenReturn(List.of(mock(CourseBakery.class), mock(CourseBakery.class)));
+        List<CourseBakery> courseBakeries = List.of(openCourseBakery(), openCourseBakery());
+        when(courseBakeryRepository.findAllByCourseIdWithBakery(10L)).thenReturn(courseBakeries);
         when(tourRedisService.startTour(5L, 10L, 2)).thenReturn(state);
         when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
                         eq(5L), eq(10L), any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
@@ -148,12 +147,47 @@ class TourServiceTest {
         Course course = sharedCourse(10L);
         when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
         when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
-        when(courseBakeryRepository.findAllByCourseId(10L)).thenReturn(List.of());
+        when(courseBakeryRepository.findAllByCourseIdWithBakery(10L)).thenReturn(List.of());
 
         assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.COURSE_BAKERY_REQUIRED);
+    }
+
+    @Test
+    void startTour_succeeds_when_bakery_hours_undefined() {
+        // 카카오/구글 임포트 등으로 영업시간이 미설정인 빵집은 "닫힘"이 아니라 "모름"으로 보고 통과시켜야 함
+        Course course = sharedCourse(10L);
+        TourStateCache state = tourState(1L, 10L, 1, 0, TourStatus.IN_PROGRESS);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+        CourseBakery undefinedHoursBakery = courseBakeryWithHours(false, false);
+        when(courseBakeryRepository.findAllByCourseIdWithBakery(10L))
+                .thenReturn(List.of(undefinedHoursBakery));
+        when(tourRedisService.startTour(1L, 10L, 1)).thenReturn(state);
+        when(reservationRepository.findFirstByUserIdAndCourseIdAndDepartureDateAndStatus(
+                        eq(1L), eq(10L), any(LocalDate.class), eq(ReservationStatus.CONFIRMED)))
+                .thenReturn(Optional.empty());
+
+        TourStartResponse response = tourService.startTour(1L, UserRole.ROLE_USER, 10L);
+
+        assertThat(response.getCourseId()).isEqualTo(10L);
+    }
+
+    @Test
+    void startTour_throws_TOUR_BAKERY_CLOSED_when_bakery_closed_now() {
+        Course course = sharedCourse(10L);
+        when(tourRedisService.hasActiveTour(1L)).thenReturn(false);
+        when(courseRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(course));
+        CourseBakery closedBakery = courseBakeryWithHours(true, false);
+        when(courseBakeryRepository.findAllByCourseIdWithBakery(10L))
+                .thenReturn(List.of(closedBakery));
+
+        assertThatThrownBy(() -> tourService.startTour(1L, UserRole.ROLE_USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.TOUR_BAKERY_CLOSED);
     }
 
     // ── visitBakery ────────────────────────────────────────────────────────────
@@ -433,5 +467,25 @@ class TourServiceTest {
         when(course.getUser()).thenReturn(null);
         when(course.getId()).thenReturn(courseId);
         return course;
+    }
+
+    /** businessHours가 없어(null) 영업시간 체크에서 걸러지는(=항상 영업 중 취급되는) CourseBakery 목 */
+    private static CourseBakery openCourseBakery() {
+        Bakery bakery = mock(Bakery.class);
+        CourseBakery courseBakery = mock(CourseBakery.class);
+        when(courseBakery.getBakery()).thenReturn(bakery);
+        return courseBakery;
+    }
+
+    /** hasDefinedHours/isOpenNow 결과를 직접 제어하는 CourseBakery 목(시간대 의존 없이 검증) */
+    private static CourseBakery courseBakeryWithHours(boolean hasDefinedHours, boolean isOpen) {
+        BusinessHours hours = mock(BusinessHours.class);
+        when(hours.hasDefinedHours(any())).thenReturn(hasDefinedHours);
+        when(hours.isOpenNow(any(), any(), any())).thenReturn(isOpen);
+        Bakery bakery = mock(Bakery.class);
+        when(bakery.getBusinessHours()).thenReturn(hours);
+        CourseBakery courseBakery = mock(CourseBakery.class);
+        when(courseBakery.getBakery()).thenReturn(bakery);
+        return courseBakery;
     }
 }


### PR DESCRIPTION
## Task
- 코스 내 빵집이 영업시간이 아니면 투어 시작 차단 (TOUR_BAKERY_CLOSED)
- Kakao/Tmap 경로, 혼잡도 체크, AI 챗봇 웹훅에 Spring Retry 기반 재시도 적용
  (최대 3회, 지수 백오프, 5xx/타임아웃/커넥션 실패만 대상)
- 재시도 소진·외부 API 실패 시 GlobalExceptionHandler에서 일관되게 처리하고 불필요한 스택트레이스 로그 제거

## What's Changed
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [ ] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #330 
