### PR TITLE
feat: 빵집 승인 시 영업시간 필수화 및 코스 상세 영업중 여부 노출

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/controller/AdminBakeryController.java
@@ -162,11 +162,11 @@ public class AdminBakeryController {
                             + "- `latitude` / `longitude` — 위경도 (0.0이면 미입력 상태)\n"
                             + "- `region` — 지역구\n"
                             + "- `dong` — 행정동\n"
-                            + "- `bakeryType` — 빵집 유형\n\n"
+                            + "- `bakeryType` — 빵집 유형\n"
+                            + "- `businessHours` — 영업 시간 (평일/주말 open·close 전부 입력)\n\n"
                             + "**권장 확인 항목**\n"
                             + "- `phone` — 전화번호\n"
-                            + "- `mapLink` — 지도 링크\n"
-                            + "- `businessHours` — 영업 시간\n\n"
+                            + "- `mapLink` — 지도 링크\n\n"
                             + "승인 후 일반 사용자에게 노출되며 AI 코스 추천 대상에도 포함됩니다.")
     @PostMapping("/approve")
     public ApiResponse<ApproveBakeriesResponse> approveBakeries(

--- a/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/entity/BusinessHours.java
@@ -36,6 +36,14 @@ public class BusinessHours {
         this.lastOrderTime = lastOrderTime;
     }
 
+    /** 평일/주말 open·close가 전부 채워져 있는지. 승인 전 필수 항목 검증에 사용. */
+    public boolean isComplete() {
+        return weekdayOpen != null
+                && weekdayClose != null
+                && weekendOpen != null
+                && weekendClose != null;
+    }
+
     public boolean isOpenNow(LocalTime now, DayOfWeek today, Set<DayOfWeek> closedDays) {
         // 정기 휴무일 체크
         if (closedDays != null && closedDays.contains(today)) {

--- a/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/BakeryService.java
@@ -493,7 +493,9 @@ public class BakeryService {
                     || bakery.getLongitude() == 0.0
                     || bakery.getRegion() == null
                     || bakery.getDong() == null
-                    || bakery.getBakeryType() == null) {
+                    || bakery.getBakeryType() == null
+                    || bakery.getBusinessHours() == null
+                    || !bakery.getBusinessHours().isComplete()) {
                 skipped.add(
                         ApproveBakeriesResponse.SkippedBakery.builder()
                                 .id(bakery.getId())

--- a/apps/be/src/main/java/com/breadbread/course/dto/response/CourseBakeryDetailResponse.java
+++ b/apps/be/src/main/java/com/breadbread/course/dto/response/CourseBakeryDetailResponse.java
@@ -1,8 +1,12 @@
 package com.breadbread.course.dto.response;
 
 import com.breadbread.bakery.dto.response.BakerySummaryResponse;
+import com.breadbread.bakery.entity.Bakery;
+import com.breadbread.bakery.entity.BusinessHours;
 import com.breadbread.course.entity.CourseBakery;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,6 +26,7 @@ public class CourseBakeryDetailResponse {
     private Double rating;
     private LocalTime openTime;
     private LocalTime closeTime;
+    private boolean open;
     private Long likeCount;
     private Long reviewCount;
     private boolean liked;
@@ -42,11 +47,23 @@ public class CourseBakeryDetailResponse {
                 .rating(bakery.getRating())
                 .openTime(bakery.getOpenTime())
                 .closeTime(bakery.getCloseTime())
+                .open(isOpenNow(cb.getBakery()))
                 .likeCount(bakery.getLikeCount())
                 .reviewCount(bakery.getReviewCount())
                 .liked(bakery.isLiked())
                 .reason(cb.getReason())
                 .recommendedBread(cb.getRecommendedBread())
                 .build();
+    }
+
+    // 영업시간이 미설정/불완전이면 "닫힘"이 아니라 "모름"으로 보고 open=true 취급 (투어 시작 차단 정책과 일관)
+    private static boolean isOpenNow(Bakery bakery) {
+        BusinessHours hours = bakery.getBusinessHours();
+        if (hours == null || !hours.isComplete()) {
+            return true;
+        }
+        ZonedDateTime nowSeoul = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        return hours.isOpenNow(
+                nowSeoul.toLocalTime(), nowSeoul.getDayOfWeek(), bakery.getClosedDays());
     }
 }

--- a/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/BakeryServiceTest.java
@@ -755,6 +755,36 @@ class BakeryServiceTest {
     }
 
     @Test
+    void approveBakeries_skips_when_businessHours_incomplete() {
+        Bakery bakery =
+                Bakery.builder()
+                        .name("빵집")
+                        .address("주소")
+                        .region("강남구")
+                        .dong("역삼동")
+                        .latitude(37.5)
+                        .longitude(127.0)
+                        .bakeryType(BakeryType.PLAIN)
+                        .weekdayOpen(LocalTime.of(9, 0))
+                        .weekdayClose(LocalTime.of(21, 0))
+                        // weekendOpen/weekendClose 미입력
+                        .dineInAvailable(false)
+                        .parkingAvailable(false)
+                        .drinkAvailable(false)
+                        .holidayClosed(false)
+                        .build();
+        ReflectionTestUtils.setField(bakery, "id", 100L);
+        ReflectionTestUtils.setField(bakery, "status", BakeryStatus.PENDING);
+        when(bakeryRepository.findByIdAndActiveTrue(100L)).thenReturn(Optional.of(bakery));
+
+        ApproveBakeriesResponse result = bakeryService.approveBakeries(1L, List.of(100L));
+
+        assertThat(bakery.getStatus()).isEqualTo(BakeryStatus.PENDING);
+        assertThat(result.getSuccessCount()).isZero();
+        assertThat(result.getSkipCount()).isEqualTo(1);
+    }
+
+    @Test
     void approveBakeries_skips_when_required_fields_null() {
         Bakery bakery =
                 Bakery.builder()
@@ -1077,6 +1107,10 @@ class BakeryServiceTest {
                         .latitude(37.5)
                         .longitude(127.0)
                         .bakeryType(BakeryType.PLAIN)
+                        .weekdayOpen(LocalTime.of(9, 0))
+                        .weekdayClose(LocalTime.of(21, 0))
+                        .weekendOpen(LocalTime.of(10, 0))
+                        .weekendClose(LocalTime.of(20, 0))
                         .dineInAvailable(false)
                         .parkingAvailable(false)
                         .drinkAvailable(false)


### PR DESCRIPTION
## Task
- 빵집 승인 조건에 영업시간(평일/주말 open·close) 완전성 검사 추가
- 관리자 승인 API 스웨거 문구에서 영업시간을 필수 항목으로 명시
- 코스 상세 응답에 빵집별 open(영업중 여부) 필드 추가

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [x] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #
