### PR TITLE
feat: 카카오 로컬 빵집 정보 월간 자동 동기화 스케줄러 추가

### DIFF
--- a/apps/be/src/main/java/com/breadbread/bakery/service/KakaoLocalUpdateService.java
+++ b/apps/be/src/main/java/com/breadbread/bakery/service/KakaoLocalUpdateService.java
@@ -64,12 +64,24 @@ public class KakaoLocalUpdateService {
                 failed.add(BakeryEntry.builder().id(bakery.getId()).name(bakery.getName()).build());
             }
         }
-        log.info(
-                "[카카오 업데이트] 전체 완료: success={}, skipped={}, failed={}, total={}",
-                success,
-                skipped.size(),
-                failed.size(),
-                bakeries.size());
+        if (skipped.isEmpty() && failed.isEmpty()) {
+            log.info(
+                    "[카카오 업데이트] 전체 완료: success={}, skipped={}, failed={}, total={}",
+                    success,
+                    skipped.size(),
+                    failed.size(),
+                    bakeries.size());
+        } else {
+            log.warn(
+                    "[카카오 업데이트] 전체 완료: success={}, skipped={}, failed={}, total={}",
+                    success,
+                    skipped.size(),
+                    failed.size(),
+                    bakeries.size());
+        }
+        if (success == 0 && skipped.isEmpty() && !failed.isEmpty()) {
+            throw new CustomException(ErrorCode.BAKERY_IMPORT_SEARCH_FAILED);
+        }
         return KakaoSyncResultResponse.builder()
                 .successCount(success)
                 .skippedCount(skipped.size())
@@ -83,7 +95,7 @@ public class KakaoLocalUpdateService {
         List<Place> places = kakaoLocalClient.searchBakeries(bakery.getName());
         Place matched = findBestMatch(bakery, places);
         if (matched == null) {
-            log.debug("[카카오 업데이트] 매칭 실패: bakeryId={}, name={}", bakery.getId(), bakery.getName());
+            log.info("[카카오 업데이트] 매칭 실패: bakeryId={}, name={}", bakery.getId(), bakery.getName());
             return false;
         }
 

--- a/apps/be/src/main/java/com/breadbread/scheduler/SchedulerController.java
+++ b/apps/be/src/main/java/com/breadbread/scheduler/SchedulerController.java
@@ -1,6 +1,7 @@
 package com.breadbread.scheduler;
 
 import com.breadbread.bakery.service.GooglePlacesUpdateService;
+import com.breadbread.bakery.service.KakaoLocalUpdateService;
 import com.breadbread.global.dto.ApiResponse;
 import com.breadbread.image.service.TempImageService;
 import com.breadbread.reservation.service.ReservationDailyService;
@@ -28,6 +29,7 @@ public class SchedulerController {
     private final ReservationRealTimeService reservationRealTimeService;
     private final TempImageService tempImageService;
     private final GooglePlacesUpdateService googlePlacesUpdateService;
+    private final KakaoLocalUpdateService kakaoLocalUpdateService;
 
     @Operation(summary = "만료 예약 취소 + 당일 예약 알림 (매일 09:00)")
     @PostMapping("/reservation-daily")
@@ -93,6 +95,19 @@ public class SchedulerController {
     public ApiResponse<Void> placesPhotoWarmup() {
         log.info("[스케줄러] places-photo-warmup 실행");
         googlePlacesUpdateService.warmAllPhotoCaches();
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "카카오 로컬 기준 전체 빵집 정보 최신화 (매월 1일 05:00)")
+    @PostMapping("/bakery-sync-kakao")
+    @ResponseStatus(HttpStatus.OK)
+    @SchedulerLock(
+            name = "schedulerController_bakerySyncKakao",
+            lockAtMostFor = "PT1H",
+            lockAtLeastFor = "PT1M")
+    public ApiResponse<Void> bakerySyncKakao() {
+        log.info("[스케줄러] bakery-sync-kakao 실행");
+        kakaoLocalUpdateService.syncAllBakeries();
         return ApiResponse.ok();
     }
 }

--- a/apps/be/src/test/java/com/breadbread/bakery/service/KakaoLocalUpdateServiceTest.java
+++ b/apps/be/src/test/java/com/breadbread/bakery/service/KakaoLocalUpdateServiceTest.java
@@ -163,16 +163,41 @@ class KakaoLocalUpdateServiceTest {
     @Test
     void syncAllBakeries_countsFailedOnException() {
         Bakery b1 = bakery(1L, "영춘모찌", 36.3504, 127.3845);
+        Bakery b2 = bakery(2L, "나폴레옹과자점", 36.351, 127.385);
+        Place p =
+                place(
+                        "나폴레옹과자점",
+                        "042-222-2222",
+                        "127.3851",
+                        "36.3511",
+                        "대전광역시 중구 은행동 1",
+                        "대전광역시 중구 은행로 1");
         when(bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.APPROVED))
-                .thenReturn(List.of(b1));
+                .thenReturn(List.of(b1, b2));
         when(bakeryRepository.findById(1L)).thenReturn(Optional.of(b1));
+        when(bakeryRepository.findById(2L)).thenReturn(Optional.of(b2));
         when(kakaoLocalClient.searchBakeries("영춘모찌")).thenThrow(new RuntimeException("API 오류"));
+        when(kakaoLocalClient.searchBakeries("나폴레옹과자점")).thenReturn(List.of(p));
 
         KakaoSyncResultResponse result = kakaoLocalUpdateService.syncAllBakeries();
 
-        assertThat(result.getSuccessCount()).isEqualTo(0);
+        assertThat(result.getSuccessCount()).isEqualTo(1);
         assertThat(result.getFailedCount()).isEqualTo(1);
         assertThat(result.getFailedBakeries()).extracting("id").containsExactly(1L);
+    }
+
+    @Test
+    void syncAllBakeries_throws_whenEveryBakeryFails() {
+        Bakery b1 = bakery(1L, "영춘모찌", 36.3504, 127.3845);
+        when(bakeryRepository.findAllByActiveTrueAndStatus(BakeryStatus.APPROVED))
+                .thenReturn(List.of(b1));
+        when(bakeryRepository.findById(1L)).thenReturn(Optional.of(b1));
+        when(kakaoLocalClient.searchBakeries("영춘모찌")).thenThrow(new RuntimeException("API 키 누락"));
+
+        assertThatThrownBy(() -> kakaoLocalUpdateService.syncAllBakeries())
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAKERY_IMPORT_SEARCH_FAILED);
     }
 
     // ───────────────────────────── helpers ─────────────────────────────


### PR DESCRIPTION
## Task
- Cloud Scheduler가 호출하는 /scheduler/bakery-sync-kakao 엔드포인트 추가
- 매칭 실패 로그를 INFO로, 요약 로그를 상황별 INFO/WARN으로 조정해 운영 가시성 확보
- 전체 빵집 동기화가 완전히 실패하면 502로 응답해 Cloud Scheduler가 실패를 감지하도록 처리

## What's Changed
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 변경 (FE만)
- [ ] 의존성 변경 (패키지 추가/삭제)

## Checklist
- [x] Lint / Formatter 적용
- [x] 테스트 코드 작성
- [ ] UI 확인 (FE만)
- [x] API 명세 업데이트 (BE만)
- [x] Breaking change 없음
- [ ] 문서 업데이트 필요 없음 (필요 시 아래 내용 작성)

## Issue
- close #335 
